### PR TITLE
Security: add disclosure policy, harden Docker defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to EZ-CorridorKey are documented here.
 
 ## [Unreleased]
 
+### Added
+- **SECURITY.md** — vulnerability disclosure policy with GitHub private advisory and email contact.
+- **CONTRIBUTING.md** — contributor guidelines adapted from upstream, covering dev setup, PR workflow, and code style.
+
+### Fixed
+- **Docker: unauthenticated services** — VNC now requires a password (was `-nopw`), filebrowser now requires login (was `--noauth`).
+- **Docker: ports bound to all interfaces** — all exposed ports (5900, 6080, 6081) now bind to `127.0.0.1` only, preventing LAN/WAN access.
+
+### Changed
+- Updated EZSCAPE Discord link in README.
+
 ---
 
 ## [1.9.0] - 2026-04-09 — Windows Installer, macOS App, Export Overhaul

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to EZ-CorridorKey
+
+Thanks for your interest in improving EZ-CorridorKey! Whether you're a VFX artist, a pipeline TD, or a developer, contributions of all kinds are welcome — bug reports, feature ideas, documentation fixes, and code.
+
+## Legal Agreement
+
+EZ-CorridorKey is a GUI built on top of [Niko Pueringer's CorridorKey](https://github.com/nikopueringer/CorridorKey). By contributing to this project, you agree that your contributions will be licensed under the same terms as the upstream project's **[CorridorKey Licence](https://github.com/nikopueringer/CorridorKey/blob/main/LICENSE)**.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11
+- A virtual environment (`python -m venv .venv`)
+- GPU with CUDA support (recommended), or Apple Silicon for MLX backend
+
+### Dev Setup
+
+```bash
+git clone https://github.com/edenaion/EZ-CorridorKey.git
+cd EZ-CorridorKey
+python -m venv .venv
+.venv/Scripts/activate      # Windows
+source .venv/bin/activate    # macOS / Linux
+pip install -r requirements.txt
+```
+
+### Running the App
+
+```bash
+python main.py --gui         # launch the desktop GUI
+python main.py --cli         # original CLI wizard (upstream compatible)
+```
+
+### Running Tests
+
+```bash
+pytest                       # run all tests
+pytest -v                    # verbose
+pytest -m "not gpu"          # skip GPU-dependent tests
+```
+
+Most tests run in seconds and don't require a GPU or model weights.
+
+### Linting and Formatting
+
+```bash
+ruff check                   # check for lint errors
+ruff format --check          # check formatting
+ruff format                  # auto-format
+```
+
+## Making Changes
+
+### Pull Requests
+
+1. Fork the repo and create a branch from `main`
+2. Make your changes
+3. Run tests and lint checks
+4. Open a pull request against `main`
+
+In your PR description, focus on **why** you made the change, not just what changed. If you're fixing a bug, describe the symptoms. If you're adding a feature, explain the use case.
+
+### What Makes a Good Contribution
+
+- **Bug fixes** — especially platform-specific issues (Windows, macOS, Linux), EXR/linear workflows, or color space handling
+- **Tests** — more coverage is always welcome, particularly for the inference pipeline and clip management
+- **Documentation** — better explanations, usage examples, or clarifying comments
+- **Performance** — reducing VRAM usage, speeding up frame processing, or optimizing I/O
+- **UI/UX** — improvements to the PySide6 GUI, accessibility, or workflow ergonomics
+
+### Code Style
+
+- [Ruff](https://docs.astral.sh/ruff/) for linting and formatting
+- Line length: 120 characters
+- Third-party model code in `gvm_core/`, `VideoMaMaInferenceModule/`, and `CorridorKeyModule/` is excluded from lint enforcement — those are kept close to their upstream research repos
+
+### Model Weights
+
+Model checkpoints (CorridorKey, GVM, VideoMaMa, MatAnyone2) are **not** in the git repo. Most tests don't need them. If you're working on inference code, follow the download instructions in the [README](README.md).
+
+## Reporting Bugs
+
+Open a [GitHub issue](https://github.com/edenaion/EZ-CorridorKey/issues) with:
+
+- OS and GPU info
+- Steps to reproduce
+- Expected vs actual behavior
+- Relevant log output (check `logs/` directory)
+
+## Security Vulnerabilities
+
+Please **do not** open public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.
+
+## Questions?
+
+Join the [Discord](https://discord.gg/TyxNjcWeF3) — it's the fastest way to get help or discuss ideas before opening a PR.

--- a/README.md
+++ b/README.md
@@ -455,6 +455,6 @@ Optional modules:
 - **MatAnyone2** ([pq-yang/MatAnyone2](https://github.com/pq-yang/MatAnyone2)) — Apache 2.0
 - **BiRefNet** ([ZhengPeng7/BiRefNet](https://github.com/ZhengPeng7/BiRefNet)) — MIT
 
-Join EZSCAPE Discord for EZ-CorridorKey troubleshooting: https://discord.gg/6kgxHUfA
+Join EZSCAPE Discord for EZ-CorridorKey troubleshooting: https://discord.gg/TyxNjcWeF3
 
 Join the Corridor Creates Discord: https://discord.gg/zvwUrdWXJm

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in EZ-CorridorKey, please report it responsibly through one of these channels:
+
+1. **GitHub Private Security Advisory** (preferred): Go to the [Security tab](https://github.com/edenaion/EZ-CorridorKey/security/advisories/new) and create a private advisory.
+2. **Email**: Send details to **EZ-CorridorKey@proton.me**
+
+**Please do not** open public GitHub issues for security vulnerabilities.
+
+## What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+
+## Response Timeline
+
+- **Acknowledgment**: Within 72 hours
+- **Initial assessment**: Within 1 week
+- **Fix or mitigation**: Depends on severity, but we aim for 30 days for critical issues
+
+## Scope
+
+The following are in scope:
+
+- The EZ-CorridorKey Python application and GUI
+- Model loading and inference pipeline
+- Docker container configuration
+- Build and packaging scripts (PyInstaller, NSIS)
+- File I/O and subprocess handling
+
+The following are **out of scope**:
+
+- Third-party model weights hosted externally
+- Upstream dependencies (report those to their maintainers)
+- Issues requiring physical access to the machine
+- Social engineering
+
+## Security Practices
+
+- All `torch.load()` calls use `weights_only=True` to prevent pickle deserialization attacks
+- Subprocess calls use list-based arguments (no `shell=True`)
+- No network-facing services in the desktop application
+- Docker ports are bound to localhost only

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     image: corridorkey:cpu
     container_name: corridorkey-cpu
     ports:
-      - "6080:6080"
-      - "6081:6081"
-      - "5900:5900"
+      - "127.0.0.1:6080:6080"
+      - "127.0.0.1:6081:6081"
+      - "127.0.0.1:5900:5900"
     environment:
       DISPLAY: ":1"
       QT_QPA_PLATFORM: "xcb"
@@ -54,9 +54,9 @@ services:
       CORRIDORKEY_INSTALL_GVM: "n"
       CORRIDORKEY_INSTALL_VIDEOMAMA: "n"
     ports:
-      - "6080:6080"
-      - "6081:6081"
-      - "5900:5900"
+      - "127.0.0.1:6080:6080"
+      - "127.0.0.1:6081:6081"
+      - "127.0.0.1:5900:5900"
     volumes:
       - corridorkey_install:/opt/corridorkey
       - corridorkey_projects:/opt/corridorkey/Projects

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -15,7 +15,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 
 [program:x11vnc]
-command=x11vnc -display :1 -forever -shared -nopw -xkb -rfbport 5900
+command=x11vnc -display :1 -forever -shared -passwd EZ-CorridorKey -xkb -rfbport 5900
 autorestart=true
 priority=20
 startsecs=2
@@ -35,7 +35,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 
 [program:filebrowser]
-command=/usr/local/bin/filebrowser --port 6081 --address 0.0.0.0 --root /opt/corridorkey/ClipsForInference --noauth
+command=/usr/local/bin/filebrowser --port 6081 --address 127.0.0.1 --root /opt/corridorkey/ClipsForInference
 autorestart=true
 priority=35
 startsecs=2


### PR DESCRIPTION
## Summary
- **SECURITY.md** — vulnerability disclosure policy with GitHub private advisory and Proton email contact
- **CONTRIBUTING.md** — contributor guidelines adapted from upstream (dev setup, PR workflow, code style)
- **Docker hardening** — bind all ports to `127.0.0.1`, add VNC password, remove filebrowser `--noauth`
- Updated EZSCAPE Discord link in README
- Changelog entry under `[Unreleased]`

## Test plan
- [x] Verify SECURITY.md renders correctly on GitHub and advisory link works
- [x] Verify CONTRIBUTING.md renders correctly
- [x] Docker: rebuild container and confirm VNC requires password
- [x] Docker: confirm ports only listen on localhost
- [x] Docker: confirm filebrowser prompts for login on first access
- [x] README Discord link resolves to EZSCAPE server