### PR TITLE
v1.9.1 — frozen build perf, MLX macOS packaging, UX fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This GUI replaces the CLI drag-and-drop workflow with a complete desktop applica
 
 **Don't want to deal with Python, git, or the command line?** Starting with v1.9.0, a full Windows installer and portable exe are available — as well as a macOS `.pkg`. Entirely optional and free — donations help support active development.
 
-[![Download on Gumroad](https://img.shields.io/badge/Download-Gumroad-ff90e8?style=for-the-badge&logo=gumroad&logoColor=white)](https://edenaion.gumroad.com/l/EZ-CorridorKey?layout=profile)
+[![Download on Gumroad](https://img.shields.io/badge/Download-Gumroad-ff90e8?style=for-the-badge&logo=gumroad&logoColor=white)](https://edenaion.gumroad.com/)
 
 The installer includes everything — Python runtime, AI models, GPU libraries — no setup required. Just install and run.
 


### PR DESCRIPTION
## Summary
- Frozen build performance and FG block artifact fixes
- MLX Metal kernels and dylibs properly bundled in macOS .app
- Pre-warm MLX on main thread to prevent Metal device deadlock
- Untrack installers/ and patches/ (internal build artifacts)
- Raise extract worker thread to HighPriority
- Restore Gumroad download link, update VirusTotal scan
- Bump README to v1.9.1