### PR TITLE
feat(docker): ROCm AMD image, device_utils, CI, and Ruff gate

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -1,0 +1,91 @@
+name: ROCm helpers & Docker image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/rocm-ci.yml"
+      - "device_utils.py"
+      - "main.py"
+      - "tests/test_rocm_setup.py"
+      - "docker/Dockerfile"
+      - "docker/Dockerfile.rocm"
+      - "docker/entrypoint.sh"
+      - "docker/entrypoint-rocm-vnc.sh"
+      - "docker/docker-compose.yml"
+      - "docker/README.md"
+      - "docker/supervisord.conf"
+      - "pyproject.toml"
+      - "docs/ROCm_Setup.md"
+      - "docs/ROCm_PR_handoff.md"
+      - "docs/AI_full_pass_review_instructions.md"
+      - "CHANGELOG.md"
+      - "README.md"
+      - "CONTRIBUTING.md"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/rocm-ci.yml"
+      - "device_utils.py"
+      - "main.py"
+      - "tests/test_rocm_setup.py"
+      - "docker/Dockerfile"
+      - "docker/Dockerfile.rocm"
+      - "docker/entrypoint.sh"
+      - "docker/entrypoint-rocm-vnc.sh"
+      - "docker/docker-compose.yml"
+      - "docker/README.md"
+      - "docker/supervisord.conf"
+      - "pyproject.toml"
+      - "docs/ROCm_Setup.md"
+      - "docs/ROCm_PR_handoff.md"
+      - "docs/AI_full_pass_review_instructions.md"
+      - "CHANGELOG.md"
+      - "README.md"
+      - "CONTRIBUTING.md"
+
+permissions:
+  contents: read
+
+jobs:
+  pytest-rocm:
+    name: pytest (ROCm mocks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Sync dev deps
+        run: uv sync --extra dev
+
+      - name: Run ROCm unit tests
+        # Limit path so pytest does not collect the whole suite (marker-only would scan all files).
+        run: uv run pytest tests/test_rocm_setup.py -m rocm -v --tb=short --noconftest
+
+  docker-rocm-runtime:
+    name: docker build (rocm-runtime)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ROCm runtime image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.rocm
+          target: rocm-runtime
+          push: false
+          tags: ez-corridorkey-rocm:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,44 @@
+name: Ruff
+
+on:
+  pull_request:
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/ruff.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/ruff.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ruff-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    name: Lint & format
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Sync dev dependencies (includes ruff)
+        run: uv sync --extra dev
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format (verify)
+        run: uv run ruff format --check .

--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,8 @@ verify-tasklist.md
 bench_results*.json
 
 # Test scripts & output (may contain local paths)
-test_*.py
+# Only the repo root — do not use bare `test_*.py` (that ignores `tests/test_*.py`).
+/test_*.py
 test_output/
 
 # Build artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,31 @@ All notable changes to EZ-CorridorKey are documented here.
 ## [Unreleased]
 
 ### Added
+- **ROCm / AMD GPU (Docker)** — optional `docker/Dockerfile.rocm` with default **`rocm-runtime`** target (`uv run python main.py`) and **`rocm-vnc`** target for browser access (noVNC / x11vnc / filebrowser, aligned with the default `docker/Dockerfile` stack). Compose profile **`rocm`** adds service `corridorkey-rocm`. Image applies ROCm PyTorch + `pytorch-triton-rocm` via `uv pip install … --reinstall` only inside the container (no ROCm optional extra in `pyproject.toml`).
+- **`device_utils.setup_rocm_env()`** — early HIP detection, `HSA_OVERRIDE_GFX_VERSION` default via `setdefault`, and stderr logging for HIP INFO before `main.setup_logging()` runs.
+- **`device_utils` in wheel/sdist** — `force-include` so the module ships with hatch-built wheels.
+- **CI: Ruff** — `.github/workflows/ruff.yml` is a **merge gate**: **`uv run ruff check .`** and **`uv run ruff format --check .`** on **`pull_request`** / **`push`** to **`main`** when Python or **`pyproject.toml`** changes (`permissions: contents: read`).
+- **CI** — `.github/workflows/rocm-ci.yml` runs mocked ROCm tests (`pytest tests/test_rocm_setup.py -m rocm --noconftest`) and attempts a **`rocm-runtime`** Docker build (`continue-on-error` due to image size / registry limits); `permissions: contents: read`; **`pull_request`** and **`push`** to **`main`** share the same **`paths`** filter (includes `docker/Dockerfile`, `docker/Dockerfile.rocm`, entrypoints, Compose, `device_utils.py`, tests, docs, and related files).
+- **ROCm polish** — `UV_LINK_MODE=copy` in `docker/Dockerfile.rocm`; Compose comments on baked `.venv` vs `CORRIDORKEY_INSTALL_*`; `docs/ROCm_Setup.md` expanded (Python 3.10, NVIDIA vs ROCm install table, SAM2/tracker, host `render` group); **`pytest` marker `rocm`** in `pyproject.toml`.
+- **`docs/AI_full_pass_review_instructions.md`** — playbook for a full line-by-line / full-file review of every path in a branch or PR (inventory, security, cross-doc consistency, verification commands, EZ-CorridorKey ROCm appendix); linked from `docs/ROCm_Setup.md` and `docs/ROCm_PR_handoff.md`.
 - **SECURITY.md** — vulnerability disclosure policy with GitHub private advisory and email contact.
 - **CONTRIBUTING.md** — contributor guidelines adapted from upstream, covering dev setup, PR workflow, and code style.
 
-### Fixed
-- **Docker: unauthenticated services** — VNC now requires a password (was `-nopw`), filebrowser now requires login (was `--noauth`).
-- **Docker: ports bound to all interfaces** — all exposed ports (5900, 6080, 6081) now bind to `127.0.0.1` only, preventing LAN/WAN access.
-
 ### Changed
+- **Ruff** — **`[tool.ruff]`** / **`[tool.ruff.lint]`** in **`pyproject.toml`** (default rules; ignore **`E402`**, **`E701`** with rationale). Applied **`ruff format`** across the tree and fixed remaining **ruff check** issues (bare **`except`**, unused bindings, **`__all__`** / re-exports, **`QApplication`** import scope, etc.) so the new CI gate passes.
+- **filebrowser install in Docker** — [`docker/Dockerfile`](../docker/Dockerfile) and [`docker/Dockerfile.rocm`](../docker/Dockerfile.rocm) fetch **`get.sh`** from a **pinned** [filebrowser/get](https://github.com/filebrowser/get) commit (`2aab36cbd9def8513160e31d753abc5a2e2aef0c`) instead of **`master`**; [`docs/ROCm_Setup.md`](../docs/ROCm_Setup.md) notes the policy.
+- **`docker/README.md`** — security note (VNC vs **filebrowser**); Compose defaults (**CPU** / **`gpu`** / **`rocm`**); first-start behavior (volume install vs baked ROCm); env / logs / update notes for **`corridorkey-rocm`**; profile-aware **`compose start`** / **`--force-recreate`** examples for **GPU**/**ROCm**/**CPU**.
+- **`docs/ROCm_Setup.md`** — CI section references workflow **`paths`** filters (when the job runs).
+- **`CONTRIBUTING.md`** — prerequisites mention **AMD (ROCm)** via Docker and link **`docs/ROCm_Setup.md`**.
+- **`[tool.uv.pip]`** — moved `torch-backend = "auto"` from `[tool.uv]` so current `uv` versions parse `pyproject.toml` without warnings.
+- **Docker: supervisord GUI env** — [`docker/supervisord.conf`](docker/supervisord.conf) passes **`CORRIDORKEY_CONTAINER_MODE="%(ENV_CORRIDORKEY_CONTAINER_MODE)s"`** into the CorridorKey subprocess; [`docker/entrypoint.sh`](docker/entrypoint.sh) and [`docker/entrypoint-rocm-vnc.sh`](docker/entrypoint-rocm-vnc.sh) default it to **`1`** so Compose / `docker run -e` can override (e.g. **`0`** for desktop-style sizing).
 - Updated EZSCAPE Discord link in README.
+
+### Fixed
+- **`.gitignore`** — root-only **`/test_*.py`** for ad-hoc scripts; the previous bare **`test_*.py`** rule ignored the entire pytest suite under **`tests/`** (including **`tests/test_rocm_setup.py`**), so CI would not see that file after checkout.
+- **`docker/Dockerfile`** — removed a duplicate **`xvfb`** package line in the apt install list.
+- **Docker: VNC password** — x11vnc uses `-passwd EZ-CorridorKey` (was `-nopw`). **filebrowser** is started without `--noauth` and listens on **127.0.0.1** inside the container; some **filebrowser** builds may prompt for first-run admin setup—see `docker/supervisord.conf`.
+- **Docker: ports bound to all interfaces** — all exposed ports (5900, 6080, 6081) now bind to `127.0.0.1` only, preventing LAN/WAN access.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ EZ-CorridorKey is a GUI built on top of [Niko Pueringer's CorridorKey](https://g
 
 - Python 3.11
 - A virtual environment (`python -m venv .venv`)
-- GPU with CUDA support (recommended), or Apple Silicon for MLX backend
+- GPU with CUDA support (recommended), or Apple Silicon for MLX backend; **AMD (ROCm)** is supported via **[Docker only](docs/ROCm_Setup.md)** (see `docker/Dockerfile.rocm` and Compose profile **`rocm`**)
 
 ### Dev Setup
 
@@ -40,6 +40,14 @@ pytest -v                    # verbose
 pytest -m "not gpu"          # skip GPU-dependent tests
 ```
 
+ROCm startup tests (mocked; no AMD GPU). Pass the file path so collection stays fast; `--noconftest` avoids `cv2` from the shared `conftest.py`:
+
+```bash
+uv run --extra dev pytest tests/test_rocm_setup.py -m rocm -v --noconftest
+```
+
+If you use Docker Compose, the **`rocm`** profile binds the same **6080–6081** ports as the default CPU/GPU services — only run one stack at a time unless you remap ports.
+
 Most tests run in seconds and don't require a GPU or model weights.
 
 ### Linting and Formatting
@@ -49,6 +57,8 @@ ruff check                   # check for lint errors
 ruff format --check          # check formatting
 ruff format                  # auto-format
 ```
+
+The **`Ruff`** workflow (`.github/workflows/ruff.yml`) runs **`ruff check .`** and **`ruff format --check .`** on pushes and pull requests that touch Python or **`pyproject.toml`**; merges should stay green. **`[tool.ruff.lint]`** in **`pyproject.toml`** documents ignored rules (**`E402`**, **`E701`**) for legacy import layout.
 
 ## Making Changes
 

--- a/CorridorKeyModule/__init__.py
+++ b/CorridorKeyModule/__init__.py
@@ -1,1 +1,3 @@
 from .inference_engine import CorridorKeyEngine
+
+__all__ = ["CorridorKeyEngine"]

--- a/CorridorKeyModule/backend.py
+++ b/CorridorKeyModule/backend.py
@@ -19,6 +19,7 @@ from .inference_engine import INFERENCE_DEFAULTS as _D
 
 _BUNDLED_CHECKPOINT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "checkpoints")
 
+
 def _resolve_checkpoint_dir() -> str:
     """Return the writable checkpoint directory.
 
@@ -30,11 +31,13 @@ def _resolve_checkpoint_dir() -> str:
         return _BUNDLED_CHECKPOINT_DIR
     try:
         from backend.project import get_data_dir
+
         ckpt_dir = os.path.join(get_data_dir(), "CorridorKeyModule", "checkpoints")
         os.makedirs(ckpt_dir, exist_ok=True)
         return ckpt_dir
     except ImportError:
         return _BUNDLED_CHECKPOINT_DIR
+
 
 CHECKPOINT_DIR = _resolve_checkpoint_dir()
 TORCH_EXT = ".pth"
@@ -124,7 +127,9 @@ def _discover_checkpoint(ext: str) -> Path:
 
     if len(matches) > 1:
         names = [os.path.basename(f) for f in matches]
-        raise ValueError(f"Multiple {ext} checkpoints in {CHECKPOINT_DIR}: {names}. Keep exactly one.")
+        raise ValueError(
+            f"Multiple {ext} checkpoints in {CHECKPOINT_DIR}: {names}. Keep exactly one."
+        )
 
     return Path(matches[0])
 
@@ -161,8 +166,10 @@ def _wrap_mlx_output(
     # Apply despeckle (MLX stubs this)
     if auto_despeckle:
         processed_alpha = cu.clean_matte(
-            alpha, area_threshold=despeckle_size,
-            dilation=despeckle_dilation, blur_size=despeckle_blur,
+            alpha,
+            area_threshold=despeckle_size,
+            dilation=despeckle_dilation,
+            blur_size=despeckle_blur,
         )
     else:
         processed_alpha = alpha
@@ -178,12 +185,13 @@ def _wrap_mlx_output(
         source_rgb = source_image
 
     source_srgb = cu.linear_to_srgb(source_rgb) if input_is_linear else source_rgb
-    source_lin = source_rgb if input_is_linear else cu.srgb_to_linear(source_rgb)
 
     # Despill the source too — _restore_opaque_source_detail blends source
     # pixels back in, and they must already be despilled or they undo the
     # despill we just applied to the model fg.
-    source_srgb_despilled = cu.despill(source_srgb, green_limit_mode="average", strength=despill_strength)
+    source_srgb_despilled = cu.despill(
+        source_srgb, green_limit_mode="average", strength=despill_strength
+    )
     source_lin_despilled = cu.srgb_to_linear(source_srgb_despilled)
 
     # Composite over checkerboard for comp output
@@ -209,7 +217,10 @@ def _wrap_mlx_output(
     # opaque regions so FG view matches what the user shot).
     fg_lin = cu.srgb_to_linear(fg)
     fg_restored_lin = _restore_opaque_source_detail(
-        source_lin_despilled, source_srgb_despilled, fg_lin, processed_alpha,
+        source_lin_despilled,
+        source_srgb_despilled,
+        fg_lin,
+        processed_alpha,
     )
     fg_restored = cu.linear_to_srgb(fg_restored_lin)
 
@@ -244,8 +255,10 @@ def _assemble_mlx_output(
 
     if auto_despeckle:
         processed_alpha = cu.clean_matte(
-            alpha, area_threshold=despeckle_size,
-            dilation=despeckle_dilation, blur_size=despeckle_blur,
+            alpha,
+            area_threshold=despeckle_size,
+            dilation=despeckle_dilation,
+            blur_size=despeckle_blur,
         )
     else:
         processed_alpha = alpha
@@ -260,12 +273,13 @@ def _assemble_mlx_output(
         source_rgb = source_image
 
     source_srgb = cu.linear_to_srgb(source_rgb) if input_is_linear else source_rgb
-    source_lin = source_rgb if input_is_linear else cu.srgb_to_linear(source_rgb)
 
     # Despill the source too — _restore_opaque_source_detail blends source
     # pixels back in, and they must already be despilled or they undo the
     # despill we just applied to the model fg.
-    source_srgb_despilled = cu.despill(source_srgb, green_limit_mode="average", strength=despill_strength)
+    source_srgb_despilled = cu.despill(
+        source_srgb, green_limit_mode="average", strength=despill_strength
+    )
     source_lin_despilled = cu.srgb_to_linear(source_srgb_despilled)
 
     h, w = fg.shape[:2]
@@ -289,7 +303,10 @@ def _assemble_mlx_output(
     # opaque regions so FG view matches what the user shot).
     fg_lin = cu.srgb_to_linear(fg)
     fg_restored_lin = _restore_opaque_source_detail(
-        source_lin_despilled, source_srgb_despilled, fg_lin, processed_alpha,
+        source_lin_despilled,
+        source_srgb_despilled,
+        fg_lin,
+        processed_alpha,
     )
     fg_restored = cu.linear_to_srgb(fg_restored_lin)
 
@@ -327,7 +344,9 @@ def _resize_float_image_bicubic(image: np.ndarray, size: tuple[int, int]) -> np.
     """Resize float image data with PIL bicubic to match upstream MLX behavior."""
     if image.ndim == 2:
         return np.asarray(
-            Image.fromarray(image.astype(np.float32), mode="F").resize(size, Image.Resampling.BICUBIC),
+            Image.fromarray(image.astype(np.float32), mode="F").resize(
+                size, Image.Resampling.BICUBIC
+            ),
             dtype=np.float32,
         )
 
@@ -407,10 +426,7 @@ def _restore_opaque_source_detail(
     )
 
     source_srgb = np.clip(source_srgb.astype(np.float32, copy=False), 0.0, 1.0)
-    green_excess = (
-        source_srgb[..., 1:2]
-        - np.maximum(source_srgb[..., 0:1], source_srgb[..., 2:3])
-    )
+    green_excess = source_srgb[..., 1:2] - np.maximum(source_srgb[..., 0:1], source_srgb[..., 2:3])
     green_spill_weight = np.clip(
         (green_excess - green_spill_threshold) / max(green_spill_softness, 1e-6),
         0.0,
@@ -422,7 +438,9 @@ def _restore_opaque_source_detail(
     return image_lin * (1.0 - detail_weight) + source_lin * detail_weight
 
 
-def _try_mlx_float_outputs(raw_engine, image_u8: np.ndarray, mask_u8: np.ndarray, refiner_scale: float) -> dict | None:
+def _try_mlx_float_outputs(
+    raw_engine, image_u8: np.ndarray, mask_u8: np.ndarray, refiner_scale: float
+) -> dict | None:
     """Use corridorkey-mlx internals to recover float outputs before uint8 quantization."""
     if not hasattr(raw_engine, "_model") or not hasattr(raw_engine, "_img_size"):
         return None
@@ -550,14 +568,20 @@ class _MLXEngineAdapter:
             refiner_scale=refiner_scale,
             input_is_linear=input_is_linear,
             fg_is_straight=fg_is_straight,
-            despill_strength=0.0,      # disable MLX stubs — adapter applies these
+            despill_strength=0.0,  # disable MLX stubs — adapter applies these
             auto_despeckle=False,
             despeckle_size=despeckle_size,
         )
 
         return _wrap_mlx_output(
-            raw, image, input_is_linear, despill_strength, auto_despeckle,
-            despeckle_size, despeckle_dilation, despeckle_blur,
+            raw,
+            image,
+            input_is_linear,
+            despill_strength,
+            auto_despeckle,
+            despeckle_size,
+            despeckle_dilation,
+            despeckle_blur,
         )
 
 
@@ -594,7 +618,10 @@ def create_engine(
 
         try:
             raw_engine = CorridorKeyMLXEngine(
-                str(ckpt), img_size=img_size, tile_size=tile_size, overlap=overlap,
+                str(ckpt),
+                img_size=img_size,
+                tile_size=tile_size,
+                overlap=overlap,
             )
             mode = f"tiled (tile={tile_size}, overlap={overlap})" if tile_size else "full-frame"
         except TypeError:

--- a/CorridorKeyModule/core/color_utils.py
+++ b/CorridorKeyModule/core/color_utils.py
@@ -1,8 +1,10 @@
 import torch
 import numpy as np
 
+
 def _is_tensor(x):
     return isinstance(x, torch.Tensor)
+
 
 def linear_to_srgb(x):
     """
@@ -12,11 +14,12 @@ def linear_to_srgb(x):
     if _is_tensor(x):
         x = x.clamp(min=0.0)
         mask = x <= 0.0031308
-        return torch.where(mask, x * 12.92, 1.055 * torch.pow(x, 1.0/2.4) - 0.055)
+        return torch.where(mask, x * 12.92, 1.055 * torch.pow(x, 1.0 / 2.4) - 0.055)
     else:
         x = np.clip(x, 0.0, None)
         mask = x <= 0.0031308
-        return np.where(mask, x * 12.92, 1.055 * np.power(x, 1.0/2.4) - 0.055)
+        return np.where(mask, x * 12.92, 1.055 * np.power(x, 1.0 / 2.4) - 0.055)
+
 
 def srgb_to_linear(x):
     """
@@ -32,6 +35,7 @@ def srgb_to_linear(x):
         mask = x <= 0.04045
         return np.where(mask, x / 12.92, np.power((x + 0.055) / 1.055, 2.4))
 
+
 def premultiply(fg, alpha):
     """
     Premultiplies foreground by alpha.
@@ -39,6 +43,7 @@ def premultiply(fg, alpha):
     alpha: Alpha [..., 1] or [1, ...]
     """
     return fg * alpha
+
 
 def unpremultiply(fg, alpha, eps=1e-6):
     """
@@ -50,12 +55,14 @@ def unpremultiply(fg, alpha, eps=1e-6):
     else:
         return fg / (alpha + eps)
 
+
 def composite_straight(fg, bg, alpha):
     """
     Composites Straight FG over BG.
     Formula: FG * Alpha + BG * (1 - Alpha)
     """
     return fg * alpha + bg * (1.0 - alpha)
+
 
 def composite_premul(fg, bg, alpha):
     """
@@ -77,7 +84,9 @@ def match_luminance(source_rgb, image_rgb, min_scale=0.9, max_scale=1.15, streng
         return image_rgb
 
     if _is_tensor(image_rgb):
-        weights = image_rgb.new_tensor([0.2126, 0.7152, 0.0722]).view(*([1] * (image_rgb.dim() - 1)), 3)
+        weights = image_rgb.new_tensor([0.2126, 0.7152, 0.0722]).view(
+            *([1] * (image_rgb.dim() - 1)), 3
+        )
         src_y = (source_rgb * weights).sum(dim=-1, keepdim=True)
         img_y = (image_rgb * weights).sum(dim=-1, keepdim=True)
         scale = (src_y / torch.clamp(img_y, min=eps)).clamp(min=min_scale, max=max_scale)
@@ -95,10 +104,11 @@ def match_luminance(source_rgb, image_rgb, min_scale=0.9, max_scale=1.15, streng
         corrected = image_rgb * (1.0 - strength) + corrected * strength
     return np.clip(corrected, 0.0, None)
 
+
 def rgb_to_yuv(image):
     """
     Converts RGB to YUV (Rec. 601).
-    Input: [..., 3, H, W] or [..., 3] depending on layout. 
+    Input: [..., 3, H, W] or [..., 3] depending on layout.
     Supports standard PyTorch BCHW.
     """
     if not _is_tensor(image):
@@ -106,13 +116,13 @@ def rgb_to_yuv(image):
 
     # Weights for RGB -> Y
     # Rec. 601: 0.299, 0.587, 0.114
-    
+
     # Assume BCHW layout if 4 dims
     if image.dim() == 4:
         r = image[:, 0:1, :, :]
         g = image[:, 1:2, :, :]
         b = image[:, 2:3, :, :]
-    elif image.dim() == 3 and image.shape[0] == 3: # CHW
+    elif image.dim() == 3 and image.shape[0] == 3:  # CHW
         r = image[0:1, :, :]
         g = image[1:2, :, :]
         b = image[2:3, :, :]
@@ -125,11 +135,12 @@ def rgb_to_yuv(image):
     y = 0.299 * r + 0.587 * g + 0.114 * b
     u = 0.492 * (b - y)
     v = 0.877 * (r - y)
-    
-    if image.dim() >= 3 and image.shape[-3] == 3: # Concatenate along Channel dim
-         return torch.cat([y, u, v], dim=-3)
+
+    if image.dim() >= 3 and image.shape[-3] == 3:  # Concatenate along Channel dim
+        return torch.cat([y, u, v], dim=-3)
     else:
-         return torch.stack([y, u, v], dim=-1)
+        return torch.stack([y, u, v], dim=-1)
+
 
 def dilate_mask(mask, radius):
     """
@@ -144,22 +155,28 @@ def dilate_mask(mask, radius):
         # PyTorch Dilation (using Max Pooling)
         # Expects [B, C, H, W]
         orig_dim = mask.dim()
-        if orig_dim == 2: mask = mask.unsqueeze(0).unsqueeze(0)
-        elif orig_dim == 3: mask = mask.unsqueeze(0)
-        
+        if orig_dim == 2:
+            mask = mask.unsqueeze(0).unsqueeze(0)
+        elif orig_dim == 3:
+            mask = mask.unsqueeze(0)
+
         kernel_size = int(radius * 2 + 1)
         padding = radius
         dilated = torch.nn.functional.max_pool2d(mask, kernel_size, stride=1, padding=padding)
-        
-        if orig_dim == 2: return dilated.squeeze()
-        elif orig_dim == 3: return dilated.squeeze(0)
+
+        if orig_dim == 2:
+            return dilated.squeeze()
+        elif orig_dim == 3:
+            return dilated.squeeze(0)
         return dilated
     else:
         # Numpy Dilation (using OpenCV)
         import cv2
+
         kernel_size = int(radius * 2 + 1)
         kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
         return cv2.dilate(mask, kernel)
+
 
 def apply_garbage_matte(predicted_matte, garbage_matte_input, dilation=10):
     """
@@ -167,21 +184,22 @@ def apply_garbage_matte(predicted_matte, garbage_matte_input, dilation=10):
     """
     if garbage_matte_input is None:
         return predicted_matte
-        
+
     garbage_mask = dilate_mask(garbage_matte_input, dilation)
-    
+
     # Ensure dimensions match for multiplication
     if _is_tensor(predicted_matte):
         # Handle broadcasting if needed
-        pass 
+        pass
     else:
         # Numpy
         if garbage_mask.ndim == 2 and predicted_matte.ndim == 3:
             garbage_mask = garbage_mask[:, :, np.newaxis]
-            
+
     return predicted_matte * garbage_mask
 
-def despill(image, green_limit_mode='average', strength=1.0):
+
+def despill(image, green_limit_mode="average", strength=1.0):
     """
     Removes green spill from an RGB image using a luminance-preserving method.
     image: RGB float (0-1).
@@ -190,26 +208,26 @@ def despill(image, green_limit_mode='average', strength=1.0):
     """
     if strength <= 0.0:
         return image
-        
+
     if _is_tensor(image):
         # PyTorch Impl
         r = image[..., 0]
         g = image[..., 1]
         b = image[..., 2]
-        
-        if green_limit_mode == 'max':
+
+        if green_limit_mode == "max":
             limit = torch.max(r, b)
         else:
             limit = (r + b) / 2.0
-            
+
         spill_amount = torch.clamp(g - limit, min=0.0)
-        
+
         g_new = g - spill_amount
         r_new = r + (spill_amount * 0.5)
         b_new = b + (spill_amount * 0.5)
-        
+
         despilled = torch.stack([r_new, g_new, b_new], dim=-1)
-        
+
         if strength < 1.0:
             return image * (1.0 - strength) + despilled * strength
         return despilled
@@ -218,23 +236,24 @@ def despill(image, green_limit_mode='average', strength=1.0):
         r = image[..., 0]
         g = image[..., 1]
         b = image[..., 2]
-        
-        if green_limit_mode == 'max':
+
+        if green_limit_mode == "max":
             limit = np.maximum(r, b)
         else:
             limit = (r + b) / 2.0
-            
+
         spill_amount = np.maximum(g - limit, 0.0)
-        
+
         g_new = g - spill_amount
         r_new = r + (spill_amount * 0.5)
         b_new = b + (spill_amount * 0.5)
-        
+
         despilled = np.stack([r_new, g_new, b_new], axis=-1)
-        
+
         if strength < 1.0:
             return image * (1.0 - strength) + despilled * strength
         return despilled
+
 
 def clean_matte(alpha_np, area_threshold=300, dilation=15, blur_size=5):
     """
@@ -243,48 +262,49 @@ def clean_matte(alpha_np, area_threshold=300, dilation=15, blur_size=5):
     """
     import cv2
     import numpy as np
-    
+
     # Needs to be 2D
     is_3d = False
     if alpha_np.ndim == 3:
         is_3d = True
         alpha_np = alpha_np[:, :, 0]
-        
+
     # Threshold to binary
     mask_8u = (alpha_np > 0.5).astype(np.uint8) * 255
-    
+
     # Find connected components
     num_labels, labels, stats, centroids = cv2.connectedComponentsWithStats(mask_8u, connectivity=8)
-    
+
     # Create an empty mask for the cleaned components
     cleaned_mask = np.zeros_like(mask_8u)
-    
+
     # Keep components larger than the threshold (skip label 0, which is background)
     for i in range(1, num_labels):
         if stats[i, cv2.CC_STAT_AREA] >= area_threshold:
             cleaned_mask[labels == i] = 255
-            
+
     # Dilate
     if dilation > 0:
         kernel_size = int(dilation * 2 + 1)
         kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
         cleaned_mask = cv2.dilate(cleaned_mask, kernel)
-        
+
     # Blur
     if blur_size > 0:
         b_size = int(blur_size * 2 + 1)
         cleaned_mask = cv2.GaussianBlur(cleaned_mask, (b_size, b_size), 0)
-        
+
     # Convert back to 0-1 float
     safe_zone = cleaned_mask.astype(np.float32) / 255.0
-    
+
     # Multiply original alpha by the safe zone
     result_alpha = alpha_np * safe_zone
-    
+
     if is_3d:
         result_alpha = result_alpha[:, :, np.newaxis]
-        
+
     return result_alpha
+
 
 def source_passthrough(original_srgb, model_fg_srgb, alpha, erode_px=None, blur_px=None):
     """
@@ -336,9 +356,7 @@ def source_passthrough(original_srgb, model_fg_srgb, alpha, erode_px=None, blur_
     # Erode inward to create a safety buffer around edges.
     # This ensures we never use original pixels where green spill might exist.
     if erode_px > 0:
-        k = cv2.getStructuringElement(
-            cv2.MORPH_ELLIPSE, (erode_px * 2 + 1, erode_px * 2 + 1)
-        )
+        k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (erode_px * 2 + 1, erode_px * 2 + 1))
         interior = cv2.erode(interior, k)
 
     # Smooth the transition so there's no visible seam between
@@ -359,24 +377,23 @@ def create_checkerboard(width, height, checker_size=64, color1=0.2, color2=0.4):
     Returns: Numpy array [H, W, 3] float (0.0-1.0)
     """
     import numpy as np
-    
+
     # Create coordinate grids
     x = np.arange(width)
     y = np.arange(height)
-    
+
     # Determine tile parity
     x_tiles = x // checker_size
     y_tiles = y // checker_size
-    
+
     # Broadcast to 2D
     x_grid, y_grid = np.meshgrid(x_tiles, y_tiles)
-    
+
     # XOR for checker pattern (1 if odd, 0 if even)
     checker = (x_grid + y_grid) % 2
-    
+
     # Map 0 to color1 and 1 to color2
     bg_img = np.where(checker == 0, color1, color2).astype(np.float32)
-    
+
     # Make it 3-channel
     return np.stack([bg_img, bg_img, bg_img], axis=-1)
-

--- a/CorridorKeyModule/core/model_transformer.py
+++ b/CorridorKeyModule/core/model_transformer.py
@@ -3,10 +3,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 import timm
 
+
 class MLP(nn.Module):
     """
     Linear Embedding: C_in -> C_out
     """
+
     def __init__(self, input_dim=2048, embed_dim=768):
         super().__init__()
         self.proj = nn.Linear(input_dim, embed_dim)
@@ -14,46 +16,63 @@ class MLP(nn.Module):
     def forward(self, x):
         return self.proj(x)
 
+
 class DecoderHead(nn.Module):
     def __init__(self, feature_channels=[112, 224, 448, 896], embedding_dim=256, output_dim=1):
         super().__init__()
-        
+
         # MLP layers to unify channel dimensions
         self.linear_c4 = MLP(input_dim=feature_channels[3], embed_dim=embedding_dim)
         self.linear_c3 = MLP(input_dim=feature_channels[2], embed_dim=embedding_dim)
         self.linear_c2 = MLP(input_dim=feature_channels[1], embed_dim=embedding_dim)
         self.linear_c1 = MLP(input_dim=feature_channels[0], embed_dim=embedding_dim)
-        
+
         # Fuse
-        self.linear_fuse = nn.Conv2d(embedding_dim*4, embedding_dim, kernel_size=1, bias=False)
+        self.linear_fuse = nn.Conv2d(embedding_dim * 4, embedding_dim, kernel_size=1, bias=False)
         self.bn = nn.BatchNorm2d(embedding_dim)
         self.relu = nn.ReLU(inplace=True)
-        
+
         # Predict
         self.dropout = nn.Dropout(0.1)
         self.classifier = nn.Conv2d(embedding_dim, output_dim, kernel_size=1)
 
     def forward(self, features):
         c1, c2, c3, c4 = features
-        
+
         n, _, h, w = c4.shape
-        
+
         # Resize to C1 size (which is H/4)
-        _c4 = self.linear_c4(c4.flatten(2).transpose(1, 2)).transpose(1, 2).view(n, -1, c4.shape[2], c4.shape[3])
-        _c4 = F.interpolate(_c4, size=c1.shape[2:], mode='bilinear', align_corners=False)
+        _c4 = (
+            self.linear_c4(c4.flatten(2).transpose(1, 2))
+            .transpose(1, 2)
+            .view(n, -1, c4.shape[2], c4.shape[3])
+        )
+        _c4 = F.interpolate(_c4, size=c1.shape[2:], mode="bilinear", align_corners=False)
 
-        _c3 = self.linear_c3(c3.flatten(2).transpose(1, 2)).transpose(1, 2).view(n, -1, c3.shape[2], c3.shape[3])
-        _c3 = F.interpolate(_c3, size=c1.shape[2:], mode='bilinear', align_corners=False)
+        _c3 = (
+            self.linear_c3(c3.flatten(2).transpose(1, 2))
+            .transpose(1, 2)
+            .view(n, -1, c3.shape[2], c3.shape[3])
+        )
+        _c3 = F.interpolate(_c3, size=c1.shape[2:], mode="bilinear", align_corners=False)
 
-        _c2 = self.linear_c2(c2.flatten(2).transpose(1, 2)).transpose(1, 2).view(n, -1, c2.shape[2], c2.shape[3])
-        _c2 = F.interpolate(_c2, size=c1.shape[2:], mode='bilinear', align_corners=False)
+        _c2 = (
+            self.linear_c2(c2.flatten(2).transpose(1, 2))
+            .transpose(1, 2)
+            .view(n, -1, c2.shape[2], c2.shape[3])
+        )
+        _c2 = F.interpolate(_c2, size=c1.shape[2:], mode="bilinear", align_corners=False)
 
-        _c1 = self.linear_c1(c1.flatten(2).transpose(1, 2)).transpose(1, 2).view(n, -1, c1.shape[2], c1.shape[3])
+        _c1 = (
+            self.linear_c1(c1.flatten(2).transpose(1, 2))
+            .transpose(1, 2)
+            .view(n, -1, c1.shape[2], c1.shape[3])
+        )
 
         _c = self.linear_fuse(torch.cat([_c4, _c3, _c2, _c1], dim=1))
         _c = self.bn(_c)
         _c = self.relu(_c)
-        
+
         x = self.dropout(_c)
         x = self.classifier(x)
 
@@ -64,12 +83,17 @@ class RefinerBlock(nn.Module):
     """
     Residual Block with Dilation and GroupNorm (Safe for Batch Size 2).
     """
+
     def __init__(self, channels, dilation=1):
         super().__init__()
-        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=dilation, dilation=dilation)
+        self.conv1 = nn.Conv2d(
+            channels, channels, kernel_size=3, padding=dilation, dilation=dilation
+        )
         self.gn1 = nn.GroupNorm(8, channels)
         self.relu = nn.ReLU(inplace=True)
-        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=dilation, dilation=dilation)
+        self.conv2 = nn.Conv2d(
+            channels, channels, kernel_size=3, padding=dilation, dilation=dilation
+        )
         self.gn2 = nn.GroupNorm(8, channels)
 
     def forward(self, x):
@@ -83,6 +107,7 @@ class RefinerBlock(nn.Module):
         out = self.relu(out)
         return out
 
+
 class CNNRefinerModule(nn.Module):
     """
     Dilated Residual Refiner (Receptive Field ~65px).
@@ -90,6 +115,7 @@ class CNNRefinerModule(nn.Module):
     Structure: Stem -> Res(d1) -> Res(d2) -> Res(d4) -> Res(d8) -> Projection.
     Tiled CNN refiner by Marclie.
     """
+
     def __init__(self, in_channels=7, hidden_channels=64, out_channels=4):
         super().__init__()
 
@@ -97,15 +123,15 @@ class CNNRefinerModule(nn.Module):
         self.stem = nn.Sequential(
             nn.Conv2d(in_channels, hidden_channels, kernel_size=3, padding=1),
             nn.GroupNorm(8, hidden_channels),
-            nn.ReLU(inplace=True)
+            nn.ReLU(inplace=True),
         )
-        
+
         # Dilated Residual Blocks (RF Expansion)
         self.res1 = RefinerBlock(hidden_channels, dilation=1)
         self.res2 = RefinerBlock(hidden_channels, dilation=2)
         self.res3 = RefinerBlock(hidden_channels, dilation=4)
         self.res4 = RefinerBlock(hidden_channels, dilation=8)
-        
+
         # Final Projection (No Activation, purely additive logits)
         self.final = nn.Conv2d(hidden_channels, out_channels, kernel_size=1)
 
@@ -131,7 +157,9 @@ class CNNRefinerModule(nn.Module):
         """Compile the fixed-shape tile CNN without changing checkpoint keys."""
         if self._compiled_process_tile is None:
             self._compiled_process_tile = torch.compile(
-                self._process_tile_impl, dynamic=False, fullgraph=True,
+                self._process_tile_impl,
+                dynamic=False,
+                fullgraph=True,
             )
 
     def _process_tile(self, x):
@@ -167,14 +195,20 @@ class CNNRefinerModule(nn.Module):
 
                 tile_h, tile_w = tile_delta.shape[2], tile_delta.shape[3]
                 # Only ramp edges that overlap with adjacent tiles, not image boundaries.
-                at_top = (y0_adj == 0)
-                at_bottom = (y1 == H)
-                at_left = (x0_adj == 0)
-                at_right = (x1 == W)
+                at_top = y0_adj == 0
+                at_bottom = y1 == H
+                at_left = x0_adj == 0
+                at_right = x1 == W
                 blend_w = self._get_blend_weight(
-                    tile_h, tile_w, tile_overlap,
-                    at_top, at_bottom, at_left, at_right,
-                    full_input.device, full_input.dtype,
+                    tile_h,
+                    tile_w,
+                    tile_overlap,
+                    at_top,
+                    at_bottom,
+                    at_left,
+                    at_right,
+                    full_input.device,
+                    full_input.dtype,
                 )
 
                 delta_sum[:, :, y0_adj:y1, x0_adj:x1] += tile_delta * blend_w
@@ -201,22 +235,18 @@ class CNNRefinerModule(nn.Module):
 
         return self._forward_tiled(full_input, coarse_pred.shape[1])
 
-    def _get_blend_weight(self, h, w, overlap,
-                          at_top, at_bottom, at_left, at_right,
-                          device, dtype):
+    def _get_blend_weight(self, h, w, overlap, at_top, at_bottom, at_left, at_right, device, dtype):
         key = (h, w, overlap, at_top, at_bottom, at_left, at_right, device, dtype)
         weight = self._blend_weight_cache.get(key)
         if weight is None:
-            weight = self._blend_weight(h, w, overlap,
-                                        at_top, at_bottom, at_left, at_right,
-                                        device, dtype)
+            weight = self._blend_weight(
+                h, w, overlap, at_top, at_bottom, at_left, at_right, device, dtype
+            )
             self._blend_weight_cache[key] = weight
         return weight
 
     @staticmethod
-    def _blend_weight(h, w, overlap,
-                      at_top, at_bottom, at_left, at_right,
-                      device, dtype):
+    def _blend_weight(h, w, overlap, at_top, at_bottom, at_left, at_right, device, dtype):
         """Linear blend ramp for tile overlap regions.
 
         Edges at image boundaries (at_top/bottom/left/right=True) keep
@@ -239,41 +269,48 @@ class CNNRefinerModule(nn.Module):
         return weight
 
 
-
 class GreenFormer(nn.Module):
-    def __init__(self, encoder_name='hiera_base_plus_224.mae_in1k_ft_in1k', in_channels=4, img_size=512, use_refiner=True):
+    def __init__(
+        self,
+        encoder_name="hiera_base_plus_224.mae_in1k_ft_in1k",
+        in_channels=4,
+        img_size=512,
+        use_refiner=True,
+    ):
         super().__init__()
-        
+
         # --- Encoder ---
         # Load Pretrained Hiera
         # 1. Create Target Model (512x512, Random Weights)
         # We use features_only=True, which wraps it in FeatureGetterNet
         print(f"Initializing {encoder_name} (img_size={img_size})...")
-        self.encoder = timm.create_model(encoder_name, pretrained=False, features_only=True, img_size=img_size)
-        # We skip downloading/loading base weights because the user's checkpoint 
-        # (loaded immediately after this) contains all weights, including correctly 
+        self.encoder = timm.create_model(
+            encoder_name, pretrained=False, features_only=True, img_size=img_size
+        )
+        # We skip downloading/loading base weights because the user's checkpoint
+        # (loaded immediately after this) contains all weights, including correctly
         # trained/sized PosEmbeds. This keeps the project offline-capable using only local assets.
         print("Skipped downloading base weights (relying on custom checkpoint).")
-        
+
         # Patch First Layer for 4 channels
         if in_channels != 3:
             self._patch_input_layer(in_channels)
-            
+
         # Get feature info
         # Verified Hiera Base Plus channels: [112, 224, 448, 896]
         # We can try to fetch dynamically
         try:
             feature_channels = self.encoder.feature_info.channels()
-        except:
+        except Exception:
             feature_channels = [112, 224, 448, 896]
         print(f"Feature Channels: {feature_channels}")
-        
+
         # --- Decoders ---
         embedding_dim = 256
-        
+
         # Alpha Decoder (Outputs 1 channel)
         self.alpha_decoder = DecoderHead(feature_channels, embedding_dim, output_dim=1)
-        
+
         # Foreground Decoder (Outputs 3 channels)
         self.fg_decoder = DecoderHead(feature_channels, embedding_dim, output_dim=3)
 
@@ -293,35 +330,42 @@ class GreenFormer(nn.Module):
         Copies existing RGB weights and initializes extras to zero.
         """
         # Hiera: self.encoder.model.patch_embed.proj
-        
+
         try:
             patch_embed = self.encoder.model.patch_embed.proj
         except AttributeError:
-             # Fallback if timm changes structure or for other models
+            # Fallback if timm changes structure or for other models
             patch_embed = self.encoder.patch_embed.proj
-        weight = patch_embed.weight.data # [Out, 3, K, K]
+        weight = patch_embed.weight.data  # [Out, 3, K, K]
         bias = patch_embed.bias.data if patch_embed.bias is not None else None
-        
+
         new_in_channels = in_channels
         out_channels, _, k, k = weight.shape
-        
+
         # Create new conv
-        new_conv = nn.Conv2d(new_in_channels, out_channels, kernel_size=k, stride=patch_embed.stride, padding=patch_embed.padding, bias=(bias is not None))
-        
+        new_conv = nn.Conv2d(
+            new_in_channels,
+            out_channels,
+            kernel_size=k,
+            stride=patch_embed.stride,
+            padding=patch_embed.padding,
+            bias=(bias is not None),
+        )
+
         # Copy weights
         new_conv.weight.data[:, :3, :, :] = weight
         # Initialize new channels to 0 (Weight Patching)
         new_conv.weight.data[:, 3:, :, :] = 0.0
-        
+
         if bias is not None:
             new_conv.bias.data = bias
-            
+
         # Replace in module
         try:
-             self.encoder.model.patch_embed.proj = new_conv
+            self.encoder.model.patch_embed.proj = new_conv
         except AttributeError:
-             self.encoder.patch_embed.proj = new_conv
-        
+            self.encoder.patch_embed.proj = new_conv
+
         print(f"Patched input layer: 3 channels -> {in_channels} channels (Extra initialized to 0)")
 
     def forward(self, x, refiner_scale=None):
@@ -329,16 +373,20 @@ class GreenFormer(nn.Module):
         input_size = x.shape[2:]
 
         # Encode
-        features = self.encoder(x) # Returns list of features
+        features = self.encoder(x)  # Returns list of features
 
         # Decode Streams
-        alpha_logits = self.alpha_decoder(features) # [B, 1, H/4, W/4]
-        fg_logits = self.fg_decoder(features)       # [B, 3, H/4, W/4]
+        alpha_logits = self.alpha_decoder(features)  # [B, 1, H/4, W/4]
+        fg_logits = self.fg_decoder(features)  # [B, 3, H/4, W/4]
 
         # Upsample to full resolution (Bilinear)
         # These are the "Coarse" LOGITS
-        alpha_logits_up = F.interpolate(alpha_logits, size=input_size, mode='bilinear', align_corners=False)
-        fg_logits_up = F.interpolate(fg_logits, size=input_size, mode='bilinear', align_corners=False)
+        alpha_logits_up = F.interpolate(
+            alpha_logits, size=input_size, mode="bilinear", align_corners=False
+        )
+        fg_logits_up = F.interpolate(
+            fg_logits, size=input_size, mode="bilinear", align_corners=False
+        )
 
         # Coarse Probs (for Loss and Refiner Input)
         alpha_coarse = torch.sigmoid(alpha_logits_up)
@@ -346,7 +394,7 @@ class GreenFormer(nn.Module):
 
         # --- Refinement (CNN Hybrid) ---
         rgb = x[:, :3, :, :]
-        coarse_pred = torch.cat([alpha_coarse, fg_coarse], dim=1) # [B, 4, H, W]
+        coarse_pred = torch.cat([alpha_coarse, fg_coarse], dim=1)  # [B, 4, H, W]
 
         # Refiner outputs DELTA LOGITS
         if self.use_refiner and self.refiner is not None:
@@ -372,7 +420,4 @@ class GreenFormer(nn.Module):
         alpha_final = torch.sigmoid(alpha_final_logits)
         fg_final = torch.sigmoid(fg_final_logits)
 
-        return {
-            'alpha': alpha_final,
-            'fg': fg_final
-        }
+        return {"alpha": alpha_final, "fg": fg_final}

--- a/CorridorKeyModule/inference_engine.py
+++ b/CorridorKeyModule/inference_engine.py
@@ -29,6 +29,7 @@ INFERENCE_DEFAULTS = {
     "edge_blur_px": None,
 }
 
+
 def _patch_hiera_global_attention(hiera_model: nn.Module) -> int:
     """Monkey-patch MaskUnitAttention.forward on global-attention blocks.
 
@@ -57,12 +58,10 @@ def _patch_hiera_global_attention(hiera_model: nn.Module) -> int:
                 qkv = self.qkv(x)
                 qkv = qkv.reshape(B, N, 3, self.heads, self.head_dim)
                 qkv = qkv.permute(2, 0, 3, 1, 4)  # [3, B, heads, N, head_dim]
-                q, k, v = qkv.unbind(0)             # each [B, heads, N, head_dim]
+                q, k, v = qkv.unbind(0)  # each [B, heads, N, head_dim]
 
                 if self.q_stride > 1:
-                    q = q.view(
-                        B, self.heads, self.q_stride, -1, self.head_dim
-                    ).amax(dim=2)
+                    q = q.view(B, self.heads, self.q_stride, -1, self.head_dim).amax(dim=2)
 
                 # Force contiguous layout so SDPA can use FlashAttention
                 q = q.contiguous()
@@ -81,6 +80,7 @@ def _patch_hiera_global_attention(hiera_model: nn.Module) -> int:
 
     return patched
 
+
 class CorridorKeyEngine:
     # VRAM threshold for optimization profile selection.
     # Below this: tiled refiner + selective compile. Above: full-frame compile.
@@ -90,10 +90,18 @@ class CorridorKeyEngine:
     #   'auto'  — detect VRAM and pick best strategy (default)
     #   'speed' — torch.compile, no tiling (12GB+ VRAM)
     #   'lowvram' — tiled refiner + compiled tile kernel (8GB GPUs)
-    VALID_OPT_MODES = ('auto', 'speed', 'lowvram')
+    VALID_OPT_MODES = ("auto", "speed", "lowvram")
 
-    def __init__(self, checkpoint_path, device='cuda', img_size=2048, use_refiner=True,
-                 optimization_mode='auto', tile_overlap=128, on_status=None):
+    def __init__(
+        self,
+        checkpoint_path,
+        device="cuda",
+        img_size=2048,
+        use_refiner=True,
+        optimization_mode="auto",
+        tile_overlap=128,
+        on_status=None,
+    ):
         logger.info("CorridorKeyEngine.__init__: begin")
         self.device = torch.device(device)
         self.img_size = img_size
@@ -106,7 +114,7 @@ class CorridorKeyEngine:
         self._compile_error = None
 
         # Allow env var override: CORRIDORKEY_OPT_MODE=speed|lowvram|auto
-        env_mode = os.environ.get('CORRIDORKEY_OPT_MODE', '').lower()
+        env_mode = os.environ.get("CORRIDORKEY_OPT_MODE", "").lower()
         if env_mode in self.VALID_OPT_MODES:
             optimization_mode = env_mode
             logger.info(f"Optimization mode override from env: {env_mode}")
@@ -121,33 +129,39 @@ class CorridorKeyEngine:
         # GVM teardown — pynvml doesn't have that problem.
         # MPS (Apple Silicon): always use lowvram mode — unified memory is
         # shared with the OS, and torch.compile/Triton doesn't support Metal.
-        is_mps = self.device.type == 'mps'
+        is_mps = self.device.type == "mps"
         if is_mps:
-            optimization_mode = 'lowvram'
+            optimization_mode = "lowvram"
             logger.info("MPS device detected — forcing low-VRAM mode (no torch.compile on Metal)")
 
-        if optimization_mode == 'speed':
+        if optimization_mode == "speed":
             self.tile_size = 0
             self._use_compile = True
             logger.info("Optimization: speed mode (torch.compile, no tiling)")
-        elif optimization_mode == 'lowvram':
+        elif optimization_mode == "lowvram":
             self.tile_size = 512
             self._use_compile = not is_mps  # Triton/inductor doesn't support MPS
-            logger.info(f"Optimization: low-VRAM mode (tiled refiner 512x512"
-                        f"{'' if self._use_compile else ', no torch.compile'})")
+            logger.info(
+                f"Optimization: low-VRAM mode (tiled refiner 512x512"
+                f"{'' if self._use_compile else ', no torch.compile'})"
+            )
         else:  # auto
             logger.info("Optimization: auto mode - probing VRAM...")
             vram_gb = self._get_vram_gb()
             if vram_gb > 0 and vram_gb < self._VRAM_TILE_THRESHOLD_GB:
                 self.tile_size = 512
                 self._use_compile = True
-                logger.info(f"Optimization: auto -> low-VRAM mode "
-                            f"({vram_gb:.1f} GB < {self._VRAM_TILE_THRESHOLD_GB} GB threshold)")
+                logger.info(
+                    f"Optimization: auto -> low-VRAM mode "
+                    f"({vram_gb:.1f} GB < {self._VRAM_TILE_THRESHOLD_GB} GB threshold)"
+                )
             else:
                 self.tile_size = 0
                 self._use_compile = True
-                logger.info(f"Optimization: auto -> speed mode "
-                            f"({vram_gb:.1f} GB >= {self._VRAM_TILE_THRESHOLD_GB} GB threshold)")
+                logger.info(
+                    f"Optimization: auto -> speed mode "
+                    f"({vram_gb:.1f} GB >= {self._VRAM_TILE_THRESHOLD_GB} GB threshold)"
+                )
 
         self.mean = np.array([0.485, 0.456, 0.406], dtype=np.float32).reshape(1, 1, 3)
         self.std = np.array([0.229, 0.224, 0.225], dtype=np.float32).reshape(1, 1, 3)
@@ -164,13 +178,14 @@ class CorridorKeyEngine:
         logger.debug("_get_vram_gb: entering")
         try:
             import pynvml
+
             logger.debug("_get_vram_gb: pynvml imported, calling nvmlInit...")
             pynvml.nvmlInit()
             logger.debug("_get_vram_gb: nvmlInit done, getting handle...")
             handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             logger.debug("_get_vram_gb: got handle, querying memory...")
             mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
-            vram = mem.total / (1024 ** 3)
+            vram = mem.total / (1024**3)
             logger.debug(f"_get_vram_gb: pynvml reports {vram:.1f} GB")
             return vram
         except Exception as e:
@@ -179,14 +194,14 @@ class CorridorKeyEngine:
         try:
             logger.debug("_get_vram_gb: falling back to torch.cuda...")
             if torch.cuda.is_available():
-                vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
+                vram = torch.cuda.get_device_properties(0).total_memory / (1024**3)
                 logger.debug(f"_get_vram_gb: torch.cuda reports {vram:.1f} GB")
                 return vram
         except Exception as e:
             logger.debug(f"_get_vram_gb: torch.cuda failed: {e}")
         logger.debug("_get_vram_gb: all probes failed, returning 0")
         return 0.0
-        
+
     def _status(self, msg: str) -> None:
         """Emit status to UI callback and log."""
         logger.info(msg)
@@ -205,24 +220,26 @@ class CorridorKeyEngine:
 
     def _has_compiled_artifacts(self) -> bool:
         """Return True if this engine may still touch compiled Torch/Triton code."""
-        refiner = getattr(self._eager_model, 'refiner', None)
-        tile_kernel = getattr(refiner, '_compiled_process_tile', None) if refiner is not None else None
+        refiner = getattr(self._eager_model, "refiner", None)
+        tile_kernel = (
+            getattr(refiner, "_compiled_process_tile", None) if refiner is not None else None
+        )
         return self._compiled_model is not None or tile_kernel is not None
 
     def _is_compile_failure(self, exc: Exception) -> bool:
         """Best-effort filter for torch.compile/Triton/Inductor runtime failures."""
         markers = (
-            'triton',
-            'torchinductor',
-            'torch._inductor',
-            'torch._dynamo',
-            'backendcompilerfailed',
-            'loweringexception',
-            'asynccompile',
-            'compileworker',
-            'inductor',
-            'compiler: cl is not found',
-            'compiler: cl.exe is not found',
+            "triton",
+            "torchinductor",
+            "torch._inductor",
+            "torch._dynamo",
+            "backendcompilerfailed",
+            "loweringexception",
+            "asynccompile",
+            "compileworker",
+            "inductor",
+            "compiler: cl is not found",
+            "compiler: cl.exe is not found",
         )
         for err in self._iter_exception_chain(exc):
             text = f"{type(err).__module__} {type(err).__name__} {err}".lower()
@@ -237,19 +254,20 @@ class CorridorKeyEngine:
         self._compiled_model = None
 
         if self._eager_model is not None:
-            refiner = getattr(self._eager_model, 'refiner', None)
-            if refiner is not None and getattr(refiner, '_compiled_process_tile', None) is not None:
+            refiner = getattr(self._eager_model, "refiner", None)
+            if refiner is not None and getattr(refiner, "_compiled_process_tile", None) is not None:
                 refiner._compiled_process_tile = None
             self.model = self._eager_model
 
         try:
             import torch._dynamo as _dynamo
+
             _dynamo.reset()
         except Exception as reset_error:
             logger.debug(f"dynamo reset skipped after compile failure: {reset_error}")
 
         try:
-            if self.device.type == 'cuda' and torch.cuda.is_available():
+            if self.device.type == "cuda" and torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception as cache_error:
             logger.debug(f"cuda cache clear skipped after compile failure: {cache_error}")
@@ -286,9 +304,11 @@ class CorridorKeyEngine:
         _diag("Step 1: GreenFormer init...")
         self._status("Initializing model backbone...")
         t0 = _time.monotonic()
-        model = GreenFormer(encoder_name='hiera_base_plus_224.mae_in1k_ft_in1k',
-                          img_size=self.img_size,
-                          use_refiner=self.use_refiner)
+        model = GreenFormer(
+            encoder_name="hiera_base_plus_224.mae_in1k_ft_in1k",
+            img_size=self.img_size,
+            use_refiner=self.use_refiner,
+        )
         _diag(f"Step 1 done: {_time.monotonic() - t0:.1f}s")
         logger.info(f"GreenFormer init: {_time.monotonic() - t0:.1f}s")
 
@@ -309,7 +329,7 @@ class CorridorKeyEngine:
         self._status("Loading checkpoint weights...")
         t0 = _time.monotonic()
         checkpoint = torch.load(self.checkpoint_path, map_location=self.device, weights_only=True)
-        state_dict = checkpoint.get('state_dict', checkpoint)
+        state_dict = checkpoint.get("state_dict", checkpoint)
         _diag(f"Step 3 done: {_time.monotonic() - t0:.1f}s")
         logger.info(f"Checkpoint loaded: {_time.monotonic() - t0:.1f}s")
 
@@ -318,13 +338,15 @@ class CorridorKeyEngine:
         model_state = model.state_dict()
 
         for k, v in state_dict.items():
-            if k.startswith('_orig_mod.'):
+            if k.startswith("_orig_mod."):
                 k = k[10:]
 
             # Check for PosEmbed Mismatch
-            if 'pos_embed' in k and k in model_state:
+            if "pos_embed" in k and k in model_state:
                 if v.shape != model_state[k].shape:
-                    logger.warning(f"PosEmbed shape mismatch: resizing {k} from {v.shape} to {model_state[k].shape}")
+                    logger.warning(
+                        f"PosEmbed shape mismatch: resizing {k} from {v.shape} to {model_state[k].shape}"
+                    )
                     N_src = v.shape[1]
                     N_dst = model_state[k].shape[1]
                     C = v.shape[2]
@@ -333,7 +355,9 @@ class CorridorKeyEngine:
                     grid_dst = int(math.sqrt(N_dst))
 
                     v_img = v.permute(0, 2, 1).view(1, C, grid_src, grid_src)
-                    v_resized = F.interpolate(v_img, size=(grid_dst, grid_dst), mode='bicubic', align_corners=False)
+                    v_resized = F.interpolate(
+                        v_img, size=(grid_dst, grid_dst), mode="bicubic", align_corners=False
+                    )
                     v = v_resized.flatten(2).transpose(1, 2)
 
             new_state_dict[k] = v
@@ -359,15 +383,19 @@ class CorridorKeyEngine:
         try:
             hiera = model.encoder.model
             n_patched = _patch_hiera_global_attention(hiera)
-            logger.info(f"Hiera attention patch: {n_patched} blocks ({_time.monotonic() - t0:.1f}s)")
+            logger.info(
+                f"Hiera attention patch: {n_patched} blocks ({_time.monotonic() - t0:.1f}s)"
+            )
         except Exception as e:
             logger.warning(f"Hiera attention patch failed: {type(e).__name__}: {e}")
 
         # Configure tiled refiner for VRAM-constrained processing.
-        if self.tile_size > 0 and hasattr(model, 'refiner') and model.refiner is not None:
+        if self.tile_size > 0 and hasattr(model, "refiner") and model.refiner is not None:
             model.refiner._tile_size = self.tile_size
             model.refiner._tile_overlap = self.tile_overlap
-            logger.info(f"Tiled refiner: {self.tile_size}x{self.tile_size} tiles, {self.tile_overlap}px overlap")
+            logger.info(
+                f"Tiled refiner: {self.tile_size}x{self.tile_size} tiles, {self.tile_overlap}px overlap"
+            )
 
         eager_model = model
         self._eager_model = eager_model
@@ -379,11 +407,13 @@ class CorridorKeyEngine:
             import subprocess
             import sys
 
-            if sys.platform == 'win32' and not getattr(subprocess.Popen, '_corridorkey_no_window', False):
+            if sys.platform == "win32" and not getattr(
+                subprocess.Popen, "_corridorkey_no_window", False
+            ):
                 _orig_popen_init = subprocess.Popen.__init__
 
                 def _silent_popen_init(self, *args, **kwargs):
-                    kwargs.setdefault('creationflags', subprocess.CREATE_NO_WINDOW)
+                    kwargs.setdefault("creationflags", subprocess.CREATE_NO_WINDOW)
                     _orig_popen_init(self, *args, **kwargs)
 
                 subprocess.Popen.__init__ = _silent_popen_init
@@ -391,26 +421,36 @@ class CorridorKeyEngine:
 
             try:
                 import triton  # noqa: F401
+
                 # Frozen builds: if triton_windows .dist-info was missing,
                 # the runtime hook flagged it.  Patch the backends dict now.
-                if os.environ.get('_TRITON_PATCH_BACKENDS') == '1':
+                if os.environ.get("_TRITON_PATCH_BACKENDS") == "1":
                     from triton.backends import backends, Backend, _find_concrete_subclasses
                     from triton.backends.driver import DriverBase
                     from triton.backends.compiler import BaseBackend
-                    if 'nvidia' not in backends:
+
+                    if "nvidia" not in backends:
                         import triton.backends.nvidia.compiler as _nv_compiler
                         import triton.backends.nvidia.driver as _nv_driver
-                        backends['nvidia'] = Backend(
+
+                        backends["nvidia"] = Backend(
                             _find_concrete_subclasses(_nv_compiler, BaseBackend),
                             _find_concrete_subclasses(_nv_driver, DriverBase),
                         )
                         logger.info("Patched triton backends: nvidia registered")
-                    del os.environ['_TRITON_PATCH_BACKENDS']
+                    del os.environ["_TRITON_PATCH_BACKENDS"]
             except Exception as e:
                 self._use_compile = False
-                logger.warning(f"Triton unavailable, skipping torch.compile: {type(e).__name__}: {e}")
+                logger.warning(
+                    f"Triton unavailable, skipping torch.compile: {type(e).__name__}: {e}"
+                )
 
-            if self._use_compile and self.tile_size > 0 and hasattr(eager_model, 'refiner') and eager_model.refiner is not None:
+            if (
+                self._use_compile
+                and self.tile_size > 0
+                and hasattr(eager_model, "refiner")
+                and eager_model.refiner is not None
+            ):
                 try:
                     t0 = _time.monotonic()
                     eager_model.refiner.compile_tile_kernel()
@@ -427,7 +467,9 @@ class CorridorKeyEngine:
                     # First launch pays the full compile cost; every launch after is near-instant.
                     try:
                         torch._inductor.config.fx_graph_cache = True
-                        logger.info("FX graph cache enabled (subsequent launches will skip recompilation)")
+                        logger.info(
+                            "FX graph cache enabled (subsequent launches will skip recompilation)"
+                        )
                     except AttributeError:
                         logger.debug("FX graph cache config not available in this PyTorch version")
 
@@ -437,7 +479,9 @@ class CorridorKeyEngine:
                     logger.info(f"torch.compile complete: {_time.monotonic() - t0:.1f}s")
                 except Exception as e:
                     self._compiled_model = None
-                    logger.warning(f"torch.compile failed (falling back to eager): {type(e).__name__}: {e}")
+                    logger.warning(
+                        f"torch.compile failed (falling back to eager): {type(e).__name__}: {e}"
+                    )
 
         self._status("Model ready")
         return model
@@ -445,7 +489,22 @@ class CorridorKeyEngine:
     _D = INFERENCE_DEFAULTS
 
     @torch.no_grad()
-    def process_frame(self, image, mask_linear, refiner_scale=_D["refiner_scale"], input_is_linear=False, fg_is_straight=True, despill_strength=_D["despill_strength"], auto_despeckle=_D["auto_despeckle"], despeckle_size=_D["despeckle_size"], despeckle_dilation=_D["despeckle_dilation"], despeckle_blur=_D["despeckle_blur"], source_passthrough=_D["source_passthrough"], edge_erode_px=_D["edge_erode_px"], edge_blur_px=_D["edge_blur_px"]):
+    def process_frame(
+        self,
+        image,
+        mask_linear,
+        refiner_scale=_D["refiner_scale"],
+        input_is_linear=False,
+        fg_is_straight=True,
+        despill_strength=_D["despill_strength"],
+        auto_despeckle=_D["auto_despeckle"],
+        despeckle_size=_D["despeckle_size"],
+        despeckle_dilation=_D["despeckle_dilation"],
+        despeckle_blur=_D["despeckle_blur"],
+        source_passthrough=_D["source_passthrough"],
+        edge_erode_px=_D["edge_erode_px"],
+        edge_blur_px=_D["edge_blur_px"],
+    ):
         """
         Process a single frame.
         Args:
@@ -476,29 +535,35 @@ class CorridorKeyEngine:
         # 1. Inputs Check & Normalization
         if image.dtype == np.uint8:
             image = image.astype(np.float32) / 255.0
-            
+
         if mask_linear.dtype == np.uint8:
             mask_linear = mask_linear.astype(np.float32) / 255.0
-            
+
         h, w = image.shape[:2]
-        
+
         # Ensure Mask Shape
         if mask_linear.ndim == 2:
             mask_linear = mask_linear[:, :, np.newaxis]
-            
+
         # 2. Resize to Model Size
         # If input is linear, we resize in linear to preserve energy/highlights,
         # THEN convert to sRGB for the model.
         if input_is_linear:
-             # Resize in Linear
-             img_resized_lin = cv2.resize(image, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
-             # Convert to sRGB for Model
-             img_resized = cu.linear_to_srgb(img_resized_lin)
+            # Resize in Linear
+            img_resized_lin = cv2.resize(
+                image, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR
+            )
+            # Convert to sRGB for Model
+            img_resized = cu.linear_to_srgb(img_resized_lin)
         else:
-             # Standard sRGB Resize
-             img_resized = cv2.resize(image, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+            # Standard sRGB Resize
+            img_resized = cv2.resize(
+                image, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR
+            )
 
-        mask_resized = cv2.resize(mask_linear, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR)
+        mask_resized = cv2.resize(
+            mask_linear, (self.img_size, self.img_size), interpolation=cv2.INTER_LINEAR
+        )
 
         if mask_resized.ndim == 2:
             mask_resized = mask_resized[:, :, np.newaxis]
@@ -508,25 +573,26 @@ class CorridorKeyEngine:
         img_norm = (img_resized - self.mean) / self.std
 
         # 4. Prepare Tensor
-        inp_np = np.concatenate([img_norm, mask_resized], axis=-1) # [H, W, 4]
+        inp_np = np.concatenate([img_norm, mask_resized], axis=-1)  # [H, W, 4]
         inp_t = torch.from_numpy(inp_np.transpose((2, 0, 1))).float().unsqueeze(0).to(self.device)
-        
+
         # 5. Inference
         refiner_scale_t = inp_t.new_tensor(refiner_scale)
         with torch.autocast(device_type=self.device.type, dtype=torch.float16):
             out = self._forward_model(inp_t, refiner_scale_t)
-            
-        pred_alpha = out['alpha']
-        pred_fg = out['fg'] # Output is sRGB (Sigmoid)
-        
+
+        pred_alpha = out["alpha"]
+        pred_fg = out["fg"]  # Output is sRGB (Sigmoid)
+
         # 6. Post-Process (Resize Back to Original Resolution)
         # We use Lanczos4 for high-quality resampling to minimize blur when going back to 4K/Original.
         res_alpha = pred_alpha[0].permute(1, 2, 0).float().cpu().numpy()
         res_fg = pred_fg[0].permute(1, 2, 0).float().cpu().numpy()
         res_alpha = cv2.resize(res_alpha, (w, h), interpolation=cv2.INTER_LANCZOS4)
         res_fg = cv2.resize(res_fg, (w, h), interpolation=cv2.INTER_LANCZOS4)
-        
-        if res_alpha.ndim == 2: res_alpha = res_alpha[:, :, np.newaxis]
+
+        if res_alpha.ndim == 2:
+            res_alpha = res_alpha[:, :, np.newaxis]
 
         # --- SOURCE PASSTHROUGH ---
         # Interior pixels (face, body, clothes — everywhere alpha ≈ 1.0) are passed
@@ -539,21 +605,25 @@ class CorridorKeyEngine:
             else:
                 original_srgb = image
             res_fg = cu.source_passthrough(
-                original_srgb, res_fg, res_alpha,
-                erode_px=edge_erode_px, blur_px=edge_blur_px
+                original_srgb, res_fg, res_alpha, erode_px=edge_erode_px, blur_px=edge_blur_px
             )
 
         # --- ADVANCED COMPOSITING ---
 
         # A. Clean Matte (Auto-Despeckle)
         if auto_despeckle:
-            processed_alpha = cu.clean_matte(res_alpha, area_threshold=despeckle_size, dilation=despeckle_dilation, blur_size=despeckle_blur)
+            processed_alpha = cu.clean_matte(
+                res_alpha,
+                area_threshold=despeckle_size,
+                dilation=despeckle_dilation,
+                blur_size=despeckle_blur,
+            )
         else:
             processed_alpha = res_alpha
 
         # B. Despill FG
         # res_fg is sRGB (with source passthrough blended in where applicable).
-        fg_despilled = cu.despill(res_fg, green_limit_mode='average', strength=despill_strength)
+        fg_despilled = cu.despill(res_fg, green_limit_mode="average", strength=despill_strength)
 
         # C. Convert to linear for output assembly.
         fg_despilled_lin = cu.srgb_to_linear(fg_despilled)
@@ -563,25 +633,25 @@ class CorridorKeyEngine:
         processed_rgba = np.concatenate([fg_premul_lin, processed_alpha], axis=-1)
 
         # ----------------------------
-        
+
         # 7. Composite (on Checkerboard) for checking
         # Generate Dark/Light Gray Checkerboard (in sRGB, convert to Linear)
         bg_srgb = cu.create_checkerboard(w, h, checker_size=128, color1=0.15, color2=0.55)
         bg_lin = cu.srgb_to_linear(bg_srgb)
-        
+
         if fg_is_straight:
-             comp_lin = cu.composite_straight(fg_despilled_lin, bg_lin, processed_alpha) 
+            comp_lin = cu.composite_straight(fg_despilled_lin, bg_lin, processed_alpha)
         else:
-             # If premultiplied model, we shouldn't multiply again (though our pipeline forces straight)
-             comp_lin = cu.composite_premul(fg_despilled_lin, bg_lin, processed_alpha)
-             
+            # If premultiplied model, we shouldn't multiply again (though our pipeline forces straight)
+            comp_lin = cu.composite_premul(fg_despilled_lin, bg_lin, processed_alpha)
+
         comp_srgb = cu.linear_to_srgb(comp_lin)
-        
+
         logger.debug(f"process_frame: {h}x{w} in {time.monotonic() - t0:.3f}s")
 
         return {
-            'alpha': res_alpha,        # Linear, Raw Prediction
-            'fg': res_fg,              # sRGB, Raw Prediction (Straight)
-            'comp': comp_srgb,         # sRGB, Composite
-            'processed': processed_rgba,  # Linear/Straight RGBA, garbage matted + despilled
+            "alpha": res_alpha,  # Linear, Raw Prediction
+            "fg": res_fg,  # sRGB, Raw Prediction (Straight)
+            "comp": comp_srgb,  # sRGB, Composite
+            "processed": processed_rgba,  # Linear/Straight RGBA, garbage matted + despilled
         }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This GUI replaces the CLI drag-and-drop workflow with a complete desktop applica
 - [Inference Controls](#inference-controls) — Parameters and output formats
 - [Hardware Requirements](#hardware-requirements) — VRAM, GPU, and platform info
 - [Contributing](#contributing--support) — How to help and get help
+- [ROCm (AMD) Docker](docs/ROCm_Setup.md) — optional AMD GPU image (`Dockerfile.rocm`)
 
 [![Star History Chart](https://api.star-history.com/svg?repos=edenaion/EZ-CorridorKey&type=Date)](https://star-history.com/#edenaion/EZ-CorridorKey&Date)
 
@@ -94,6 +95,8 @@ The installer includes everything — Python runtime, AI models, GPU libraries �
 ### Alternate Installation: Docker
 
 For Linux users or remote/cloud setups, EZ-CorridorKey can run inside Docker with browser-based access via noVNC. See [docker/README.md](docker/README.md) for setup instructions. The native install above is recommended for Windows and macOS.
+
+**AMD GPU (ROCm):** use the separate image and instructions in [docs/ROCm_Setup.md](docs/ROCm_Setup.md) ([`docker/Dockerfile.rocm`](docker/Dockerfile.rocm)); Compose profile **`rocm`** (`docker compose --profile rocm …`). Stop the default CPU/GPU stack first if ports **6080–6081** are already bound.
 
 ---
 

--- a/VideoMaMaInferenceModule/__init__.py
+++ b/VideoMaMaInferenceModule/__init__.py
@@ -6,5 +6,5 @@ __all__ = [
     "run_inference",
     "extract_frames_from_video",
     "save_video",
-    "VideoInferencePipeline"
+    "VideoInferencePipeline",
 ]

--- a/VideoMaMaInferenceModule/inference.py
+++ b/VideoMaMaInferenceModule/inference.py
@@ -11,7 +11,6 @@ import cv2
 import numpy as np
 from PIL import Image
 from typing import Callable, Iterator, List, Optional
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +21,17 @@ if current_dir not in sys.path:
 
 from .pipeline import VideoInferencePipeline
 
-def load_videomama_model(base_model_path: Optional[str] = None, unet_checkpoint_path: Optional[str] = None, device: str = "cuda") -> VideoInferencePipeline:
+
+def load_videomama_model(
+    base_model_path: Optional[str] = None,
+    unet_checkpoint_path: Optional[str] = None,
+    device: str = "cuda",
+) -> VideoInferencePipeline:
     """
     Load VideoMaMa pipeline with pretrained weights.
 
     Args:
-        base_model_path (str, optional): Path to the base Stable Video Diffusion model. 
+        base_model_path (str, optional): Path to the base Stable Video Diffusion model.
                                          Defaults to 'checkpoints/stable-video-diffusion-img2vid-xt' in module dir.
         unet_checkpoint_path (str, optional): Path to the fine-tuned UNet checkpoint.
                                               Defaults to 'checkpoints/VideoMaMa' in module dir.
@@ -38,14 +42,16 @@ def load_videomama_model(base_model_path: Optional[str] = None, unet_checkpoint_
     """
     # Default to local checkpoints if not provided
     if base_model_path is None:
-        base_model_path = os.path.join(current_dir, "checkpoints", "stable-video-diffusion-img2vid-xt")
-    
+        base_model_path = os.path.join(
+            current_dir, "checkpoints", "stable-video-diffusion-img2vid-xt"
+        )
+
     if unet_checkpoint_path is None:
         unet_checkpoint_path = os.path.join(current_dir, "checkpoints", "VideoMaMa")
 
     logger.info(f"Loading Base model from {base_model_path}...")
     logger.info(f"Loading VideoMaMa UNet from {unet_checkpoint_path}...")
-    
+
     # Check if paths exist
     if not os.path.exists(base_model_path):
         raise FileNotFoundError(f"Base model path not found: {base_model_path}")
@@ -55,14 +61,17 @@ def load_videomama_model(base_model_path: Optional[str] = None, unet_checkpoint_
     pipeline = VideoInferencePipeline(
         base_model_path=base_model_path,
         unet_checkpoint_path=unet_checkpoint_path,
-        weight_dtype=torch.float16, # Use float16 for inference by default
-        device=device
+        weight_dtype=torch.float16,  # Use float16 for inference by default
+        device=device,
     )
-    
+
     logger.info("VideoMaMa pipeline loaded successfully")
     return pipeline
 
-def extract_frames_from_video(video_path: str, max_frames: Optional[int] = None) -> tuple[List[np.ndarray], float]:
+
+def extract_frames_from_video(
+    video_path: str, max_frames: Optional[int] = None
+) -> tuple[List[np.ndarray], float]:
     """
     Extract frames from video file.
 
@@ -78,7 +87,7 @@ def extract_frames_from_video(video_path: str, max_frames: Optional[int] = None)
 
     cap = cv2.VideoCapture(video_path)
     original_fps = cap.get(cv2.CAP_PROP_FPS)
-    
+
     all_frames = []
     while cap.isOpened():
         ret, frame = cap.read()
@@ -87,15 +96,16 @@ def extract_frames_from_video(video_path: str, max_frames: Optional[int] = None)
         # Convert BGR to RGB
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         all_frames.append(frame_rgb)
-    
+
     cap.release()
-    
+
     if max_frames and len(all_frames) > max_frames:
         frames = all_frames[:max_frames]
     else:
         frames = all_frames
-    
+
     return frames, original_fps
+
 
 def run_inference(
     pipeline: VideoInferencePipeline,
@@ -121,7 +131,9 @@ def run_inference(
         List[np.ndarray]: Chunk of output RGB frames (H,W,3) uint8.
     """
     if len(input_frames) != len(mask_frames):
-        raise ValueError(f"Input frames ({len(input_frames)}) and mask frames ({len(mask_frames)}) must have same length.")
+        raise ValueError(
+            f"Input frames ({len(input_frames)}) and mask frames ({len(mask_frames)}) must have same length."
+        )
 
     if not input_frames:
         return
@@ -131,12 +143,14 @@ def run_inference(
     target_width, target_height = 1024, 576
     total_chunks = (len(input_frames) + chunk_size - 1) // chunk_size
 
-    logger.info(f"Processing {len(input_frames)} frames in chunks of {chunk_size} ({total_chunks} chunks)")
+    logger.info(
+        f"Processing {len(input_frames)} frames in chunks of {chunk_size} ({total_chunks} chunks)"
+    )
 
     for i in range(0, len(input_frames), chunk_size):
         chunk_idx = i // chunk_size + 1
-        chunk_input = input_frames[i:i + chunk_size]
-        chunk_masks = mask_frames[i:i + chunk_size]
+        chunk_input = input_frames[i : i + chunk_size]
+        chunk_masks = mask_frames[i : i + chunk_size]
 
         # Per-chunk PIL conversion + resize (2-3 sec instead of minutes upfront)
         chunk_frames_pil = [
@@ -148,10 +162,14 @@ def run_inference(
             if m.ndim == 3:
                 m = cv2.cvtColor(m, cv2.COLOR_RGB2GRAY)
             chunk_masks_pil.append(
-                Image.fromarray(m, mode='L').resize((target_width, target_height), Image.Resampling.BILINEAR)
+                Image.fromarray(m, mode="L").resize(
+                    (target_width, target_height), Image.Resampling.BILINEAR
+                )
             )
 
-        logger.debug(f"Running inference on chunk {chunk_idx}/{total_chunks} ({len(chunk_frames_pil)} frames)")
+        logger.debug(
+            f"Running inference on chunk {chunk_idx}/{total_chunks} ({len(chunk_frames_pil)} frames)"
+        )
 
         torch.cuda.empty_cache()
 
@@ -170,10 +188,12 @@ def run_inference(
         )
 
         # Resize output back to original resolution
-        chunk_output_resized = [f.resize(original_size, Image.Resampling.BILINEAR)
-                                for f in chunk_output]
+        chunk_output_resized = [
+            f.resize(original_size, Image.Resampling.BILINEAR) for f in chunk_output
+        ]
 
         yield [np.array(f) for f in chunk_output_resized]
+
 
 def save_video(frames: List[np.ndarray], output_path: str, fps: float):
     """
@@ -186,16 +206,15 @@ def save_video(frames: List[np.ndarray], output_path: str, fps: float):
     """
     if not frames:
         return
-    
+
     height, width = frames[0].shape[:2]
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
-    
+
     for frame in frames:
         # Convert RGB to BGR for OpenCV
         frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
         out.write(frame_bgr)
-    
+
     out.release()
     logger.info(f"Saved video to {output_path}")
-

--- a/VideoMaMaInferenceModule/pipeline.py
+++ b/VideoMaMaInferenceModule/pipeline.py
@@ -1,9 +1,8 @@
 # pipeline_svd_masked.py
 
-import inspect
 import logging as _logging
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import PIL.Image
@@ -20,7 +19,6 @@ from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 
 # Import necessary helpers from the original SVD pipeline
 from diffusers.pipelines.stable_video_diffusion.pipeline_stable_video_diffusion import (
-    _append_dims,
     retrieve_timesteps,
     _resize_with_antialiasing,
 )
@@ -69,6 +67,7 @@ class StableVideoDiffusionPipelineOutput(BaseOutput):
             List of denoised PIL images of length `batch_size` or numpy array or torch tensor of shape
             `(batch_size, num_frames, height, width, num_channels)`.
     """
+
     frames: Union[List[List[PIL.Image.Image]], np.ndarray, torch.Tensor]
 
 
@@ -83,12 +82,12 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
     _callback_tensor_inputs = ["latents"]
 
     def __init__(
-            self,
-            vae: AutoencoderKLTemporalDecoder,
-            image_encoder: CLIPVisionModelWithProjection,
-            unet: UNetSpatioTemporalConditionModel,
-            scheduler: EulerDiscreteScheduler,
-            feature_extractor: CLIPImageProcessor,
+        self,
+        vae: AutoencoderKLTemporalDecoder,
+        image_encoder: CLIPVisionModelWithProjection,
+        unet: UNetSpatioTemporalConditionModel,
+        scheduler: EulerDiscreteScheduler,
+        feature_extractor: CLIPImageProcessor,
     ):
         super().__init__()
 
@@ -100,13 +99,15 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
-        self.video_processor = VideoProcessor(do_resize=True, vae_scale_factor=self.vae_scale_factor)
+        self.video_processor = VideoProcessor(
+            do_resize=True, vae_scale_factor=self.vae_scale_factor
+        )
 
     def _encode_image(
-            self,
-            image: PipelineImageInput,
-            device: Union[str, torch.device],
-            num_videos_per_prompt: int,
+        self,
+        image: PipelineImageInput,
+        device: Union[str, torch.device],
+        num_videos_per_prompt: int,
     ) -> torch.Tensor:
         dtype = next(self.image_encoder.parameters()).dtype
 
@@ -137,10 +138,10 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
         return image_embeddings
 
     def _encode_vae_image(
-            self,
-            image: torch.Tensor,
-            device: Union[str, torch.device],
-            num_videos_per_prompt: int,
+        self,
+        image: torch.Tensor,
+        device: Union[str, torch.device],
+        num_videos_per_prompt: int,
     ):
         image = image.to(device=device, dtype=torch.float16)
         image_latents = self.vae.encode(image).latent_dist.sample()
@@ -148,13 +149,13 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
         return image_latents
 
     def _get_add_time_ids(
-            self,
-            fps: int,
-            motion_bucket_id: int,
-            noise_aug_strength: float,
-            dtype: torch.dtype,
-            batch_size: int,
-            num_videos_per_prompt: int,
+        self,
+        fps: int,
+        motion_bucket_id: int,
+        noise_aug_strength: float,
+        dtype: torch.dtype,
+        batch_size: int,
+        num_videos_per_prompt: int,
     ):
         add_time_ids = [fps, motion_bucket_id, noise_aug_strength]
         passed_add_embed_dim = self.unet.config.addition_time_embed_dim * len(add_time_ids)
@@ -172,8 +173,10 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
         latents = 1 / self.vae.config.scaling_factor * latents
         frames = []
         for i in range(0, latents.shape[0], decode_chunk_size):
-            num_frames_in = latents[i: i + decode_chunk_size].shape[0]
-            frame = self.vae.decode(latents[i: i + decode_chunk_size], num_frames=num_frames_in).sample
+            num_frames_in = latents[i : i + decode_chunk_size].shape[0]
+            frame = self.vae.decode(
+                latents[i : i + decode_chunk_size], num_frames=num_frames_in
+            ).sample
             frames.append(frame)
         frames = torch.cat(frames, dim=0)
         frames = frames.reshape(-1, num_frames, *frames.shape[1:]).permute(0, 2, 1, 3, 4)
@@ -182,27 +185,31 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
 
     def check_inputs(self, image, height, width):
         if (
-                not isinstance(image, torch.Tensor)
-                and not isinstance(image, PIL.Image.Image)
-                and not isinstance(image, list)
+            not isinstance(image, torch.Tensor)
+            and not isinstance(image, PIL.Image.Image)
+            and not isinstance(image, list)
         ):
-            raise ValueError(f"`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is {type(image)}")
+            raise ValueError(
+                f"`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is {type(image)}"
+            )
         if height % 8 != 0 or width % 8 != 0:
-            raise ValueError(f"`height` and `width` have to be divisible by 8 but are {height} and {width}.")
+            raise ValueError(
+                f"`height` and `width` have to be divisible by 8 but are {height} and {width}."
+            )
 
     def prepare_latents(
-            self,
-            batch_size: int,
-            num_frames: int,
-            height: int,
-            width: int,
-            dtype: torch.dtype,
-            device: Union[str, torch.device],
-            generator: torch.Generator,
-            latents: Optional[torch.Tensor] = None,
-            initial_latents: Optional[torch.Tensor] = None,
-            denoising_strength: float = 1.0,
-            timestep: Optional[torch.Tensor] = None,
+        self,
+        batch_size: int,
+        num_frames: int,
+        height: int,
+        width: int,
+        dtype: torch.dtype,
+        device: Union[str, torch.device],
+        generator: torch.Generator,
+        latents: Optional[torch.Tensor] = None,
+        initial_latents: Optional[torch.Tensor] = None,
+        denoising_strength: float = 1.0,
+        timestep: Optional[torch.Tensor] = None,
     ):
         num_channels_latents = self.unet.config.out_channels
         shape = (
@@ -230,44 +237,50 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
         return latents
 
     def _encode_video_vae(
-            self,
-            video_frames: torch.Tensor,  # Expects (B, F, C, H, W)
-            device: Union[str, torch.device],
+        self,
+        video_frames: torch.Tensor,  # Expects (B, F, C, H, W)
+        device: Union[str, torch.device],
     ):
         video_frames = video_frames.to(device=device, dtype=self.vae.dtype)
         batch_size, num_frames = video_frames.shape[:2]
 
         # Reshape for VAE encoding
-        video_frames_reshaped = video_frames.reshape(batch_size * num_frames, *video_frames.shape[2:])  # (B*F, C, H, W)
-        latents = self.vae.encode(video_frames_reshaped).latent_dist.sample()  # (B*F, C_latent, H_latent, W_latent)
+        video_frames_reshaped = video_frames.reshape(
+            batch_size * num_frames, *video_frames.shape[2:]
+        )  # (B*F, C, H, W)
+        latents = self.vae.encode(
+            video_frames_reshaped
+        ).latent_dist.sample()  # (B*F, C_latent, H_latent, W_latent)
 
         # Reshape back to video format
-        latents = latents.reshape(batch_size, num_frames, *latents.shape[1:])  # (B, F, C_latent, H_latent, W_latent)
+        latents = latents.reshape(
+            batch_size, num_frames, *latents.shape[1:]
+        )  # (B, F, C_latent, H_latent, W_latent)
 
         return latents
 
     @torch.no_grad()
     def __call__(
-            self,
-            image: Union[List[PIL.Image.Image], torch.Tensor],
-            mask_image: Union[List[PIL.Image.Image], torch.Tensor],
-            alpha_matte_image: Optional[Union[List[PIL.Image.Image], torch.Tensor]] = None,
-            denoising_strength: float = 0.7,
-            height: int = 576,
-            width: int = 1024,
-            num_frames: Optional[int] = None,
-            num_inference_steps: int = 30,
-            sigmas: Optional[List[float]] = None,
-            fps: int = 7,
-            motion_bucket_id: int = 127,
-            noise_aug_strength: float = 0.02,
-            decode_chunk_size: Optional[int] = None,
-            num_videos_per_prompt: Optional[int] = 1,
-            generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-            latents: Optional[torch.Tensor] = None,
-            output_type: Optional[str] = "pil",
-            return_dict: bool = True,
-            mask_noise_strength: float = 0.0,
+        self,
+        image: Union[List[PIL.Image.Image], torch.Tensor],
+        mask_image: Union[List[PIL.Image.Image], torch.Tensor],
+        alpha_matte_image: Optional[Union[List[PIL.Image.Image], torch.Tensor]] = None,
+        denoising_strength: float = 0.7,
+        height: int = 576,
+        width: int = 1024,
+        num_frames: Optional[int] = None,
+        num_inference_steps: int = 30,
+        sigmas: Optional[List[float]] = None,
+        fps: int = 7,
+        motion_bucket_id: int = 127,
+        noise_aug_strength: float = 0.02,
+        decode_chunk_size: Optional[int] = None,
+        num_videos_per_prompt: Optional[int] = 1,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+        output_type: Optional[str] = "pil",
+        return_dict: bool = True,
+        mask_noise_strength: float = 0.0,
     ):
         height = height or self.unet.config.sample_size * self.vae_scale_factor
         width = width or self.unet.config.sample_size * self.vae_scale_factor
@@ -294,8 +307,16 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
 
         fps = fps - 1
 
-        image_tensor = self.video_processor.preprocess(image, height=height, width=width).to(device).unsqueeze(0)
-        mask_tensor = self.video_processor.preprocess(mask_image, height=height, width=width).to(device).unsqueeze(0)
+        image_tensor = (
+            self.video_processor.preprocess(image, height=height, width=width)
+            .to(device)
+            .unsqueeze(0)
+        )
+        mask_tensor = (
+            self.video_processor.preprocess(mask_image, height=height, width=width)
+            .to(device)
+            .unsqueeze(0)
+        )
 
         noise = randn_tensor(image_tensor.shape, generator=generator, device=device, dtype=dtype)
         image_tensor = image_tensor + noise_aug_strength * noise
@@ -315,31 +336,45 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
             interpolated_mask = F.interpolate(
                 binarized_mask_reshaped,
                 size=target_size,
-                mode='nearest',
+                mode="nearest",
             )
             mask_latents = interpolated_mask.reshape(b, f, *interpolated_mask.shape[1:])
         else:
-            raise ValueError(f"Unsupported number of UNet input channels: {self.unet.config.in_channels}.")
+            raise ValueError(
+                f"Unsupported number of UNet input channels: {self.unet.config.in_channels}."
+            )
 
         if mask_noise_strength > 0.0:
-            mask_noise = randn_tensor(mask_latents.shape, generator=generator, device=device, dtype=dtype)
+            mask_noise = randn_tensor(
+                mask_latents.shape, generator=generator, device=device, dtype=dtype
+            )
             mask_latents = mask_latents + mask_noise_strength * mask_noise
 
         added_time_ids = self._get_add_time_ids(
-            fps, motion_bucket_id, noise_aug_strength, image_embeddings.dtype, batch_size, num_videos_per_prompt
+            fps,
+            motion_bucket_id,
+            noise_aug_strength,
+            image_embeddings.dtype,
+            batch_size,
+            num_videos_per_prompt,
         )
         added_time_ids = added_time_ids.to(device)
 
         # --- MODIFIED FOR ALPHA MATTE REFINEMENT ---
-        timesteps, num_inference_steps = retrieve_timesteps(self.scheduler, num_inference_steps, device, None, sigmas)
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler, num_inference_steps, device, None, sigmas
+        )
 
         # self.scheduler.set_timesteps(num_inference_steps, device=device)
         # timesteps = self.scheduler.timesteps
         initial_latents = None
 
         if alpha_matte_image is not None:
-            alpha_matte_tensor = self.video_processor.preprocess(alpha_matte_image, height=height, width=width).to(
-                device).unsqueeze(0)
+            alpha_matte_tensor = (
+                self.video_processor.preprocess(alpha_matte_image, height=height, width=width)
+                .to(device)
+                .unsqueeze(0)
+            )
             initial_latents = self._encode_video_vae(alpha_matte_tensor, device)
             initial_latents = initial_latents / self.vae.config.scaling_factor
 
@@ -371,16 +406,23 @@ class StableVideoDiffusionPipelineWithMask(DiffusionPipeline):
         with self.progress_bar(total=len(timesteps)) as progress_bar:
             for i, t in enumerate(timesteps):
                 latent_model_input = self.scheduler.scale_model_input(latents, t)
-                latent_model_input = torch.cat([latent_model_input, conditional_latents, mask_latents], dim=2)
+                latent_model_input = torch.cat(
+                    [latent_model_input, conditional_latents, mask_latents], dim=2
+                )
 
                 noise_pred = self.unet(
-                    latent_model_input, t, encoder_hidden_states=image_embeddings, added_time_ids=added_time_ids,
-                    return_dict=False
+                    latent_model_input,
+                    t,
+                    encoder_hidden_states=image_embeddings,
+                    added_time_ids=added_time_ids,
+                    return_dict=False,
                 )[0]
 
                 latents = self.scheduler.step(noise_pred, t, latents).prev_sample
 
-                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                if i == len(timesteps) - 1 or (
+                    (i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0
+                ):
                     progress_bar.update()
 
         frames = self.decode_latents(latents, num_frames, decode_chunk_size)
@@ -404,12 +446,12 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
     _callback_tensor_inputs = ["latents"]
 
     def __init__(
-            self,
-            vae: AutoencoderKLTemporalDecoder,
-            image_encoder: CLIPVisionModelWithProjection,
-            unet: UNetSpatioTemporalConditionModel,
-            scheduler: EulerDiscreteScheduler,
-            feature_extractor: CLIPImageProcessor,
+        self,
+        vae: AutoencoderKLTemporalDecoder,
+        image_encoder: CLIPVisionModelWithProjection,
+        unet: UNetSpatioTemporalConditionModel,
+        scheduler: EulerDiscreteScheduler,
+        feature_extractor: CLIPImageProcessor,
     ):
         super().__init__()
 
@@ -421,13 +463,15 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
-        self.video_processor = VideoProcessor(do_resize=True, vae_scale_factor=self.vae_scale_factor)
+        self.video_processor = VideoProcessor(
+            do_resize=True, vae_scale_factor=self.vae_scale_factor
+        )
 
     def _encode_image(
-            self,
-            image: PipelineImageInput,
-            device: Union[str, torch.device],
-            num_videos_per_prompt: int,
+        self,
+        image: PipelineImageInput,
+        device: Union[str, torch.device],
+        num_videos_per_prompt: int,
     ) -> torch.Tensor:
         dtype = next(self.image_encoder.parameters()).dtype
 
@@ -458,10 +502,10 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
         return image_embeddings
 
     def _encode_vae_image(
-            self,
-            image: torch.Tensor,
-            device: Union[str, torch.device],
-            num_videos_per_prompt: int,
+        self,
+        image: torch.Tensor,
+        device: Union[str, torch.device],
+        num_videos_per_prompt: int,
     ):
         image = image.to(device=device, dtype=torch.float16)
         image_latents = self.vae.encode(image).latent_dist.sample()
@@ -469,13 +513,13 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
         return image_latents
 
     def _get_add_time_ids(
-            self,
-            fps: int,
-            motion_bucket_id: int,
-            noise_aug_strength: float,
-            dtype: torch.dtype,
-            batch_size: int,
-            num_videos_per_prompt: int,
+        self,
+        fps: int,
+        motion_bucket_id: int,
+        noise_aug_strength: float,
+        dtype: torch.dtype,
+        batch_size: int,
+        num_videos_per_prompt: int,
     ):
         add_time_ids = [fps, motion_bucket_id, noise_aug_strength]
         passed_add_embed_dim = self.unet.config.addition_time_embed_dim * len(add_time_ids)
@@ -493,8 +537,10 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
         latents = 1 / self.vae.config.scaling_factor * latents
         frames = []
         for i in range(0, latents.shape[0], decode_chunk_size):
-            num_frames_in = latents[i: i + decode_chunk_size].shape[0]
-            frame = self.vae.decode(latents[i: i + decode_chunk_size], num_frames=num_frames_in).sample
+            num_frames_in = latents[i : i + decode_chunk_size].shape[0]
+            frame = self.vae.decode(
+                latents[i : i + decode_chunk_size], num_frames=num_frames_in
+            ).sample
             frames.append(frame)
         frames = torch.cat(frames, dim=0)
         frames = frames.reshape(-1, num_frames, *frames.shape[1:]).permute(0, 2, 1, 3, 4)
@@ -503,24 +549,28 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
 
     def check_inputs(self, image, height, width):
         if (
-                not isinstance(image, torch.Tensor)
-                and not isinstance(image, PIL.Image.Image)
-                and not isinstance(image, list)
+            not isinstance(image, torch.Tensor)
+            and not isinstance(image, PIL.Image.Image)
+            and not isinstance(image, list)
         ):
-            raise ValueError(f"`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is {type(image)}")
+            raise ValueError(
+                f"`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is {type(image)}"
+            )
         if height % 8 != 0 or width % 8 != 0:
-            raise ValueError(f"`height` and `width` have to be divisible by 8 but are {height} and {width}.")
+            raise ValueError(
+                f"`height` and `width` have to be divisible by 8 but are {height} and {width}."
+            )
 
     def prepare_latents(
-            self,
-            batch_size: int,
-            num_frames: int,
-            height: int,
-            width: int,
-            dtype: torch.dtype,
-            device: Union[str, torch.device],
-            generator: torch.Generator,
-            latents: Optional[torch.Tensor] = None,
+        self,
+        batch_size: int,
+        num_frames: int,
+        height: int,
+        width: int,
+        dtype: torch.dtype,
+        device: Union[str, torch.device],
+        generator: torch.Generator,
+        latents: Optional[torch.Tensor] = None,
     ):
         # The number of channels for the initial noise is based on the UNet's out_channels
         num_channels_latents = self.unet.config.out_channels
@@ -532,7 +582,9 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
             width // self.vae_scale_factor,
         )
         if isinstance(generator, list) and len(generator) != batch_size:
-            raise ValueError(f"batch size {batch_size} must match the length of the generators {len(generator)}.")
+            raise ValueError(
+                f"batch size {batch_size} must match the length of the generators {len(generator)}."
+            )
 
         if latents is None:
             latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
@@ -543,40 +595,46 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
         return latents
 
     def _encode_video_vae(
-            self,
-            video_frames: torch.Tensor,  # Expects (B, F, C, H, W)
-            device: Union[str, torch.device],
+        self,
+        video_frames: torch.Tensor,  # Expects (B, F, C, H, W)
+        device: Union[str, torch.device],
     ):
         video_frames = video_frames.to(device=device, dtype=self.vae.dtype)
         batch_size, num_frames = video_frames.shape[:2]
 
         # Reshape for VAE encoding
-        video_frames_reshaped = video_frames.reshape(batch_size * num_frames, *video_frames.shape[2:])  # (B*F, C, H, W)
-        latents = self.vae.encode(video_frames_reshaped).latent_dist.sample()  # (B*F, C_latent, H_latent, W_latent)
+        video_frames_reshaped = video_frames.reshape(
+            batch_size * num_frames, *video_frames.shape[2:]
+        )  # (B*F, C, H, W)
+        latents = self.vae.encode(
+            video_frames_reshaped
+        ).latent_dist.sample()  # (B*F, C_latent, H_latent, W_latent)
 
         # Reshape back to video format
-        latents = latents.reshape(batch_size, num_frames, *latents.shape[1:])  # (B, F, C_latent, H_latent, W_latent)
+        latents = latents.reshape(
+            batch_size, num_frames, *latents.shape[1:]
+        )  # (B, F, C_latent, H_latent, W_latent)
 
         return latents
 
     @torch.no_grad()
     def __call__(
-            self,
-            image: Union[List[PIL.Image.Image], torch.Tensor],
-            mask_image: Union[List[PIL.Image.Image], torch.Tensor],
-            height: int = 576,
-            width: int = 1024,
-            num_frames: Optional[int] = None,
-            fps: int = 7,
-            motion_bucket_id: int = 127,
-            noise_aug_strength: float = 0.0,
-            decode_chunk_size: Optional[int] = None,
-            num_videos_per_prompt: Optional[int] = 1,
-            generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-            latents: Optional[torch.Tensor] = None,
-            output_type: Optional[str] = "pil",
-            return_dict: bool = True,
-            mask_noise_strength: float = 0.0,
+        self,
+        image: Union[List[PIL.Image.Image], torch.Tensor],
+        mask_image: Union[List[PIL.Image.Image], torch.Tensor],
+        height: int = 576,
+        width: int = 1024,
+        num_frames: Optional[int] = None,
+        fps: int = 7,
+        motion_bucket_id: int = 127,
+        noise_aug_strength: float = 0.0,
+        decode_chunk_size: Optional[int] = None,
+        num_videos_per_prompt: Optional[int] = 1,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+        output_type: Optional[str] = "pil",
+        return_dict: bool = True,
+        mask_noise_strength: float = 0.0,
     ):
         height = height or self.unet.config.sample_size * self.vae_scale_factor
         width = width or self.unet.config.sample_size * self.vae_scale_factor
@@ -596,7 +654,8 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
                 raise ValueError("`image` and `mask_image` must have the same number of frames.")
             if num_frames != len(image):
                 logger.warning(
-                    f"Mismatch between `num_frames` ({num_frames}) and number of input images ({len(image)}). Using {len(image)}.")
+                    f"Mismatch between `num_frames` ({num_frames}) and number of input images ({len(image)}). Using {len(image)}."
+                )
                 num_frames = len(image)
 
         batch_size = 1
@@ -608,9 +667,16 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
 
         fps = fps - 1
 
-        image_tensor = self.video_processor.preprocess(image, height=height, width=width).to(device).unsqueeze(0)
-        mask_tensor = self.video_processor.preprocess(mask_image, height=height, width=width).to(
-            device).unsqueeze(0)
+        image_tensor = (
+            self.video_processor.preprocess(image, height=height, width=width)
+            .to(device)
+            .unsqueeze(0)
+        )
+        mask_tensor = (
+            self.video_processor.preprocess(mask_image, height=height, width=width)
+            .to(device)
+            .unsqueeze(0)
+        )
 
         noise = randn_tensor(image_tensor.shape, generator=generator, device=device, dtype=dtype)
         image_tensor = image_tensor + noise_aug_strength * noise
@@ -630,7 +696,7 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
             interpolated_mask = F.interpolate(
                 binarized_mask_reshaped,
                 size=target_size,
-                mode='nearest',
+                mode="nearest",
             )
             mask_latents = interpolated_mask.reshape(b, f, *interpolated_mask.shape[1:])
         else:
@@ -640,11 +706,18 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
             )
 
         if mask_noise_strength > 0.0:
-            mask_noise = randn_tensor(mask_latents.shape, generator=generator, device=device, dtype=dtype)
+            mask_noise = randn_tensor(
+                mask_latents.shape, generator=generator, device=device, dtype=dtype
+            )
             mask_latents = mask_latents + mask_noise_strength * mask_noise
 
         added_time_ids = self._get_add_time_ids(
-            fps, motion_bucket_id, noise_aug_strength, image_embeddings.dtype, batch_size, num_videos_per_prompt
+            fps,
+            motion_bucket_id,
+            noise_aug_strength,
+            image_embeddings.dtype,
+            batch_size,
+            num_videos_per_prompt,
         )
         added_time_ids = added_time_ids.to(device)
 
@@ -667,8 +740,11 @@ class StableVideoDiffusionPipelineOnestepWithMask(DiffusionPipeline):
         latent_model_input = torch.cat([latents, conditional_latents, mask_latents], dim=2)
 
         noise_pred = self.unet(
-            latent_model_input, timestep, encoder_hidden_states=image_embeddings, added_time_ids=added_time_ids,
-            return_dict=False
+            latent_model_input,
+            timestep,
+            encoder_hidden_states=image_embeddings,
+            added_time_ids=added_time_ids,
+            return_dict=False,
         )[0]
 
         # The model's prediction is the final denoised latent
@@ -689,14 +765,14 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
     _callback_tensor_inputs = ["latents"]
 
     def __init__(
-            self,
-            vae: AutoencoderKLTemporalDecoder,
-            unet: UNetSpatioTemporalConditionModel,
-            scheduler: EulerDiscreteScheduler,
-            mask_projector: torch.nn.Module,
-            # CLIP models are not strictly needed for inference if embeddings are not used
-            image_encoder: CLIPVisionModelWithProjection = None,
-            feature_extractor: CLIPImageProcessor = None,
+        self,
+        vae: AutoencoderKLTemporalDecoder,
+        unet: UNetSpatioTemporalConditionModel,
+        scheduler: EulerDiscreteScheduler,
+        mask_projector: torch.nn.Module,
+        # CLIP models are not strictly needed for inference if embeddings are not used
+        image_encoder: CLIPVisionModelWithProjection = None,
+        feature_extractor: CLIPImageProcessor = None,
     ):
         super().__init__()
         self.register_modules(
@@ -708,7 +784,9 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
-        self.video_processor = VideoProcessor(do_resize=False, vae_scale_factor=self.vae_scale_factor)
+        self.video_processor = VideoProcessor(
+            do_resize=False, vae_scale_factor=self.vae_scale_factor
+        )
 
     def _encode_image_vae(self, image: torch.Tensor, device: Union[str, torch.device]):
         image = image.to(device=device, dtype=self.vae.dtype)
@@ -720,7 +798,9 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
         latents = 1 / self.vae.config.scaling_factor * latents
         frames = []
         for i in range(0, latents.shape[0], decode_chunk_size):
-            frame = self.vae.decode(latents[i: i + decode_chunk_size], num_frames=decode_chunk_size).sample
+            frame = self.vae.decode(
+                latents[i : i + decode_chunk_size], num_frames=decode_chunk_size
+            ).sample
             frames.append(frame)
 
         frames = torch.cat(frames, dim=0)
@@ -729,38 +809,44 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
         return frames
 
     def _encode_video_vae(
-            self,
-            video_frames: torch.Tensor,  # Expects (B, F, C, H, W)
-            device: Union[str, torch.device],
+        self,
+        video_frames: torch.Tensor,  # Expects (B, F, C, H, W)
+        device: Union[str, torch.device],
     ):
         video_frames = video_frames.to(device=device, dtype=self.vae.dtype)
         batch_size, num_frames = video_frames.shape[:2]
 
         # Reshape for VAE encoding
-        video_frames_reshaped = video_frames.reshape(batch_size * num_frames, *video_frames.shape[2:])  # (B*F, C, H, W)
-        latents = self.vae.encode(video_frames_reshaped).latent_dist.sample()  # (B*F, C_latent, H_latent, W_latent)
+        video_frames_reshaped = video_frames.reshape(
+            batch_size * num_frames, *video_frames.shape[2:]
+        )  # (B*F, C, H, W)
+        latents = self.vae.encode(
+            video_frames_reshaped
+        ).latent_dist.sample()  # (B*F, C_latent, H_latent, W_latent)
 
         # Reshape back to video format
-        latents = latents.reshape(batch_size, num_frames, *latents.shape[1:])  # (B, F, C_latent, H_latent, W_latent)
+        latents = latents.reshape(
+            batch_size, num_frames, *latents.shape[1:]
+        )  # (B, F, C_latent, H_latent, W_latent)
 
         return latents
 
     @torch.no_grad()
     def __call__(
-            self,
-            image: Union[PIL.Image.Image, torch.Tensor],  # Static image for appearance
-            mask_image: List[PIL.Image.Image],  # Video mask for motion
-            height: int = 576,
-            width: int = 1024,
-            num_frames: Optional[int] = None,
-            num_inference_steps: int = 25,
-            fps: int = 7,
-            motion_bucket_id: int = 127,
-            noise_aug_strength: float = 0.0,  # Noise is added to latents now
-            decode_chunk_size: Optional[int] = 8,
-            generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-            output_type: Optional[str] = "pil",
-            return_dict: bool = True,
+        self,
+        image: Union[PIL.Image.Image, torch.Tensor],  # Static image for appearance
+        mask_image: List[PIL.Image.Image],  # Video mask for motion
+        height: int = 576,
+        width: int = 1024,
+        num_frames: Optional[int] = None,
+        num_inference_steps: int = 25,
+        fps: int = 7,
+        motion_bucket_id: int = 127,
+        noise_aug_strength: float = 0.0,  # Noise is added to latents now
+        decode_chunk_size: Optional[int] = 8,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        output_type: Optional[str] = "pil",
+        return_dict: bool = True,
     ):
         device = self._execution_device
         dtype = self.unet.dtype
@@ -788,17 +874,27 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
         encoder_hidden_states = rearrange(encoder_hidden_states, "b f s d -> (b f) s d")
 
         # 3. PREPARE LATENTS
-        shape = (1, num_frames, self.unet.config.out_channels, height // self.vae_scale_factor,
-                 width // self.vae_scale_factor)
+        shape = (
+            1,
+            num_frames,
+            self.unet.config.out_channels,
+            height // self.vae_scale_factor,
+            width // self.vae_scale_factor,
+        )
         latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
         if noise_aug_strength > 0:
-            latents += noise_aug_strength * randn_tensor(latents.shape, generator=generator, device=device,
-                                                         dtype=dtype)
+            latents += noise_aug_strength * randn_tensor(
+                latents.shape, generator=generator, device=device, dtype=dtype
+            )
         latents = latents * self.scheduler.init_noise_sigma
 
         # 4. GET ADDED TIME IDS
         # For pipeline, batch size is 1
-        added_time_ids = [fps - 1, motion_bucket_id, 0.0]  # noise_aug_strength for add_time_ids is 0 for inference
+        added_time_ids = [
+            fps - 1,
+            motion_bucket_id,
+            0.0,
+        ]  # noise_aug_strength for add_time_ids is 0 for inference
         added_time_ids = torch.tensor([added_time_ids], dtype=dtype, device=device)
 
         # 5. DENOISING LOOP
@@ -811,7 +907,10 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
                 unet_input = torch.cat([latent_model_input, conditional_latents], dim=2)
 
                 noise_pred = self.unet(
-                    unet_input, t, encoder_hidden_states=encoder_hidden_states, added_time_ids=added_time_ids
+                    unet_input,
+                    t,
+                    encoder_hidden_states=encoder_hidden_states,
+                    added_time_ids=added_time_ids,
                 ).sample
 
                 latents = self.scheduler.step(noise_pred, t, latents).prev_sample
@@ -829,9 +928,7 @@ class StableVideoDiffusionPipelineWithCrossAtnnMask(DiffusionPipeline):
 # pipeline.py
 
 import torch
-import torch.nn.functional as F
 from PIL import Image
-from einops import rearrange
 from torchvision import transforms
 from diffusers import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
@@ -845,8 +942,13 @@ class VideoInferencePipeline:
     separating it from data loading and saving, which can vary between tasks.
     """
 
-    def __init__(self, base_model_path: str, unet_checkpoint_path: str, device: str = "cuda",
-                 weight_dtype: torch.dtype = torch.float16):
+    def __init__(
+        self,
+        base_model_path: str,
+        unet_checkpoint_path: str,
+        device: str = "cuda",
+        weight_dtype: torch.dtype = torch.float16,
+    ):
         """
         Loads all necessary models into memory.
 
@@ -863,12 +965,18 @@ class VideoInferencePipeline:
 
         # Load models from pretrained paths
         try:
-            self.feature_extractor = CLIPImageProcessor.from_pretrained(base_model_path, subfolder="feature_extractor")
-            self.image_encoder = CLIPVisionModelWithProjection.from_pretrained(base_model_path,
-                                                                               subfolder="image_encoder",
-                                                                               variant="fp16")
-            self.vae = AutoencoderKLTemporalDecoder.from_pretrained(base_model_path, subfolder="vae", variant="fp16")
-            self.unet = UNetSpatioTemporalConditionModel.from_pretrained(unet_checkpoint_path, subfolder="unet")
+            self.feature_extractor = CLIPImageProcessor.from_pretrained(
+                base_model_path, subfolder="feature_extractor"
+            )
+            self.image_encoder = CLIPVisionModelWithProjection.from_pretrained(
+                base_model_path, subfolder="image_encoder", variant="fp16"
+            )
+            self.vae = AutoencoderKLTemporalDecoder.from_pretrained(
+                base_model_path, subfolder="vae", variant="fp16"
+            )
+            self.unet = UNetSpatioTemporalConditionModel.from_pretrained(
+                unet_checkpoint_path, subfolder="unet"
+            )
         except Exception as e:
             raise IOError(f"Fatal error loading models: {e}")
 
@@ -881,13 +989,22 @@ class VideoInferencePipeline:
 
     def unload(self) -> None:
         """Move all GPU models to CPU to free VRAM before deletion."""
-        for attr in ('image_encoder', 'vae', 'unet'):
+        for attr in ("image_encoder", "vae", "unet"):
             model = getattr(self, attr, None)
             if model is not None:
-                model.to('cpu')
+                model.to("cpu")
 
-    def run(self, cond_frames, mask_frames, seed=42, mask_cond_mode="vae", fps=7, motion_bucket_id=127,
-            noise_aug_strength=0.0, on_status=None):
+    def run(
+        self,
+        cond_frames,
+        mask_frames,
+        seed=42,
+        mask_cond_mode="vae",
+        fps=7,
+        motion_bucket_id=127,
+        noise_aug_strength=0.0,
+        on_status=None,
+    ):
         """
         Runs the core inference process on a sequence of conditioning and mask frames.
 
@@ -917,12 +1034,16 @@ class VideoInferencePipeline:
             first_frame_tensor = cond_video_tensor[:, 0, :, :, :]
             pixel_values_for_clip = self._resize_with_antialiasing(first_frame_tensor, (224, 224))
             pixel_values_for_clip = ((pixel_values_for_clip + 1.0) / 2.0).clamp(0, 1)
-            pixel_values = self.feature_extractor(images=pixel_values_for_clip, do_rescale=False, return_tensors="pt").pixel_values
+            pixel_values = self.feature_extractor(
+                images=pixel_values_for_clip, do_rescale=False, return_tensors="pt"
+            ).pixel_values
             image_embeddings = self.image_encoder(
                 pixel_values.to(self.device, dtype=self.model_dtype)
             ).image_embeds
-            
-            _logger.debug(f"CLIP Embeds Max: {image_embeddings.max().item():.4f}, Mean: {image_embeddings.mean().item():.4f}")
+
+            _logger.debug(
+                f"CLIP Embeds Max: {image_embeddings.max().item():.4f}, Mean: {image_embeddings.mean().item():.4f}"
+            )
 
             # Setup for UNet which uses weight_dtype (likely FP16)
             image_embeddings = image_embeddings.to(dtype=self.weight_dtype)
@@ -933,8 +1054,10 @@ class VideoInferencePipeline:
                 on_status("VAE encode")
             cond_video_tensor_model = cond_video_tensor.to(dtype=self.model_dtype)
             cond_latents = self._tensor_to_vae_latent(cond_video_tensor_model)
-            
-            _logger.debug(f"Cond Latents Max: {cond_latents.max().item():.4f}, Mean: {cond_latents.mean().item():.4f}")
+
+            _logger.debug(
+                f"Cond Latents Max: {cond_latents.max().item():.4f}, Mean: {cond_latents.mean().item():.4f}"
+            )
 
             # Cast back to weight_dtype (FP16) for UNet
             cond_latents = cond_latents.to(dtype=self.weight_dtype)
@@ -943,15 +1066,18 @@ class VideoInferencePipeline:
             if mask_cond_mode == "vae":
                 mask_video_tensor_model = mask_video_tensor.to(dtype=self.model_dtype)
                 mask_latents = self._tensor_to_vae_latent(mask_video_tensor_model)
-                _logger.debug(f"Mask Latents Max: {mask_latents.max().item():.4f}, Mean: {mask_latents.mean().item():.4f}")
+                _logger.debug(
+                    f"Mask Latents Max: {mask_latents.max().item():.4f}, Mean: {mask_latents.mean().item():.4f}"
+                )
                 mask_latents = mask_latents.to(dtype=self.weight_dtype)
                 mask_latents = mask_latents / self.vae.config.scaling_factor
             elif mask_cond_mode == "interpolate":
                 target_shape = cond_latents.shape[-2:]
                 b, t, c, h, w = mask_video_tensor.shape
                 mask_video_reshaped = rearrange(mask_video_tensor, "b t c h w -> (b t) c h w")
-                interpolated_mask = F.interpolate(mask_video_reshaped, size=target_shape, mode='bilinear',
-                                                  align_corners=False)
+                interpolated_mask = F.interpolate(
+                    mask_video_reshaped, size=target_shape, mode="bilinear", align_corners=False
+                )
                 mask_latents = rearrange(interpolated_mask, "(b t) c h w -> b t c h w", b=b)
             else:
                 raise ValueError(f"Unknown mask_cond_mode: {mask_cond_mode}")
@@ -960,15 +1086,22 @@ class VideoInferencePipeline:
             if on_status:
                 on_status("UNet forward pass")
             generator = torch.Generator(device=self.device).manual_seed(seed)
-            noisy_latents = torch.randn(cond_latents.shape, generator=generator, device=self.device,
-                                        dtype=self.weight_dtype)
+            noisy_latents = torch.randn(
+                cond_latents.shape, generator=generator, device=self.device, dtype=self.weight_dtype
+            )
             timesteps = torch.full((1,), 1.0, device=self.device, dtype=torch.long)
-            added_time_ids = self._get_add_time_ids(fps, motion_bucket_id, noise_aug_strength, batch_size=1)
+            added_time_ids = self._get_add_time_ids(
+                fps, motion_bucket_id, noise_aug_strength, batch_size=1
+            )
 
             unet_input = torch.cat([noisy_latents, cond_latents, mask_latents], dim=2)
-            pred_latents = self.unet(unet_input, timesteps, encoder_hidden_states, added_time_ids=added_time_ids).sample
-            
-            _logger.debug(f"Pred Latents Max: {pred_latents.max().item():.4f}, Mean: {pred_latents.mean().item():.4f}")
+            pred_latents = self.unet(
+                unet_input, timesteps, encoder_hidden_states, added_time_ids=added_time_ids
+            ).sample
+
+            _logger.debug(
+                f"Pred Latents Max: {pred_latents.max().item():.4f}, Mean: {pred_latents.mean().item():.4f}"
+            )
 
             # --- 5. Decode Latents to Video Frames ---
             pred_latents = ((1 / self.vae.config.scaling_factor) * pred_latents.squeeze(0)).to(
@@ -997,7 +1130,9 @@ class VideoInferencePipeline:
             frames = []
             # Process in chunks to avoid VRAM issues, especially for long videos
             import time as _time
+
             n_decode_chunks = (pred_latents.shape[0] + 7) // 8
+
             def _cuda_gb() -> tuple[float, float]:
                 if not torch.cuda.is_available():
                     return 0.0, 0.0
@@ -1005,28 +1140,39 @@ class VideoInferencePipeline:
                     torch.cuda.memory_allocated() / 1e9,
                     torch.cuda.max_memory_allocated() / 1e9,
                 )
+
             cur_gb, peak_gb = _cuda_gb()
-            _logger.info(f"VAE decode: {pred_latents.shape[0]} frames in {n_decode_chunks} sub-chunks of 8, "
-                         f"VRAM {cur_gb:.1f}/{peak_gb:.1f} GB")
+            _logger.info(
+                f"VAE decode: {pred_latents.shape[0]} frames in {n_decode_chunks} sub-chunks of 8, "
+                f"VRAM {cur_gb:.1f}/{peak_gb:.1f} GB"
+            )
             for i in range(0, pred_latents.shape[0], 8):
                 _t0 = _time.monotonic()
                 _sc = i // 8 + 1
-                chunk = pred_latents[i: i + 8]
-                _logger.info(f"VAE decode sub-chunk {_sc}/{n_decode_chunks} ({chunk.shape[0]} frames)...")
+                chunk = pred_latents[i : i + 8]
+                _logger.info(
+                    f"VAE decode sub-chunk {_sc}/{n_decode_chunks} ({chunk.shape[0]} frames)..."
+                )
                 if on_status:
                     on_status(f"VAE decode {_sc}/{n_decode_chunks}")
                 decoded_chunk = self.vae.decode(chunk, num_frames=chunk.shape[0]).sample.cpu()
                 cur_gb, _ = _cuda_gb()
-                _logger.info(f"VAE decode sub-chunk {_sc}/{n_decode_chunks} done in {_time.monotonic() - _t0:.1f}s, "
-                             f"VRAM {cur_gb:.1f} GB")
+                _logger.info(
+                    f"VAE decode sub-chunk {_sc}/{n_decode_chunks} done in {_time.monotonic() - _t0:.1f}s, "
+                    f"VRAM {cur_gb:.1f} GB"
+                )
                 frames.append(decoded_chunk)
                 del chunk
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
 
             video_tensor = torch.cat(frames, dim=0)
-            _logger.debug(f"Video Tensor (Pre-Clamp) Max: {video_tensor.max().item():.4f}, Mean: {video_tensor.mean().item():.4f}")
-            video_tensor = (video_tensor / 2.0 + 0.5).clamp(0, 1).mean(dim=1, keepdim=True).repeat(1, 3, 1, 1)
+            _logger.debug(
+                f"Video Tensor (Pre-Clamp) Max: {video_tensor.max().item():.4f}, Mean: {video_tensor.mean().item():.4f}"
+            )
+            video_tensor = (
+                (video_tensor / 2.0 + 0.5).clamp(0, 1).mean(dim=1, keepdim=True).repeat(1, 3, 1, 1)
+            )
 
             # Return a list of PIL images
             return [transforms.ToPILImage()(frame) for frame in video_tensor]
@@ -1040,16 +1186,16 @@ class VideoInferencePipeline:
         """Encodes a video tensor into the VAE's latent space in chunks to avoid OOM."""
         video_length = t.shape[1]
         t = rearrange(t, "b f c h w -> (b f) c h w")
-        
+
         # Process in chunks of 8
         chunk_size = 8
         latents_list = []
-        
+
         for i in range(0, t.shape[0], chunk_size):
-            chunk = t[i:i + chunk_size]
+            chunk = t[i : i + chunk_size]
             chunk_latents = self.vae.encode(chunk).latent_dist.sample()
             latents_list.append(chunk_latents)
-            
+
         latents = torch.cat(latents_list, dim=0)
         latents = rearrange(latents, "(b f) c h w -> b f c h w", f=video_length)
         return latents * self.vae.config.scaling_factor
@@ -1061,11 +1207,16 @@ class VideoInferencePipeline:
         expected_add_embed_dim = self.unet.add_embedding.linear_1.in_features
         if expected_add_embed_dim != passed_add_embed_dim:
             raise ValueError(
-                f"Model expects an added time embedding vector of length {expected_add_embed_dim}, but a vector of {passed_add_embed_dim} was created.")
-        add_time_ids = torch.tensor([add_time_ids_list], dtype=self.weight_dtype, device=self.device)
+                f"Model expects an added time embedding vector of length {expected_add_embed_dim}, but a vector of {passed_add_embed_dim} was created."
+            )
+        add_time_ids = torch.tensor(
+            [add_time_ids_list], dtype=self.weight_dtype, device=self.device
+        )
         return add_time_ids.repeat(batch_size, 1)
 
-    def _resize_with_antialiasing(self, input_tensor, size, interpolation="bicubic", align_corners=True):
+    def _resize_with_antialiasing(
+        self, input_tensor, size, interpolation="bicubic", align_corners=True
+    ):
         """
         Resizes a tensor with anti-aliasing for CLIP input, mirroring k-diffusion.
         This is a direct copy of the helper function from your original scripts.
@@ -1074,8 +1225,10 @@ class VideoInferencePipeline:
         factors = (h / size[0], w / size[1])
         sigmas = (max((factors[0] - 1.0) / 2.0, 0.001), max((factors[1] - 1.0) / 2.0, 0.001))
         ks = int(max(2.0 * 2 * sigmas[0], 3)), int(max(2.0 * 2 * sigmas[1], 3))
-        if (ks[0] % 2) == 0: ks = ks[0] + 1, ks[1]
-        if (ks[1] % 2) == 0: ks = ks[0], ks[1] + 1
+        if (ks[0] % 2) == 0:
+            ks = ks[0] + 1, ks[1]
+        if (ks[1] % 2) == 0:
+            ks = ks[0], ks[1] + 1
 
         def _compute_padding(kernel_size):
             computed = [k - 1 for k in kernel_size]
@@ -1090,22 +1243,28 @@ class VideoInferencePipeline:
 
         def _filter2d(input_tensor, kernel):
             b, c, h, w = input_tensor.shape
-            tmp_kernel = kernel[:, None, ...].to(device=input_tensor.device, dtype=input_tensor.dtype)
+            tmp_kernel = kernel[:, None, ...].to(
+                device=input_tensor.device, dtype=input_tensor.dtype
+            )
             tmp_kernel = tmp_kernel.expand(-1, c, -1, -1)
             height, width = tmp_kernel.shape[-2:]
             padding_shape = _compute_padding([height, width])
             input_tensor_padded = F.pad(input_tensor, padding_shape, mode="reflect")
             tmp_kernel = tmp_kernel.reshape(-1, 1, height, width)
-            input_tensor_padded = input_tensor_padded.view(-1, tmp_kernel.size(0), input_tensor_padded.size(-2),
-                                                           input_tensor_padded.size(-1))
-            output = F.conv2d(input_tensor_padded, tmp_kernel, groups=tmp_kernel.size(0), padding=0, stride=1)
+            input_tensor_padded = input_tensor_padded.view(
+                -1, tmp_kernel.size(0), input_tensor_padded.size(-2), input_tensor_padded.size(-1)
+            )
+            output = F.conv2d(
+                input_tensor_padded, tmp_kernel, groups=tmp_kernel.size(0), padding=0, stride=1
+            )
             return output.view(b, c, h, w)
 
         def _gaussian(window_size, sigma):
             if isinstance(sigma, float):
                 sigma = torch.tensor([[sigma]])
-            x = (torch.arange(window_size, device=sigma.device, dtype=sigma.dtype) - window_size // 2).expand(
-                sigma.shape[0], -1)
+            x = (
+                torch.arange(window_size, device=sigma.device, dtype=sigma.dtype) - window_size // 2
+            ).expand(sigma.shape[0], -1)
             if window_size % 2 == 0:
                 x = x + 0.5
             gauss = torch.exp(-x.pow(2.0) / (2 * sigma.pow(2.0)))
@@ -1124,4 +1283,6 @@ class VideoInferencePipeline:
             return _filter2d(out_x, kernel_y[..., None])
 
         blurred_input = _gaussian_blur2d(input_tensor, ks, sigmas)
-        return F.interpolate(blurred_input, size=size, mode=interpolation, align_corners=align_corners)
+        return F.interpolate(
+            blurred_input, size=size, mode=interpolation, align_corners=align_corners
+        )

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,26 +1,45 @@
 """Backend service layer for ez-CorridorKey."""
 
 from .clip_state import (
-    ClipAsset, ClipEntry, ClipState, InOutRange, PipelineRoute,
-    classify_pipeline_route, mask_sequence_is_videomama_ready,
+    ClipAsset,
+    ClipEntry,
+    ClipState,
+    InOutRange,
+    PipelineRoute,
+    classify_pipeline_route,
+    mask_sequence_is_videomama_ready,
 )
 from .clip_scanner import scan_clips_dir, scan_project_clips
 from .errors import CorridorKeyError
 from .job_queue import GPUJob, GPUJobQueue, JobType, JobStatus
 from .project import (
-    projects_root, get_data_dir, create_project, add_clips_to_project,
-    sanitize_stem, get_clip_dirs, is_v2_project,
-    write_project_json, read_project_json,
-    write_clip_json, read_clip_json,
-    get_display_name, set_display_name,
-    is_video_file, is_image_file, VIDEO_FILE_FILTER,
-    folder_has_image_sequence, count_sequence_frames,
-    validate_sequence_stems, find_clip_by_source,
-    save_custom_output_dir, load_custom_output_dir,
+    projects_root,
+    get_data_dir,
+    create_project,
+    add_clips_to_project,
+    sanitize_stem,
+    get_clip_dirs,
+    is_v2_project,
+    write_project_json,
+    read_project_json,
+    write_clip_json,
+    read_clip_json,
+    get_display_name,
+    set_display_name,
+    is_video_file,
+    is_image_file,
+    VIDEO_FILE_FILTER,
+    folder_has_image_sequence,
+    count_sequence_frames,
+    validate_sequence_stems,
+    find_clip_by_source,
+    save_custom_output_dir,
+    load_custom_output_dir,
 )
 from .project_media import (
     create_clip_from_sequence,
-    add_sequences_to_project, create_project_from_media,
+    add_sequences_to_project,
+    create_project_from_media,
 )
 from .natural_sort import natural_sort_key, natsorted
 from .service import CorridorKeyService, InferenceParams, OutputConfig

--- a/backend/annotation_prompts.py
+++ b/backend/annotation_prompts.py
@@ -227,8 +227,14 @@ def _expand_points_for_brush(
     diag = r * 0.35
     offsets = [
         (0.0, 0.0),
-        (half, 0.0), (-half, 0.0), (0.0, half), (0.0, -half),
-        (diag, diag), (diag, -diag), (-diag, diag), (-diag, -diag),
+        (half, 0.0),
+        (-half, 0.0),
+        (0.0, half),
+        (0.0, -half),
+        (diag, diag),
+        (diag, -diag),
+        (-diag, diag),
+        (-diag, -diag),
     ]
 
     expanded: list[tuple[float, float]] = []
@@ -259,7 +265,9 @@ def _dedupe_points(points: Iterable[tuple[float, float]]) -> list[tuple[float, f
     return result
 
 
-def _bounding_box(points: Sequence[tuple[float, float]]) -> tuple[float, float, float, float] | None:
+def _bounding_box(
+    points: Sequence[tuple[float, float]],
+) -> tuple[float, float, float, float] | None:
     if not points:
         return None
     xs = [p[0] for p in points]

--- a/backend/clip_scanner.py
+++ b/backend/clip_scanner.py
@@ -3,6 +3,7 @@
 Extracted from clip_state.py to keep that module focused on dataclasses
 and state machine logic.
 """
+
 from __future__ import annotations
 
 import logging
@@ -42,7 +43,7 @@ def scan_project_clips(project_dir: str) -> list[ClipEntry]:
         entries: list[ClipEntry] = []
         for item in sorted(os.listdir(clips_dir)):
             item_path = os.path.join(clips_dir, item)
-            if item.startswith('.') or item.startswith('_'):
+            if item.startswith(".") or item.startswith("_"):
                 continue
             if not os.path.isdir(item_path):
                 continue
@@ -94,6 +95,7 @@ def scan_clips_dir(
 
     # If the directory itself is a v2 project, scan its clips directly
     from .project import is_v2_project
+
     if is_v2_project(clips_dir):
         return scan_project_clips(clips_dir)
 
@@ -103,12 +105,13 @@ def scan_clips_dir(
         item_path = os.path.join(clips_dir, item)
 
         # Skip hidden and special items
-        if item.startswith('.') or item.startswith('_'):
+        if item.startswith(".") or item.startswith("_"):
             continue
 
         if os.path.isdir(item_path):
             # Check if this is a v2 project container (has clips/ subdir)
             from .project import is_v2_project
+
             if is_v2_project(item_path):
                 # v2 project: scan its clips/ subdirectory
                 for clip in scan_project_clips(item_path):
@@ -126,15 +129,13 @@ def scan_clips_dir(
                     # Skip folders without valid input assets
                     logger.debug(str(e))
 
-        elif (allow_standalone_videos
-              and os.path.isfile(item_path)
-              and _is_video_file(item_path)):
+        elif allow_standalone_videos and os.path.isfile(item_path) and _is_video_file(item_path):
             # Standalone video file → treat as a clip needing extraction
             stem = os.path.splitext(item)[0]
             if stem in seen_names:
                 continue  # folder clip already exists with this name
             clip = ClipEntry(name=stem, root_path=clips_dir)
-            clip.input_asset = ClipAsset(item_path, 'video')
+            clip.input_asset = ClipAsset(item_path, "video")
             clip.state = ClipState.EXTRACTING
             entries.append(clip)
             seen_names.add(stem)

--- a/backend/clip_state.py
+++ b/backend/clip_state.py
@@ -24,6 +24,7 @@ Transitions:
     ERROR → EXTRACTING (retry extraction)
     COMPLETE → READY   (reprocess with different params)
 """
+
 from __future__ import annotations
 
 import json
@@ -64,11 +65,14 @@ _TRANSITIONS: dict[ClipState, set[ClipState]] = {
 
 class PipelineRoute(Enum):
     """Pipeline route for a clip in batch processing."""
-    INFERENCE_ONLY = "inference_only"       # READY/COMPLETE → inference
-    GVM_PIPELINE = "gvm_pipeline"           # RAW, no annotations → GVM → inference
-    VIDEOMAMA_PIPELINE = "videomama_pipeline"  # Annotations → track dense masks → VideoMaMa → inference
-    VIDEOMAMA_INFERENCE = "videomama_inference" # MASKED → VideoMaMa → inference
-    SKIP = "skip"                           # EXTRACTING or ERROR — cannot process
+
+    INFERENCE_ONLY = "inference_only"  # READY/COMPLETE → inference
+    GVM_PIPELINE = "gvm_pipeline"  # RAW, no annotations → GVM → inference
+    VIDEOMAMA_PIPELINE = (
+        "videomama_pipeline"  # Annotations → track dense masks → VideoMaMa → inference
+    )
+    VIDEOMAMA_INFERENCE = "videomama_inference"  # MASKED → VideoMaMa → inference
+    SKIP = "skip"  # EXTRACTING or ERROR — cannot process
 
 
 def mask_sequence_is_videomama_ready(root_path: str) -> bool:
@@ -112,6 +116,7 @@ def classify_pipeline_route(clip: "ClipEntry") -> PipelineRoute:
 @dataclass
 class ClipAsset:
     """Represents an input source — either an image sequence directory or a video file."""
+
     path: str
     asset_type: str  # 'sequence' or 'video'
     frame_count: int = 0
@@ -120,15 +125,16 @@ class ClipAsset:
         self._calculate_length()
 
     def _calculate_length(self):
-        if self.asset_type == 'sequence':
+        if self.asset_type == "sequence":
             if os.path.isdir(self.path):
                 files = [f for f in os.listdir(self.path) if _is_image_file(f)]
                 self.frame_count = len(files)
             else:
                 self.frame_count = 0
-        elif self.asset_type == 'video':
+        elif self.asset_type == "video":
             try:
                 import cv2
+
                 cap = cv2.VideoCapture(self.path)
                 if cap.isOpened():
                     self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -142,24 +148,26 @@ class ClipAsset:
 
         Uses natural sort so frame_2 sorts before frame_10 (not lexicographic).
         """
-        if self.asset_type != 'sequence' or not os.path.isdir(self.path):
+        if self.asset_type != "sequence" or not os.path.isdir(self.path):
             return []
         from .natural_sort import natsorted
+
         return natsorted([f for f in os.listdir(self.path) if _is_image_file(f)])
 
     def is_exr_sequence(self) -> bool:
         """True if this is an image sequence where the first frame is EXR."""
-        if self.asset_type != 'sequence':
+        if self.asset_type != "sequence":
             return False
         files = self.get_frame_files()
         if not files:
             return False
-        return files[0].lower().endswith('.exr')
+        return files[0].lower().endswith(".exr")
 
 
 @dataclass
 class InOutRange:
     """In/out frame range for sub-clip processing. Both indices inclusive, 0-based."""
+
     in_point: int
     out_point: int
 
@@ -181,6 +189,7 @@ class InOutRange:
 @dataclass
 class ClipEntry:
     """A single shot/clip with its assets and processing state."""
+
     name: str
     root_path: str
     state: ClipState = ClipState.RAW
@@ -192,8 +201,8 @@ class ClipEntry:
     warnings: list[str] = field(default_factory=list)
     error_message: Optional[str] = None
     extraction_progress: float = 0.0  # 0.0 to 1.0 during EXTRACTING
-    extraction_total: int = 0         # total frames expected during extraction
-    custom_output_dir: str = ""       # Per-clip output dir override (from clip.json)
+    extraction_total: int = 0  # total frames expected during extraction
+    custom_output_dir: str = ""  # Per-clip output dir override (from clip.json)
     _processing: bool = field(default=False, repr=False)  # lock: watcher must not reclassify
 
     @property
@@ -238,6 +247,7 @@ class ClipEntry:
         # 2. Global default from QSettings (Qt Core — no UI dependency)
         try:
             from PySide6.QtCore import QSettings
+
             global_dir = QSettings().value("output/default_directory", "", type=str)
             if global_dir:
                 # Use project/clip subfolders to prevent cross-project collision.
@@ -267,6 +277,7 @@ class ClipEntry:
             return ""
         try:
             import json
+
             with open(metadata_path, "r", encoding="utf-8") as handle:
                 payload = json.load(handle)
         except Exception:
@@ -279,10 +290,7 @@ class ClipEntry:
         return bool(
             self.input_asset is not None
             and self.input_asset.is_exr_sequence()
-            and (
-                not self.has_video_metadata()
-                or self._video_source_transfer() == "linear"
-            )
+            and (not self.has_video_metadata() or self._video_source_transfer() == "linear")
         )
 
     @property
@@ -354,7 +362,8 @@ class ClipEntry:
             return None
         try:
             import json
-            with open(manifest_path, 'r') as f:
+
+            with open(manifest_path, "r") as f:
                 return json.load(f)
         except Exception as e:
             logger.debug(f"Failed to read manifest at {manifest_path}: {e}")
@@ -363,6 +372,7 @@ class ClipEntry:
     def _resolve_original_path(self) -> Optional[str]:
         """Resolve the original video path from clip.json or project.json."""
         from .project import _read_clip_or_project_json
+
         data = _read_clip_or_project_json(self.root_path)
         if not data:
             return None
@@ -383,6 +393,7 @@ class ClipEntry:
         message if the referenced folder no longer exists.
         """
         from .project import _read_clip_or_project_json
+
         data = _read_clip_or_project_json(self.root_path)
         if not data:
             return None
@@ -398,9 +409,7 @@ class ClipEntry:
         self.state = ClipState.ERROR
         self.error_message = f"Source folder missing: {path}"
         self.source_type = "sequence"
-        logger.warning(
-            f"Clip '{self.name}': external sequence folder no longer exists: {path}"
-        )
+        logger.warning(f"Clip '{self.name}': external sequence folder no longer exists: {path}")
         return None
 
     def _resolve_source_type(self) -> str:
@@ -409,6 +418,7 @@ class ClipEntry:
         Returns 'video', 'sequence', or 'unknown' (legacy clips without metadata).
         """
         from .project import _read_clip_or_project_json
+
         data = _read_clip_or_project_json(self.root_path)
         if not data:
             return "unknown"
@@ -436,6 +446,7 @@ class ClipEntry:
 
         # Load per-clip output dir override from clip.json
         from .project import load_custom_output_dir
+
         self.custom_output_dir = load_custom_output_dir(self.root_path)
 
         # Input asset — check new names first, fall back to legacy
@@ -444,24 +455,25 @@ class ClipEntry:
         source_dir = os.path.join(self.root_path, "Source")
 
         if os.path.isdir(frames_dir) and os.listdir(frames_dir):
-            self.input_asset = ClipAsset(frames_dir, 'sequence')
+            self.input_asset = ClipAsset(frames_dir, "sequence")
             # Determine source_type: check clip.json for provenance
             self.source_type = self._resolve_source_type()
         elif os.path.isdir(input_dir) and os.listdir(input_dir):
-            self.input_asset = ClipAsset(input_dir, 'sequence')
+            self.input_asset = ClipAsset(input_dir, "sequence")
             self.source_type = self._resolve_source_type()
         elif os.path.isdir(source_dir):
             videos = [f for f in os.listdir(source_dir) if _is_video_file(f)]
             if videos:
                 self.input_asset = ClipAsset(
-                    os.path.join(source_dir, videos[0]), 'video',
+                    os.path.join(source_dir, videos[0]),
+                    "video",
                 )
                 self.source_type = "video"
             else:
                 # Source/ exists but is empty — check project.json for external reference
                 original = self._resolve_original_path()
                 if original:
-                    self.input_asset = ClipAsset(original, 'video')
+                    self.input_asset = ClipAsset(original, "video")
                     self.source_type = "video"
                 else:
                     raise ClipScanError(f"Clip '{self.name}': 'Source' dir has no video.")
@@ -469,7 +481,7 @@ class ClipEntry:
             # No local Frames/Input/Source — check clip.json for external sequence ref
             ext_seq = self._resolve_external_sequence()
             if ext_seq:
-                self.input_asset = ClipAsset(ext_seq, 'sequence')
+                self.input_asset = ClipAsset(ext_seq, "sequence")
                 self.source_type = "sequence"
             elif self.state == ClipState.ERROR:
                 # _resolve_external_sequence() set ERROR (missing source folder)
@@ -479,17 +491,16 @@ class ClipEntry:
                 candidates = glob_module.glob(os.path.join(self.root_path, "[Ii]nput.*"))
                 candidates = [c for c in candidates if _is_video_file(c)]
                 if candidates:
-                    self.input_asset = ClipAsset(candidates[0], 'video')
+                    self.input_asset = ClipAsset(candidates[0], "video")
                     self.source_type = "video"
                 elif os.path.isdir(input_dir):
-                    raise ClipScanError(
-                        f"Clip '{self.name}': Input dir is empty — no image files."
-                    )
+                    raise ClipScanError(f"Clip '{self.name}': Input dir is empty — no image files.")
                 else:
                     raise ClipScanError(f"Clip '{self.name}': no Input found.")
 
         # Load display name from project.json if available
         from .project import get_display_name
+
         display = get_display_name(self.root_path)
         if display != os.path.basename(self.root_path):
             self.name = display
@@ -497,30 +508,27 @@ class ClipEntry:
         # Alpha hint asset
         alpha_dir = os.path.join(self.root_path, "AlphaHint")
         if os.path.isdir(alpha_dir) and os.listdir(alpha_dir):
-            self.alpha_asset = ClipAsset(alpha_dir, 'sequence')
+            self.alpha_asset = ClipAsset(alpha_dir, "sequence")
         else:
-            alpha_candidates = glob_module.glob(
-                os.path.join(self.root_path, "AlphaHint.*")
-            )
+            alpha_candidates = glob_module.glob(os.path.join(self.root_path, "AlphaHint.*"))
             alpha_candidates = [c for c in alpha_candidates if _is_video_file(c)]
             if alpha_candidates:
-                self.alpha_asset = ClipAsset(alpha_candidates[0], 'video')
+                self.alpha_asset = ClipAsset(alpha_candidates[0], "video")
 
         # VideoMaMa mask hint — directory OR video file
         mask_dir = os.path.join(self.root_path, "VideoMamaMaskHint")
         if os.path.isdir(mask_dir) and os.listdir(mask_dir):
-            self.mask_asset = ClipAsset(mask_dir, 'sequence')
+            self.mask_asset = ClipAsset(mask_dir, "sequence")
         else:
             # Check for mask video file (VideoMamaMaskHint.mp4 etc.)
-            mask_candidates = glob_module.glob(
-                os.path.join(self.root_path, "VideoMamaMaskHint.*")
-            )
+            mask_candidates = glob_module.glob(os.path.join(self.root_path, "VideoMamaMaskHint.*"))
             mask_candidates = [c for c in mask_candidates if _is_video_file(c)]
             if mask_candidates:
-                self.mask_asset = ClipAsset(mask_candidates[0], 'video')
+                self.mask_asset = ClipAsset(mask_candidates[0], "video")
 
         # Load in/out range from project.json
         from .project import load_in_out_range
+
         self.in_out_range = load_in_out_range(self.root_path)
 
         # Determine initial state
@@ -570,8 +578,7 @@ class ClipEntry:
 
         if self.mask_asset is not None:
             self.state = ClipState.MASKED
-        elif (self.input_asset is not None
-              and self.input_asset.asset_type == "video"):
+        elif self.input_asset is not None and self.input_asset.asset_type == "video":
             # Video input needs extraction to image sequence
             self.state = ClipState.EXTRACTING
         else:

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -3,11 +3,13 @@
 
 class CorridorKeyError(Exception):
     """Base exception for all CorridorKey backend errors."""
+
     pass
 
 
 class ClipScanError(CorridorKeyError):
     """Raised when a clip directory cannot be scanned or is malformed."""
+
     pass
 
 
@@ -31,9 +33,7 @@ class FrameReadError(CorridorKeyError):
         self.clip_name = clip_name
         self.frame_index = frame_index
         self.path = path
-        super().__init__(
-            f"Clip '{clip_name}': failed to read frame {frame_index} ({path})"
-        )
+        super().__init__(f"Clip '{clip_name}': failed to read frame {frame_index} ({path})")
 
 
 class WriteFailureError(CorridorKeyError):
@@ -43,9 +43,7 @@ class WriteFailureError(CorridorKeyError):
         self.clip_name = clip_name
         self.frame_index = frame_index
         self.path = path
-        super().__init__(
-            f"Clip '{clip_name}': failed to write frame {frame_index} ({path})"
-        )
+        super().__init__(f"Clip '{clip_name}': failed to write frame {frame_index} ({path})")
 
 
 class MaskChannelError(CorridorKeyError):
@@ -68,8 +66,7 @@ class VRAMInsufficientError(CorridorKeyError):
         self.required_gb = required_gb
         self.available_gb = available_gb
         super().__init__(
-            f"Insufficient VRAM: {required_gb:.1f}GB required, "
-            f"{available_gb:.1f}GB available"
+            f"Insufficient VRAM: {required_gb:.1f}GB required, {available_gb:.1f}GB available"
         )
 
 
@@ -81,8 +78,7 @@ class InvalidStateTransitionError(CorridorKeyError):
         self.current_state = current_state
         self.target_state = target_state
         super().__init__(
-            f"Clip '{clip_name}': invalid state transition "
-            f"{current_state} -> {target_state}"
+            f"Clip '{clip_name}': invalid state transition {current_state} -> {target_state}"
         )
 
 

--- a/backend/ffmpeg_tools/__init__.py
+++ b/backend/ffmpeg_tools/__init__.py
@@ -8,6 +8,7 @@ Pure Python, no Qt deps. Provides:
 - stitch_video() — image sequence -> video (H.264)
 - write/read_video_metadata() — sidecar JSON for roundtrip fidelity
 """
+
 from __future__ import annotations
 
 # Re-export stdlib modules that tests monkeypatch on the module object
@@ -41,6 +42,10 @@ from .probe import probe_video
 from .stitching import stitch_video
 
 __all__ = [
+    # stdlib re-exports (tests monkeypatch these on the package)
+    "shutil",
+    "subprocess",
+    "sys",
     # discovery
     "FFmpegValidationResult",
     "FFmpegVersionInfo",

--- a/backend/ffmpeg_tools/color.py
+++ b/backend/ffmpeg_tools/color.py
@@ -1,4 +1,5 @@
 """Probe-driven colour-space filter chain for EXR extraction."""
+
 from __future__ import annotations
 
 import logging
@@ -14,9 +15,14 @@ def _is_rgb_pix_fmt(pix_fmt: str) -> bool:
     if not pix_fmt:
         return False
     pf = pix_fmt.lower()
-    return (pf.startswith("rgb") or pf.startswith("bgr") or
-            pf.startswith("gbr") or pf.startswith("argb") or
-            pf.startswith("abgr") or pf == "pal8")
+    return (
+        pf.startswith("rgb")
+        or pf.startswith("bgr")
+        or pf.startswith("gbr")
+        or pf.startswith("argb")
+        or pf.startswith("abgr")
+        or pf == "pal8"
+    )
 
 
 def _is_yuv_pix_fmt(pix_fmt: str) -> bool:
@@ -24,13 +30,22 @@ def _is_yuv_pix_fmt(pix_fmt: str) -> bool:
     if not pix_fmt:
         return False
     pf = pix_fmt.lower()
-    return (pf.startswith("yuv") or pf.startswith("yuva") or
-            pf.startswith("nv12") or pf.startswith("nv16") or
-            pf.startswith("nv21") or pf.startswith("p010") or
-            pf.startswith("p016") or pf.startswith("p210") or
-            pf.startswith("p216") or pf.startswith("p410") or
-            pf.startswith("p416") or pf.startswith("y210") or
-            pf.startswith("y212") or pf.startswith("y216"))
+    return (
+        pf.startswith("yuv")
+        or pf.startswith("yuva")
+        or pf.startswith("nv12")
+        or pf.startswith("nv16")
+        or pf.startswith("nv21")
+        or pf.startswith("p010")
+        or pf.startswith("p016")
+        or pf.startswith("p210")
+        or pf.startswith("p216")
+        or pf.startswith("p410")
+        or pf.startswith("p416")
+        or pf.startswith("y210")
+        or pf.startswith("y212")
+        or pf.startswith("y216")
+    )
 
 
 def _clean_color_value(value: str | None) -> str:
@@ -96,36 +111,61 @@ def _default_range(pix_fmt: str) -> str:
 
 # in_color_matrix (swscale colorspace table)
 _SCALE_MATRIX_MAP = {
-    "bt470bg": "bt601",          # BT.470 System B/G = same matrix as BT.601
-    "bt2020c": "bt2020ncl",     # constant-luminance -> non-constant (swscale compat)
+    "bt470bg": "bt601",  # BT.470 System B/G = same matrix as BT.601
+    "bt2020c": "bt2020ncl",  # constant-luminance -> non-constant (swscale compat)
 }
 _KNOWN_MATRICES = {
-    "bt709", "fcc", "bt601", "smpte170m", "smpte240m",
-    "bt2020nc", "bt2020ncl",
+    "bt709",
+    "fcc",
+    "bt601",
+    "smpte170m",
+    "smpte240m",
+    "bt2020nc",
+    "bt2020ncl",
 }
 
 # in_primaries
 _SCALE_PRIMARIES_MAP = {
     # Most ffprobe primaries pass through. Guard edge cases.
-    "film": "bt470m",           # "film" (SMPTE-C) -> bt470m
+    "film": "bt470m",  # "film" (SMPTE-C) -> bt470m
 }
 _KNOWN_PRIMARIES = {
-    "bt709", "bt470m", "bt470bg", "smpte170m", "smpte240m",
-    "film", "bt2020", "smpte428", "smpte431", "smpte432",
+    "bt709",
+    "bt470m",
+    "bt470bg",
+    "smpte170m",
+    "smpte240m",
+    "film",
+    "bt2020",
+    "smpte428",
+    "smpte431",
+    "smpte432",
 }
 
 # in_transfer
 _SCALE_TRANSFER_MAP = {
-    "bt470bg": "gamma28",       # BT.470 System B/G = gamma 2.8
-    "bt470m": "gamma22",        # BT.470 System M = gamma 2.2
-    "bt2020-12": "bt2020-12",   # pass through (explicit for clarity)
+    "bt470bg": "gamma28",  # BT.470 System B/G = gamma 2.8
+    "bt470m": "gamma22",  # BT.470 System M = gamma 2.2
+    "bt2020-12": "bt2020-12",  # pass through (explicit for clarity)
     "bt2020-10": "bt2020-10",
 }
 _KNOWN_TRANSFERS = {
-    "bt709", "gamma22", "gamma28", "smpte170m", "smpte240m",
-    "linear", "log", "log_sqrt", "iec61966-2-4", "bt1361e",
-    "iec61966-2-1", "bt2020-10", "bt2020-12", "smpte2084",
-    "smpte428", "arib-std-b67",
+    "bt709",
+    "gamma22",
+    "gamma28",
+    "smpte170m",
+    "smpte240m",
+    "linear",
+    "log",
+    "log_sqrt",
+    "iec61966-2-4",
+    "bt1361e",
+    "iec61966-2-1",
+    "bt2020-10",
+    "bt2020-12",
+    "smpte2084",
+    "smpte428",
+    "arib-std-b67",
 }
 
 
@@ -140,7 +180,10 @@ def _safe_scale_value(value: str, mapping: dict, known: set, param_name: str) ->
         logger.warning(
             "Unknown %s value '%s' (mapped from '%s') — FFmpeg may reject this. "
             "Add it to _SCALE_%s_MAP in ffmpeg_tools.py",
-            param_name, mapped, value, param_name.upper(),
+            param_name,
+            mapped,
+            value,
+            param_name.upper(),
         )
     return mapped
 
@@ -185,7 +228,9 @@ def build_exr_vf(video_info: dict) -> str:
 
     logger.info(
         "EXR colour conversion: pix_fmt=%s matrix=%s range=%s",
-        pix_fmt, cs, cr,
+        pix_fmt,
+        cs,
+        cr,
     )
 
     # Only in_color_matrix and in_range are standard swscale options.
@@ -197,6 +242,4 @@ def build_exr_vf(video_info: dict) -> str:
     raw_ct = video_info.get("color_transfer")
     prefix = f"setparams=color_trc={ct}," if raw_ct is None else ""
 
-    return (
-        f"{prefix}scale=in_color_matrix={cs}:in_range={cr},format=gbrpf32le"
-    )
+    return f"{prefix}scale=in_color_matrix={cs}:in_range={cr},format=gbrpf32le"

--- a/backend/ffmpeg_tools/discovery.py
+++ b/backend/ffmpeg_tools/discovery.py
@@ -3,6 +3,7 @@
 Locates ffmpeg/ffprobe binaries, validates version requirements,
 and provides repair/install functionality per platform.
 """
+
 from __future__ import annotations
 
 import logging
@@ -37,16 +38,15 @@ _FFMPEG_SEARCH_PATHS_WINDOWS = [
 
 _FFMPEG_SEARCH_PATHS_UNIX = [
     _LOCAL_FFMPEG_BIN,
-    "/opt/homebrew/bin",        # macOS Homebrew (Apple Silicon)
-    "/usr/local/bin",           # macOS Homebrew (Intel) / Linux manual install
-    "/usr/bin",                 # Linux system package
-    "/snap/bin",                # Linux snap
+    "/opt/homebrew/bin",  # macOS Homebrew (Apple Silicon)
+    "/usr/local/bin",  # macOS Homebrew (Intel) / Linux manual install
+    "/usr/bin",  # Linux system package
+    "/snap/bin",  # Linux snap
     os.path.expanduser("~/bin"),
 ]
 
 _FFMPEG_SEARCH_PATHS = (
-    _FFMPEG_SEARCH_PATHS_WINDOWS if sys.platform == "win32"
-    else _FFMPEG_SEARCH_PATHS_UNIX
+    _FFMPEG_SEARCH_PATHS_WINDOWS if sys.platform == "win32" else _FFMPEG_SEARCH_PATHS_UNIX
 )
 _FFMPEG_RELEASE_RE = re.compile(
     r"\b(?:ffmpeg|ffprobe)(?:\.exe)?\s+version\s+(?:n)?(?P<major>\d+)(?:\.\d+)*",
@@ -129,9 +129,7 @@ def _read_program_version(binary_path: str, program_name: str) -> FFmpegVersionI
     )
     if result.returncode != 0:
         stderr = (result.stderr or "").strip()
-        raise RuntimeError(
-            f"{program_name} failed to report its version: {stderr[:300]}"
-        )
+        raise RuntimeError(f"{program_name} failed to report its version: {stderr[:300]}")
 
     output = result.stdout or result.stderr or ""
     first_line = next((line.strip() for line in output.splitlines() if line.strip()), "")
@@ -144,9 +142,7 @@ def _read_program_version(binary_path: str, program_name: str) -> FFmpegVersionI
     if _FFMPEG_DEV_BUILD_RE.search(first_line):
         return FFmpegVersionInfo(first_line=first_line, major=None, is_dev_build=True)
 
-    raise RuntimeError(
-        f"Could not determine {program_name} version from: {first_line}"
-    )
+    raise RuntimeError(f"Could not determine {program_name} version from: {first_line}")
 
 
 def validate_ffmpeg_install(require_probe: bool = True) -> FFmpegValidationResult:
@@ -180,9 +176,7 @@ def validate_ffmpeg_install(require_probe: bool = True) -> FFmpegValidationResul
     if ffmpeg_version.major is not None and ffmpeg_version.major < _MIN_FFMPEG_MAJOR:
         return FFmpegValidationResult(
             ok=False,
-            message=(
-                f"FFmpeg 7.0 or newer is required. Detected {ffmpeg_version.first_line}."
-            ),
+            message=(f"FFmpeg 7.0 or newer is required. Detected {ffmpeg_version.first_line}."),
             ffmpeg_path=ffmpeg,
             ffprobe_path=ffprobe,
             ffmpeg_version=ffmpeg_version,
@@ -242,10 +236,7 @@ def validate_ffmpeg_install(require_probe: bool = True) -> FFmpegValidationResul
                 ffprobe_version=ffprobe_version,
             )
 
-        if (
-            sys.platform == "win32"
-            and "essentials_build" in ffprobe_version.first_line.lower()
-        ):
+        if sys.platform == "win32" and "essentials_build" in ffprobe_version.first_line.lower():
             return FFmpegValidationResult(
                 ok=False,
                 message=(
@@ -259,9 +250,7 @@ def validate_ffmpeg_install(require_probe: bool = True) -> FFmpegValidationResul
             )
 
     if ffprobe_version is not None:
-        summary = (
-            f"FFmpeg OK: {ffmpeg_version.first_line} | {ffprobe_version.first_line}"
-        )
+        summary = f"FFmpeg OK: {ffmpeg_version.first_line} | {ffprobe_version.first_line}"
     else:
         summary = f"FFmpeg OK: {ffmpeg_version.first_line}"
 
@@ -306,12 +295,7 @@ def get_ffmpeg_install_help() -> str:
         install_cmd = "sudo pacman -S ffmpeg"
     else:
         install_cmd = "Install ffmpeg with your package manager"
-    return (
-        f"{install_cmd}\n\n"
-        "Then verify:\n"
-        "    ffmpeg -version\n"
-        "    ffprobe -version"
-    )
+    return f"{install_cmd}\n\nThen verify:\n    ffmpeg -version\n    ffprobe -version"
 
 
 def repair_ffmpeg_install(
@@ -324,6 +308,7 @@ def repair_ffmpeg_install(
     On Linux, raises with install instructions (sudo requires a terminal).
     """
     if sys.platform == "darwin":
+
         def _emit(phase: str, current: int = 0, total: int = 0) -> None:
             if progress_callback:
                 progress_callback(phase, current, total)
@@ -340,7 +325,9 @@ def repair_ffmpeg_install(
         try:
             subprocess.run(
                 ["brew", "install", "ffmpeg"],
-                check=True, capture_output=True, text=True,
+                check=True,
+                capture_output=True,
+                text=True,
             )
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(

--- a/backend/ffmpeg_tools/extraction.py
+++ b/backend/ffmpeg_tools/extraction.py
@@ -1,4 +1,5 @@
 """Frame extraction from video files via FFmpeg."""
+
 from __future__ import annotations
 
 import logging
@@ -23,12 +24,12 @@ logger = logging.getLogger(__name__)
 # Each entry: (hwaccel_name, pre-input flags for FFmpeg)
 _HWACCEL_PRIORITY: dict[str, list[tuple[str, list[str]]]] = {
     "win32": [
-        ("cuda",    ["-hwaccel", "cuda"]),
+        ("cuda", ["-hwaccel", "cuda"]),
         ("d3d11va", ["-hwaccel", "d3d11va"]),
-        ("dxva2",   ["-hwaccel", "dxva2"]),
+        ("dxva2", ["-hwaccel", "dxva2"]),
     ],
     "linux": [
-        ("cuda",  ["-hwaccel", "cuda"]),
+        ("cuda", ["-hwaccel", "cuda"]),
         ("vaapi", ["-hwaccel", "vaapi"]),
     ],
     "darwin": [
@@ -60,7 +61,9 @@ def detect_hwaccel(ffmpeg: str | None = None) -> list[str]:
     try:
         result = subprocess.run(
             [ffmpeg, "-hwaccels"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
             creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
         )
         available = set(result.stdout.lower().split())
@@ -104,18 +107,15 @@ def _recompress_to_dwab(
     if os.path.isfile(marker):
         return
 
-    exr_files = sorted([f for f in os.listdir(out_dir)
-                        if f.lower().endswith('.exr')])
+    exr_files = sorted([f for f in os.listdir(out_dir) if f.lower().endswith(".exr")])
     total = len(exr_files)
     if total == 0:
         return
 
     if getattr(sys, "frozen", False):
-        _recompress_multiprocess(out_dir, exr_files, total, marker,
-                                 on_progress, cancel_event)
+        _recompress_multiprocess(out_dir, exr_files, total, marker, on_progress, cancel_event)
     else:
-        _recompress_subprocess(out_dir, exr_files, total, marker,
-                               on_progress, cancel_event)
+        _recompress_subprocess(out_dir, exr_files, total, marker, on_progress, cancel_event)
 
 
 def _recompress_one_exr(args: tuple) -> bool:
@@ -127,36 +127,41 @@ def _recompress_one_exr(args: tuple) -> bool:
         import numpy as np
         import OpenEXR
         import Imath
+
         img = cv2.imread(src, cv2.IMREAD_UNCHANGED)
         if img is None:
             return False
         HALF = Imath.Channel(Imath.PixelType(Imath.PixelType.HALF))
         h, w = img.shape[:2]
         hdr = OpenEXR.Header(w, h)
-        hdr['compression'] = Imath.Compression(Imath.Compression.DWAB_COMPRESSION)
+        hdr["compression"] = Imath.Compression(Imath.Compression.DWAB_COMPRESSION)
         if img.ndim == 2:
-            hdr['channels'] = {'Y': HALF}
+            hdr["channels"] = {"Y": HALF}
             out = OpenEXR.OutputFile(tmp, hdr)
-            out.writePixels({'Y': img.astype(np.float16).tobytes()})
+            out.writePixels({"Y": img.astype(np.float16).tobytes()})
             out.close()
         elif img.ndim == 3 and img.shape[2] == 3:
-            hdr['channels'] = {'R': HALF, 'G': HALF, 'B': HALF}
+            hdr["channels"] = {"R": HALF, "G": HALF, "B": HALF}
             out = OpenEXR.OutputFile(tmp, hdr)
-            out.writePixels({
-                'R': img[:, :, 2].astype(np.float16).tobytes(),
-                'G': img[:, :, 1].astype(np.float16).tobytes(),
-                'B': img[:, :, 0].astype(np.float16).tobytes(),
-            })
+            out.writePixels(
+                {
+                    "R": img[:, :, 2].astype(np.float16).tobytes(),
+                    "G": img[:, :, 1].astype(np.float16).tobytes(),
+                    "B": img[:, :, 0].astype(np.float16).tobytes(),
+                }
+            )
             out.close()
         elif img.ndim == 3 and img.shape[2] == 4:
-            hdr['channels'] = {'R': HALF, 'G': HALF, 'B': HALF, 'A': HALF}
+            hdr["channels"] = {"R": HALF, "G": HALF, "B": HALF, "A": HALF}
             out = OpenEXR.OutputFile(tmp, hdr)
-            out.writePixels({
-                'R': img[:, :, 2].astype(np.float16).tobytes(),
-                'G': img[:, :, 1].astype(np.float16).tobytes(),
-                'B': img[:, :, 0].astype(np.float16).tobytes(),
-                'A': img[:, :, 3].astype(np.float16).tobytes(),
-            })
+            out.writePixels(
+                {
+                    "R": img[:, :, 2].astype(np.float16).tobytes(),
+                    "G": img[:, :, 1].astype(np.float16).tobytes(),
+                    "B": img[:, :, 0].astype(np.float16).tobytes(),
+                    "A": img[:, :, 3].astype(np.float16).tobytes(),
+                }
+            )
             out.close()
         else:
             return False
@@ -190,8 +195,7 @@ def _recompress_multiprocess(
     done = 0
 
     ctx = multiprocessing.get_context("spawn")
-    work = [(os.path.join(out_dir, f), os.path.join(out_dir, f + ".tmp"))
-            for f in exr_files]
+    work = [(os.path.join(out_dir, f), os.path.join(out_dir, f + ".tmp")) for f in exr_files]
 
     with ProcessPoolExecutor(max_workers=workers, mp_context=ctx) as pool:
         futs = {pool.submit(_recompress_one_exr, item): item for item in work}
@@ -205,7 +209,7 @@ def _recompress_multiprocess(
             if on_progress:
                 on_progress(done, total)
 
-    with open(marker, 'w') as f:
+    with open(marker, "w") as f:
         f.write("done")
     logger.info(f"DWAB recompression complete: {total} frames")
 
@@ -221,7 +225,7 @@ def _recompress_subprocess(
     """DWAB recompress using a subprocess with ProcessPoolExecutor (dev mode)."""
     python = sys.executable
 
-    script_content = r'''
+    script_content = r"""
 import os, sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
@@ -289,10 +293,10 @@ if __name__ == "__main__":
             done += 1
             print(f"PROGRESS {done} {total}", flush=True)
     print("DONE", flush=True)
-'''
+"""
 
     script_path = os.path.join(out_dir, "_dwab_recompress.py")
-    with open(script_path, 'w') as f:
+    with open(script_path, "w") as f:
         f.write(script_content)
 
     logger.info(f"Recompressing {total} EXR frames to DWAB (subprocess)...")
@@ -306,6 +310,7 @@ if __name__ == "__main__":
     )
 
     import queue as _queue
+
     line_q: _queue.Queue[str | None] = _queue.Queue()
 
     def _reader():
@@ -359,11 +364,10 @@ if __name__ == "__main__":
 
     if proc.returncode != 0:
         stderr_out = proc.stderr.read() if proc.stderr else ""
-        logger.error(f"DWAB recompression failed (code {proc.returncode}): "
-                     f"{stderr_out[:500]}")
+        logger.error(f"DWAB recompression failed (code {proc.returncode}): {stderr_out[:500]}")
         return
 
-    with open(marker, 'w') as f:
+    with open(marker, "w") as f:
         f.write("done")
     logger.info(f"DWAB recompression complete: {total} frames")
 
@@ -426,13 +430,11 @@ def extract_frames(
     # is fully done, just count frames.
     dwab_marker = os.path.join(out_dir, ".dwab_done")
     if os.path.isfile(dwab_marker):
-        extracted = len([f for f in os.listdir(out_dir)
-                         if f.lower().endswith('.exr')])
+        extracted = len([f for f in os.listdir(out_dir) if f.lower().endswith(".exr")])
         logger.info(f"Extraction already complete: {extracted} DWAB frames")
         return extracted
 
-    existing = sorted([f for f in os.listdir(out_dir)
-                       if f.lower().endswith('.exr')])
+    existing = sorted([f for f in os.listdir(out_dir) if f.lower().endswith(".exr")])
     if existing:
         # Remove the last N frames — they may be corrupt or incomplete
         remove_count = min(_RESUME_ROLLBACK, len(existing))
@@ -440,8 +442,10 @@ def extract_frames(
             os.remove(os.path.join(out_dir, fname))
         start_frame = max(0, len(existing) - remove_count)
         if start_frame > 0:
-            logger.info(f"Resuming extraction from frame {start_frame} "
-                        f"({len(existing)} existed, rolled back {remove_count})")
+            logger.info(
+                f"Resuming extraction from frame {start_frame} "
+                f"({len(existing)} existed, rolled back {remove_count})"
+            )
 
     # EXR-specific FFmpeg args: ZIP16 compression, half-float.
     # Build an explicit colour conversion filter from probed metadata
@@ -464,10 +468,14 @@ def extract_frames(
             return [
                 ffmpeg,
                 *hw_flags,
-                "-ss", f"{seek_sec:.4f}",
-                "-i", video_path,
-                "-start_number", str(start_frame),
-                "-vsync", "passthrough",
+                "-ss",
+                f"{seek_sec:.4f}",
+                "-i",
+                video_path,
+                "-start_number",
+                str(start_frame),
+                "-vsync",
+                "passthrough",
                 *exr_args,
                 out_dir + "/" + pattern,
                 "-y",
@@ -475,9 +483,12 @@ def extract_frames(
         return [
             ffmpeg,
             *hw_flags,
-            "-i", video_path,
-            "-start_number", "0",
-            "-vsync", "passthrough",
+            "-i",
+            video_path,
+            "-start_number",
+            "0",
+            "-vsync",
+            "passthrough",
             *exr_args,
             out_dir + "/" + pattern,
             "-y",
@@ -489,8 +500,10 @@ def extract_frames(
 
         cmd = _build_cmd(hw_flags)
         hwaccel_label = hw_flags[1] if hw_flags else "software"
-        logger.info(f"Extracting frames (EXR half-float, decode={hwaccel_label}): "
-                    f"{video_path} -> {out_dir} (start_frame={start_frame})")
+        logger.info(
+            f"Extracting frames (EXR half-float, decode={hwaccel_label}): "
+            f"{video_path} -> {out_dir} (start_frame={start_frame})"
+        )
 
         proc = subprocess.Popen(
             cmd,
@@ -505,6 +518,7 @@ def extract_frames(
         stderr_tail: list[str] = []  # keep last N lines for error reporting
 
         import queue as _queue
+
         line_q: _queue.Queue[str | None] = _queue.Queue()
 
         def _reader():
@@ -562,11 +576,12 @@ def extract_frames(
 
     # If hardware decode failed, retry with software decode
     if returncode != 0 and hwaccel_flags and not (cancel_event and cancel_event.is_set()):
-        logger.warning(f"Hardware decode failed (code {returncode}), "
-                       f"retrying with software decode...")
+        logger.warning(
+            f"Hardware decode failed (code {returncode}), retrying with software decode..."
+        )
         # Clean up any partial frames from the failed attempt
         for f in os.listdir(out_dir):
-            if f.lower().endswith('.exr'):
+            if f.lower().endswith(".exr"):
                 os.remove(os.path.join(out_dir, f))
         last_frame = start_frame
         returncode, stderr_out = _run_ffmpeg([])  # empty = software decode
@@ -577,9 +592,18 @@ def extract_frames(
         if stderr_out:
             for line in stderr_out.splitlines():
                 low = line.lower()
-                if any(kw in low for kw in ("error", "invalid", "no such",
-                                             "not found", "unknown",
-                                             "unrecognized", "failed")):
+                if any(
+                    kw in low
+                    for kw in (
+                        "error",
+                        "invalid",
+                        "no such",
+                        "not found",
+                        "unknown",
+                        "unrecognized",
+                        "failed",
+                    )
+                ):
                     err_detail = line.strip()
                     break
         msg = f"FFmpeg extraction failed (code {returncode})"
@@ -588,8 +612,7 @@ def extract_frames(
         raise RuntimeError(msg)
 
     # Count extracted frames
-    extracted = len([f for f in os.listdir(out_dir)
-                     if f.lower().endswith('.exr')])
+    extracted = len([f for f in os.listdir(out_dir) if f.lower().endswith(".exr")])
     logger.info(f"Extracted {extracted} EXR frames (ZIP16)")
 
     # Pass 2: Recompress ZIP16 -> DWAB

--- a/backend/ffmpeg_tools/metadata.py
+++ b/backend/ffmpeg_tools/metadata.py
@@ -1,4 +1,5 @@
 """Video metadata sidecar read/write."""
+
 from __future__ import annotations
 
 import json
@@ -18,7 +19,7 @@ def write_video_metadata(clip_root: str, metadata: dict) -> None:
     as source_probe and exr_vf for extraction bug reports.
     """
     path = os.path.join(clip_root, _METADATA_FILENAME)
-    with open(path, 'w') as f:
+    with open(path, "w") as f:
         json.dump(metadata, f, indent=2)
     logger.debug(f"Video metadata written: {path}")
 
@@ -29,7 +30,7 @@ def read_video_metadata(clip_root: str) -> dict | None:
     if not os.path.isfile(path):
         return None
     try:
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.debug(f"Failed to read video metadata: {e}")

--- a/backend/ffmpeg_tools/probe.py
+++ b/backend/ffmpeg_tools/probe.py
@@ -1,4 +1,5 @@
 """Video probing via ffprobe."""
+
 from __future__ import annotations
 
 import json
@@ -27,15 +28,20 @@ def probe_video(path: str) -> dict:
 
     cmd = [
         ffprobe,
-        "-v", "quiet",
-        "-print_format", "json",
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
         "-show_streams",
         "-show_format",
         path,
     ]
 
     result = subprocess.run(
-        cmd, capture_output=True, text=True, timeout=30,
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
         creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
     )
     if result.returncode != 0:
@@ -70,8 +76,9 @@ def probe_video(path: str) -> dict:
             pass
 
     if frame_count <= 0:
-        duration = float(video_stream.get("duration", 0) or
-                         data.get("format", {}).get("duration", 0))
+        duration = float(
+            video_stream.get("duration", 0) or data.get("format", {}).get("duration", 0)
+        )
         if duration > 0:
             frame_count = int(duration * fps)
 
@@ -81,8 +88,9 @@ def probe_video(path: str) -> dict:
         "height": int(video_stream.get("height", 0)),
         "frame_count": frame_count,
         "codec": video_stream.get("codec_name", "unknown"),
-        "duration": float(video_stream.get("duration", 0) or
-                          data.get("format", {}).get("duration", 0)),
+        "duration": float(
+            video_stream.get("duration", 0) or data.get("format", {}).get("duration", 0)
+        ),
         # Color metadata for building explicit conversion filters
         "pix_fmt": video_stream.get("pix_fmt", ""),
         "color_space": video_stream.get("color_space", ""),

--- a/backend/ffmpeg_tools/stitching.py
+++ b/backend/ffmpeg_tools/stitching.py
@@ -1,4 +1,5 @@
 """Video stitching from image sequences via FFmpeg."""
+
 from __future__ import annotations
 
 import logging
@@ -46,14 +47,15 @@ def stitch_video(
         raise RuntimeError("FFmpeg not found")
 
     # Count total frames
-    total_frames = len([f for f in os.listdir(in_dir)
-                        if f.lower().endswith(('.png', '.jpg', '.jpeg', '.exr'))])
+    total_frames = len(
+        [f for f in os.listdir(in_dir) if f.lower().endswith((".png", ".jpg", ".jpeg", ".exr"))]
+    )
 
     # Auto-detect codec/pixel format from output extension
     ext = os.path.splitext(out_path)[1].lower()
-    is_webm = ext == '.webm'
-    is_mov = ext == '.mov'
-    is_exr = pattern.lower().endswith('.exr')
+    is_webm = ext == ".webm"
+    is_mov = ext == ".mov"
+    is_exr = pattern.lower().endswith(".exr")
 
     if is_mov:
         codec = "prores_ks"

--- a/backend/frame_io.py
+++ b/backend/frame_io.py
@@ -8,6 +8,7 @@ This module consolidates frame-reading patterns that were previously duplicated
 across service.py methods (_read_input_frame, reprocess_single_frame,
 _load_frames_for_videomama, _load_mask_frames_for_videomama).
 """
+
 from __future__ import annotations
 
 import logging
@@ -27,8 +28,10 @@ logger = logging.getLogger(__name__)
 # EXR write flags for cv2.imwrite — PXR24 half-float (fallback only;
 # prefer write_exr() for output since OpenCV's DWAB writer is broken)
 EXR_WRITE_FLAGS = [
-    cv2.IMWRITE_EXR_TYPE, cv2.IMWRITE_EXR_TYPE_HALF,
-    cv2.IMWRITE_EXR_COMPRESSION, cv2.IMWRITE_EXR_COMPRESSION_PXR24,
+    cv2.IMWRITE_EXR_TYPE,
+    cv2.IMWRITE_EXR_TYPE_HALF,
+    cv2.IMWRITE_EXR_COMPRESSION,
+    cv2.IMWRITE_EXR_COMPRESSION_PXR24,
 ]
 
 
@@ -57,6 +60,7 @@ def _srgb_to_linear(srgb: np.ndarray) -> np.ndarray:
 def _exr_compression_constant(name: str):
     """Map a compression name to the Imath compression enum value."""
     import Imath
+
     _MAP = {
         "dwab": Imath.Compression.DWAB_COMPRESSION,
         "piz": Imath.Compression.PIZ_COMPRESSION,
@@ -91,39 +95,43 @@ def write_exr(path: str, img: np.ndarray, compression: str = "dwab") -> bool:
             # Grayscale — single Y channel
             h, w = img.shape
             header = OpenEXR.Header(w, h)
-            header['compression'] = comp
-            header['channels'] = {'Y': HALF}
+            header["compression"] = comp
+            header["channels"] = {"Y": HALF}
             y = img.astype(np.float16)
             out = OpenEXR.OutputFile(path, header)
-            out.writePixels({'Y': y.tobytes()})
+            out.writePixels({"Y": y.tobytes()})
             out.close()
         elif img.ndim == 3 and img.shape[2] == 3:
             # BGR → R, G, B channels
             h, w = img.shape[:2]
             header = OpenEXR.Header(w, h)
-            header['compression'] = comp
-            header['channels'] = {'R': HALF, 'G': HALF, 'B': HALF}
+            header["compression"] = comp
+            header["channels"] = {"R": HALF, "G": HALF, "B": HALF}
             b = img[:, :, 0].astype(np.float16)
             g = img[:, :, 1].astype(np.float16)
             r = img[:, :, 2].astype(np.float16)
             out = OpenEXR.OutputFile(path, header)
-            out.writePixels({'R': r.tobytes(), 'G': g.tobytes(), 'B': b.tobytes()})
+            out.writePixels({"R": r.tobytes(), "G": g.tobytes(), "B": b.tobytes()})
             out.close()
         elif img.ndim == 3 and img.shape[2] == 4:
             # BGRA → R, G, B, A channels
             h, w = img.shape[:2]
             header = OpenEXR.Header(w, h)
-            header['compression'] = comp
-            header['channels'] = {'R': HALF, 'G': HALF, 'B': HALF, 'A': HALF}
+            header["compression"] = comp
+            header["channels"] = {"R": HALF, "G": HALF, "B": HALF, "A": HALF}
             b = img[:, :, 0].astype(np.float16)
             g = img[:, :, 1].astype(np.float16)
             r = img[:, :, 2].astype(np.float16)
             a = img[:, :, 3].astype(np.float16)
             out = OpenEXR.OutputFile(path, header)
-            out.writePixels({
-                'R': r.tobytes(), 'G': g.tobytes(),
-                'B': b.tobytes(), 'A': a.tobytes(),
-            })
+            out.writePixels(
+                {
+                    "R": r.tobytes(),
+                    "G": g.tobytes(),
+                    "B": b.tobytes(),
+                    "A": a.tobytes(),
+                }
+            )
             out.close()
         else:
             logger.warning(f"Unsupported image shape for EXR write: {img.shape}")
@@ -161,7 +169,6 @@ def recompress_exr(src_path: str, dst_path: str, compression: str = "dwab") -> b
     return write_exr(dst_path, img, compression=compression)
 
 
-
 def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> Optional[np.ndarray]:
     """Read an image file (EXR or standard) as float32 RGB [0, 1].
 
@@ -173,7 +180,7 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> Optional[np
     Returns:
         float32 array [H, W, 3] in RGB order, or None if read fails.
     """
-    is_exr = fpath.lower().endswith('.exr')
+    is_exr = fpath.lower().endswith(".exr")
 
     if is_exr:
         img = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
@@ -196,7 +203,8 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> Optional[np
 
 
 def read_video_frame_at(
-    video_path: str, frame_index: int,
+    video_path: str,
+    frame_index: int,
 ) -> Optional[np.ndarray]:
     """Read a single frame from a video by index, as float32 RGB [0, 1].
 
@@ -297,7 +305,8 @@ def decode_video_mask_frame(frame: np.ndarray) -> np.ndarray:
 
 
 def read_video_mask_at(
-    video_path: str, frame_index: int,
+    video_path: str,
+    frame_index: int,
 ) -> Optional[np.ndarray]:
     """Read a single mask frame from a video by index, as float32 [H, W] [0, 1].
 

--- a/backend/job_queue.py
+++ b/backend/job_queue.py
@@ -14,6 +14,7 @@ Design:
     - Deduplication prevents double-submit of same clip+job_type
     - Job history preserved for UI display (cancelled/completed/failed)
 """
+
 from __future__ import annotations
 
 import logging
@@ -53,6 +54,7 @@ class JobStatus(Enum):
 @dataclass
 class GPUJob:
     """A single GPU job to be executed."""
+
     job_type: JobType
     clip_name: str
     id: str = field(default_factory=lambda: uuid.uuid4().hex[:8])
@@ -80,7 +82,9 @@ class GPUJob:
 
 
 # Callback type aliases
-ProgressCallback = Callable[..., None]  # clip_name, current, total, **kwargs (fps, elapsed, eta_seconds)
+ProgressCallback = Callable[
+    ..., None
+]  # clip_name, current, total, **kwargs (fps, elapsed, eta_seconds)
 WarningCallback = Callable[[str], None]  # message
 CompletionCallback = Callable[[str], None]  # clip_name
 ErrorCallback = Callable[[str, str], None]  # clip_name, error_message
@@ -131,10 +135,7 @@ class GPUJobQueue:
         with self._lock:
             # Preview jobs: replace existing queued jobs of the same preview type.
             if job.job_type in (JobType.PREVIEW_REPROCESS, JobType.SAM2_PREVIEW):
-                replaced = [
-                    j for j in self._queue
-                    if j.job_type == job.job_type
-                ]
+                replaced = [j for j in self._queue if j.job_type == job.job_type]
                 for old in replaced:
                     self._queue.remove(old)
                     old.status = JobStatus.CANCELLED
@@ -211,7 +212,9 @@ class GPUJobQueue:
             except ValueError:
                 pass
             self._history.append(job)
-            logger.error(f"Job failed [{job.id}]: {job.job_type.value} for '{job.clip_name}': {error}")
+            logger.error(
+                f"Job failed [{job.id}]: {job.job_type.value} for '{job.clip_name}': {error}"
+            )
         # Emit AFTER lock release
         if self.on_error:
             self.on_error(job.clip_name, error)
@@ -240,11 +243,15 @@ class GPUJobQueue:
                     self._queue.remove(job)
                 job.status = JobStatus.CANCELLED
                 self._history.append(job)
-                logger.info(f"Job removed from queue [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+                logger.info(
+                    f"Job removed from queue [{job.id}]: {job.job_type.value} for '{job.clip_name}'"
+                )
             elif job.status == JobStatus.RUNNING:
                 # Signal cancel — worker calls mark_cancelled() after catching JobCancelledError
                 job.request_cancel()
-                logger.info(f"Job cancel requested [{job.id}]: {job.job_type.value} for '{job.clip_name}'")
+                logger.info(
+                    f"Job cancel requested [{job.id}]: {job.job_type.value} for '{job.clip_name}'"
+                )
 
     def cancel_current(self) -> None:
         """Cancel all currently running jobs."""

--- a/backend/natural_sort.py
+++ b/backend/natural_sort.py
@@ -5,11 +5,12 @@ Handles non-zero-padded frame numbers correctly:
 
 No external dependency — pure Python implementation.
 """
+
 from __future__ import annotations
 
 import re
 
-_SPLIT_RE = re.compile(r'(\d+)')
+_SPLIT_RE = re.compile(r"(\d+)")
 
 
 def natural_sort_key(text: str) -> list[str | int]:

--- a/backend/project.py
+++ b/backend/project.py
@@ -17,6 +17,7 @@ A project is a timestamped container holding one or more clips:
 
 Legacy v1 format (no clips/ dir) is still supported for backward compat.
 """
+
 from __future__ import annotations
 
 import json
@@ -53,17 +54,18 @@ def get_data_dir() -> str:
     Dev mode: project root (same as _app_dir).
     Frozen: QSettings app/install_path, falling back to platform default.
     """
-    if not getattr(sys, 'frozen', False):
+    if not getattr(sys, "frozen", False):
         if _app_dir:
             return _app_dir
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     # Portable: all data next to the exe
     exe_dir = os.path.dirname(sys.executable)
-    if os.path.isfile(os.path.join(exe_dir, 'portable.txt')):
+    if os.path.isfile(os.path.join(exe_dir, "portable.txt")):
         return exe_dir
     # Frozen: read user-chosen install path
     try:
         from PySide6.QtCore import QSettings
+
         saved = QSettings().value("app/install_path", "", type=str)
         if saved and os.path.isdir(saved):
             return saved
@@ -73,7 +75,9 @@ def get_data_dir() -> str:
     if sys.platform == "win32":
         return os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), "EZ-CorridorKey")
     elif sys.platform == "darwin":
-        return os.path.join(os.path.expanduser("~"), "Library", "Application Support", "EZ-CorridorKey")
+        return os.path.join(
+            os.path.expanduser("~"), "Library", "Application Support", "EZ-CorridorKey"
+        )
     return os.path.join(os.path.expanduser("~"), ".local", "share", "EZ-CorridorKey")
 
 
@@ -85,7 +89,7 @@ def projects_root() -> str:
     """
     if _app_dir:
         root = os.path.join(_app_dir, "Projects")
-    elif getattr(sys, 'frozen', False):
+    elif getattr(sys, "frozen", False):
         root = os.path.join(os.path.dirname(sys.executable), "Projects")
     else:
         # Fallback: two levels up from this file (backend/ -> repo root)
@@ -170,17 +174,22 @@ def create_project(
     clip_names: list[str] = []
     for video_path in source_video_paths:
         clip_name = _create_clip_folder(
-            clips_dir, video_path, copy_source=copy_source,
+            clips_dir,
+            video_path,
+            copy_source=copy_source,
         )
         clip_names.append(clip_name)
 
     # Write project.json (v2 — project-level metadata only)
-    write_project_json(project_dir, {
-        "version": 2,
-        "created": datetime.now().isoformat(),
-        "display_name": project_display_name,
-        "clips": clip_names,
-    })
+    write_project_json(
+        project_dir,
+        {
+            "version": 2,
+            "created": datetime.now().isoformat(),
+            "display_name": project_display_name,
+            "clips": clip_names,
+        },
+    )
 
     return project_dir
 
@@ -207,7 +216,9 @@ def add_clips_to_project(
     new_paths: list[str] = []
     for video_path in source_video_paths:
         clip_name = _create_clip_folder(
-            clips_dir, video_path, copy_source=copy_source,
+            clips_dir,
+            video_path,
+            copy_source=copy_source,
         )
         new_paths.append(os.path.join(clips_dir, clip_name))
 
@@ -280,13 +291,16 @@ def _create_clip_folder(
         logger.info(f"Referencing source video in place: {video_path}")
 
     # Write clip.json (per-clip metadata)
-    write_clip_json(clip_dir, {
-        "source": {
-            "original_path": os.path.abspath(video_path),
-            "filename": filename,
-            "copied": copy_source,
+    write_clip_json(
+        clip_dir,
+        {
+            "source": {
+                "original_path": os.path.abspath(video_path),
+                "filename": filename,
+                "copied": copy_source,
+            },
         },
-    })
+    )
 
     return clip_name
 
@@ -303,7 +317,8 @@ def get_clip_dirs(project_dir: str) -> list[str]:
             os.path.join(clips_dir, d)
             for d in os.listdir(clips_dir)
             if os.path.isdir(os.path.join(clips_dir, d))
-            and not d.startswith('.') and not d.startswith('_')
+            and not d.startswith(".")
+            and not d.startswith("_")
         )
     # v1 fallback: project dir itself is the clip
     return [project_dir]
@@ -457,6 +472,7 @@ def load_in_out_range(clip_root: str):
     if data and "in_out_range" in data:
         try:
             from .clip_state import InOutRange
+
             return InOutRange.from_dict(data["in_out_range"])
         except (KeyError, TypeError):
             return None
@@ -502,16 +518,22 @@ def folder_has_image_sequence(folder_path: str) -> bool:
     """
     if not os.path.isdir(folder_path):
         return False
-    return any(is_image_file(f) for f in os.listdir(folder_path)
-               if os.path.isfile(os.path.join(folder_path, f)))
+    return any(
+        is_image_file(f)
+        for f in os.listdir(folder_path)
+        if os.path.isfile(os.path.join(folder_path, f))
+    )
 
 
 def count_sequence_frames(folder_path: str) -> int:
     """Count image files in a folder (potential sequence frame count)."""
     if not os.path.isdir(folder_path):
         return 0
-    return sum(1 for f in os.listdir(folder_path)
-               if os.path.isfile(os.path.join(folder_path, f)) and is_image_file(f))
+    return sum(
+        1
+        for f in os.listdir(folder_path)
+        if os.path.isfile(os.path.join(folder_path, f)) and is_image_file(f)
+    )
 
 
 def validate_sequence_stems(folder_path: str) -> list[str]:

--- a/backend/project_media.py
+++ b/backend/project_media.py
@@ -3,6 +3,7 @@
 Extracted from project.py to keep that module focused on core project
 management (creation, JSON helpers, path utilities).
 """
+
 from __future__ import annotations
 
 import logging
@@ -13,14 +14,12 @@ from datetime import datetime
 
 from .project import (
     is_image_file,
-    is_video_file,
     projects_root,
     sanitize_stem,
     write_clip_json,
     write_project_json,
     read_project_json,
     _create_clip_folder,
-    _VIDEO_EXTS,
 )
 
 logger = logging.getLogger(__name__)
@@ -85,7 +84,8 @@ def create_clip_from_sequence(
         frames_dir = os.path.join(clip_dir, "Frames")
         os.makedirs(frames_dir, exist_ok=True)
         files_to_copy = specific_files or [
-            f for f in os.listdir(source_folder)
+            f
+            for f in os.listdir(source_folder)
             if os.path.isfile(os.path.join(source_folder, f)) and is_image_file(f)
         ]
         for f in files_to_copy:
@@ -93,22 +93,23 @@ def create_clip_from_sequence(
             dst = os.path.join(frames_dir, f)
             if os.path.isfile(src) and not os.path.isfile(dst):
                 shutil.copy2(src, dst)
-        logger.info(
-            f"Copied {len(files_to_copy)} frame(s) from {source_folder} -> {frames_dir}"
-        )
+        logger.info(f"Copied {len(files_to_copy)} frame(s) from {source_folder} -> {frames_dir}")
     else:
         logger.info(f"Referencing image sequence in place: {source_folder}")
 
     # Write clip.json with sequence source metadata
     clip_display = display_name or os.path.basename(source_folder).replace("_", " ")
-    write_clip_json(clip_dir, {
-        "source": {
-            "type": "sequence",
-            "original_path": os.path.abspath(source_folder),
-            "copied": copy_source,
+    write_clip_json(
+        clip_dir,
+        {
+            "source": {
+                "type": "sequence",
+                "original_path": os.path.abspath(source_folder),
+                "copied": copy_source,
+            },
+            "display_name": clip_display,
         },
-        "display_name": clip_display,
-    })
+    )
 
     return clip_name
 
@@ -135,7 +136,9 @@ def add_sequences_to_project(
     new_paths: list[str] = []
     for folder in sequence_folders:
         clip_name = create_clip_from_sequence(
-            clips_dir, folder, copy_source=copy_source,
+            clips_dir,
+            folder,
+            copy_source=copy_source,
         )
         new_paths.append(os.path.join(clips_dir, clip_name))
 
@@ -217,22 +220,29 @@ def create_project_from_media(
     # Add video clips
     for video_path in video_paths:
         clip_name = _create_clip_folder(
-            clips_dir, video_path, copy_source=copy_video,
+            clips_dir,
+            video_path,
+            copy_source=copy_video,
         )
         clip_names.append(clip_name)
 
     # Add sequence clips
     for seq_folder in sequence_folders:
         clip_name = create_clip_from_sequence(
-            clips_dir, seq_folder, copy_source=copy_sequences,
+            clips_dir,
+            seq_folder,
+            copy_source=copy_sequences,
         )
         clip_names.append(clip_name)
 
-    write_project_json(project_dir, {
-        "version": 2,
-        "created": datetime.now().isoformat(),
-        "display_name": project_display_name,
-        "clips": clip_names,
-    })
+    write_project_json(
+        project_dir,
+        {
+            "version": 2,
+            "created": datetime.now().isoformat(),
+            "display_name": project_display_name,
+            "clips": clip_names,
+        },
+    )
 
     return project_dir

--- a/backend/service/__init__.py
+++ b/backend/service/__init__.py
@@ -1,4 +1,5 @@
 """Backend service package — re-exports the public API."""
+
 import importlib
 import cv2
 from .core import CorridorKeyService, InferenceParams, OutputConfig, FrameResult

--- a/backend/service/core.py
+++ b/backend/service/core.py
@@ -9,6 +9,7 @@ Model Residency Policy:
     model type, the previous is unloaded and VRAM freed via
     torch.cuda.empty_cache(). This prevents OOM on 24GB cards.
 """
+
 from __future__ import annotations
 
 import gc
@@ -39,6 +40,7 @@ class InferenceParams:
     in CorridorKeyModule.inference_engine).  Change a default there and
     it propagates to every engine path and the service layer.
     """
+
     input_is_linear: bool = False
     despill_strength: float = _D["despill_strength"]
     auto_despeckle: bool = _D["auto_despeckle"]
@@ -54,7 +56,7 @@ class InferenceParams:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, d: dict) -> 'InferenceParams':
+    def from_dict(cls, d: dict) -> "InferenceParams":
         known = {f.name for f in cls.__dataclass_fields__.values()}
         return cls(**{k: v for k, v in d.items() if k in known})
 
@@ -62,8 +64,9 @@ class InferenceParams:
 @dataclass
 class OutputConfig:
     """Which output types to produce and their format."""
+
     fg_enabled: bool = True
-    fg_format: str = "exr"   # "exr" or "png"
+    fg_format: str = "exr"  # "exr" or "png"
     matte_enabled: bool = True
     matte_format: str = "exr"
     comp_enabled: bool = True
@@ -76,7 +79,7 @@ class OutputConfig:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, d: dict) -> 'OutputConfig':
+    def from_dict(cls, d: dict) -> "OutputConfig":
         known = {f.name for f in cls.__dataclass_fields__.values()}
         return cls(**{k: v for k, v in d.items() if k in known})
 
@@ -98,6 +101,7 @@ class OutputConfig:
 @dataclass
 class FrameResult:
     """Result summary for a single processed frame (no numpy in this struct)."""
+
     frame_index: int
     input_stem: str
     success: bool
@@ -136,7 +140,7 @@ class CorridorKeyService(
         self._matanyone2_processor = None
         self._birefnet_processor = None
         self._active_model = _ActiveModel.NONE
-        self._device: str = 'cpu'
+        self._device: str = "cpu"
         self._job_queue: Optional[GPUJobQueue] = None
         self._sam2_model_id: str = "facebook/sam2.1-hiera-base-plus"
         # GPU mutex — serializes ALL model operations
@@ -173,6 +177,7 @@ class CorridorKeyService(
                 self._active_model = _ActiveModel.NONE
             try:
                 import torch
+
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
             except Exception:
@@ -189,7 +194,9 @@ class CorridorKeyService(
             logger.warning("Invalid model resolution %d, ignoring", res)
             return
         if res != self._model_resolution:
-            logger.info("Model resolution: %d -> %d (engine reload required)", self._model_resolution, res)
+            logger.info(
+                "Model resolution: %d -> %d (engine reload required)", self._model_resolution, res
+            )
             self._model_resolution = res
             # Clear engine pool — next inference will rebuild at new resolution
             for eng in self._engine_pool:
@@ -199,6 +206,7 @@ class CorridorKeyService(
                 self._active_model = _ActiveModel.NONE
             try:
                 import torch
+
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
             except Exception:
@@ -220,6 +228,7 @@ class CorridorKeyService(
                 gc.collect()
                 try:
                     import torch
+
                     if torch.cuda.is_available():
                         torch.cuda.empty_cache()
                 except Exception:
@@ -252,16 +261,17 @@ class CorridorKeyService(
         """Detect best available compute device (CUDA > MPS > CPU)."""
         try:
             import torch
+
             if torch.cuda.is_available():
-                self._device = 'cuda'
-            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-                self._device = 'mps'
+                self._device = "cuda"
+            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                self._device = "mps"
                 logger.info("Apple MPS acceleration available")
             else:
-                self._device = 'cpu'
+                self._device = "cpu"
                 logger.warning("No GPU acceleration available — using CPU (will be very slow)")
         except ImportError:
-            self._device = 'cpu'
+            self._device = "cpu"
             logger.warning("PyTorch not installed — using CPU")
         logger.info(f"Compute device: {self._device}")
         return self._device
@@ -270,17 +280,18 @@ class CorridorKeyService(
         """Get GPU VRAM info in GB. Returns empty dict if not CUDA."""
         try:
             import torch
+
             if not torch.cuda.is_available():
                 return {}
             props = torch.cuda.get_device_properties(0)
             total_bytes = props.total_mem
             reserved = torch.cuda.memory_reserved(0)
             return {
-                'total': total_bytes / (1024**3),
-                'reserved': reserved / (1024**3),
-                'allocated': torch.cuda.memory_allocated(0) / (1024**3),
-                'free': (total_bytes - reserved) / (1024**3),
-                'name': torch.cuda.get_device_name(0),
+                "total": total_bytes / (1024**3),
+                "reserved": reserved / (1024**3),
+                "allocated": torch.cuda.memory_allocated(0) / (1024**3),
+                "free": (total_bytes - reserved) / (1024**3),
+                "name": torch.cuda.get_device_name(0),
             }
         except Exception as e:
             logger.debug(f"VRAM query failed: {e}")
@@ -289,7 +300,9 @@ class CorridorKeyService(
     # --- Clip Scanning ---
 
     def scan_clips(
-        self, clips_dir: str, allow_standalone_videos: bool = True,
+        self,
+        clips_dir: str,
+        allow_standalone_videos: bool = True,
     ) -> list[ClipEntry]:
         """Scan a directory for clip folders."""
         return scan_clips_dir(clips_dir, allow_standalone_videos=allow_standalone_videos)

--- a/backend/service/frame_ops.py
+++ b/backend/service/frame_ops.py
@@ -2,6 +2,7 @@
 
 Read/write individual frames, masks, manifests, and output images.
 """
+
 from __future__ import annotations
 
 import json
@@ -18,7 +19,6 @@ from ..frame_io import (
     _linear_to_srgb,
     _srgb_to_linear,
     decode_video_mask_frame,
-    read_video_frame_at,
     read_video_frames,
 )
 from ..validators import validate_frame_read, validate_write
@@ -43,7 +43,7 @@ class FrameOpsMixin:
             (image_float32, stem_name, is_linear)
         """
         from . import read_image_frame
-        
+
         logger.debug(f"Reading input frame {frame_index} for '{clip.name}'")
         input_stem = f"{frame_index:05d}"
 
@@ -72,7 +72,7 @@ class FrameOpsMixin:
     ) -> Optional[np.ndarray]:
         """Read a single alpha/mask frame and normalize to [H, W] float32."""
         from . import read_mask_frame
-        
+
         if alpha_cap:
             ret, frame = alpha_cap.read()
             if not ret:
@@ -92,13 +92,18 @@ class FrameOpsMixin:
             return mask
 
     def _write_image(
-        self, img: np.ndarray, path: str, fmt: str, clip_name: str, frame_index: int,
+        self,
+        img: np.ndarray,
+        path: str,
+        fmt: str,
+        clip_name: str,
+        frame_index: int,
         exr_compression: str = "dwab",
     ) -> None:
         """Write a single image in the requested format."""
         import cv2
         from . import write_exr
-        
+
         if fmt == "exr":
             # EXR requires float32 — convert if uint8 (e.g. pre-converted comp)
             if img.dtype == np.uint8:
@@ -107,7 +112,9 @@ class FrameOpsMixin:
                 img = img.astype(np.float32)
             validate_write(
                 write_exr(path, img, compression=exr_compression),
-                clip_name, frame_index, path,
+                clip_name,
+                frame_index,
+                path,
             )
         else:
             # PNG 8-bit
@@ -139,7 +146,7 @@ class FrameOpsMixin:
         manifest_path = os.path.join(output_root, ".corridorkey_manifest.json")
         tmp_path = manifest_path + ".tmp"
         try:
-            with open(tmp_path, 'w') as f:
+            with open(tmp_path, "w") as f:
                 json.dump(manifest, f, indent=2)
             # Atomic replace (os.replace is atomic on both POSIX and Windows)
             os.replace(tmp_path, manifest_path)
@@ -157,11 +164,12 @@ class FrameOpsMixin:
     ) -> None:
         """Write output types for a single frame respecting OutputConfig."""
         from .core import OutputConfig
+
         cfg = output_config or OutputConfig()
         logger.debug(f"Writing outputs for '{clip_name}' frame {frame_index} stem='{input_stem}'")
 
-        pred_fg = res['fg']
-        pred_alpha = res['alpha']
+        pred_fg = res["fg"]
+        pred_alpha = res["alpha"]
 
         # FG
         if cfg.fg_enabled:
@@ -169,22 +177,34 @@ class FrameOpsMixin:
             if cfg.fg_format == "exr":
                 fg_rgb = _srgb_to_linear(fg_rgb)
             fg_bgr = cv2.cvtColor(fg_rgb.astype(np.float32), cv2.COLOR_RGB2BGR)
-            fg_path = os.path.join(dirs['fg'], f"{input_stem}.{cfg.fg_format}")
-            self._write_image(fg_bgr, fg_path, cfg.fg_format, clip_name, frame_index,
-                              exr_compression=cfg.exr_compression)
+            fg_path = os.path.join(dirs["fg"], f"{input_stem}.{cfg.fg_format}")
+            self._write_image(
+                fg_bgr,
+                fg_path,
+                cfg.fg_format,
+                clip_name,
+                frame_index,
+                exr_compression=cfg.exr_compression,
+            )
 
         # Matte
         if cfg.matte_enabled:
             alpha = pred_alpha
             if alpha.ndim == 3:
                 alpha = alpha[:, :, 0]
-            matte_path = os.path.join(dirs['matte'], f"{input_stem}.{cfg.matte_format}")
-            self._write_image(alpha, matte_path, cfg.matte_format, clip_name, frame_index,
-                              exr_compression=cfg.exr_compression)
+            matte_path = os.path.join(dirs["matte"], f"{input_stem}.{cfg.matte_format}")
+            self._write_image(
+                alpha,
+                matte_path,
+                cfg.matte_format,
+                clip_name,
+                frame_index,
+                exr_compression=cfg.exr_compression,
+            )
 
         # Comp
         if cfg.comp_enabled:
-            comp_srgb = res['comp']
+            comp_srgb = res["comp"]
             if cfg.comp_format == "exr":
                 comp_rgb = _srgb_to_linear(comp_srgb)
                 comp_bgr = cv2.cvtColor(comp_rgb.astype(np.float32), cv2.COLOR_RGB2BGR)
@@ -193,13 +213,19 @@ class FrameOpsMixin:
                     (np.clip(comp_srgb, 0.0, 1.0) * 255.0).astype(np.uint8),
                     cv2.COLOR_RGB2BGR,
                 )
-            comp_path = os.path.join(dirs['comp'], f"{input_stem}.{cfg.comp_format}")
-            self._write_image(comp_bgr, comp_path, cfg.comp_format, clip_name, frame_index,
-                              exr_compression=cfg.exr_compression)
+            comp_path = os.path.join(dirs["comp"], f"{input_stem}.{cfg.comp_format}")
+            self._write_image(
+                comp_bgr,
+                comp_path,
+                cfg.comp_format,
+                clip_name,
+                frame_index,
+                exr_compression=cfg.exr_compression,
+            )
 
         # Processed (RGBA — linear premul for EXR, sRGB straight for PNG)
-        if cfg.processed_enabled and 'processed' in res:
-            proc_rgba = res['processed']  # [H,W,4] premultiplied linear float
+        if cfg.processed_enabled and "processed" in res:
+            proc_rgba = res["processed"]  # [H,W,4] premultiplied linear float
             if cfg.processed_format == "exr":
                 proc_bgra = cv2.cvtColor(proc_rgba, cv2.COLOR_RGBA2BGRA)
             else:
@@ -212,9 +238,15 @@ class FrameOpsMixin:
                 rgb_srgb = _linear_to_srgb(np.clip(rgb_straight, 0.0, 1.0))
                 proc_srgb = np.concatenate([rgb_srgb, alpha], axis=-1)
                 proc_bgra = cv2.cvtColor(proc_srgb, cv2.COLOR_RGBA2BGRA)
-            proc_path = os.path.join(dirs['processed'], f"{input_stem}.{cfg.processed_format}")
-            self._write_image(proc_bgra, proc_path, cfg.processed_format, clip_name, frame_index,
-                              exr_compression=cfg.exr_compression)
+            proc_path = os.path.join(dirs["processed"], f"{input_stem}.{cfg.processed_format}")
+            self._write_image(
+                proc_bgra,
+                proc_path,
+                cfg.processed_format,
+                clip_name,
+                frame_index,
+                exr_compression=cfg.exr_compression,
+            )
 
     def _load_first_frame_mask(
         self, clip: ClipEntry, frame_shape: tuple[int, int]
@@ -226,7 +258,7 @@ class FrameOpsMixin:
         if clip.mask_asset is None:
             return None
 
-        if clip.mask_asset.asset_type == 'sequence':
+        if clip.mask_asset.asset_type == "sequence":
             mask_files = clip.mask_asset.get_frame_files()
             if not mask_files:
                 return None
@@ -245,14 +277,16 @@ class FrameOpsMixin:
         return None
 
     def _load_frames_for_videomama(
-        self, asset: ClipAsset, clip_name: str,
+        self,
+        asset: ClipAsset,
+        clip_name: str,
         job=None,
         on_status: Optional[Callable[[str], None]] = None,
     ) -> list[np.ndarray]:
         """Load input frames for VideoMaMa as uint8 RGB [0, 255]."""
         from . import read_image_frame
-        
-        if asset.asset_type == 'video':
+
+        if asset.asset_type == "video":
             raw = read_video_frames(asset.path)
             return [(np.clip(f, 0.0, 1.0) * 255.0).astype(np.uint8) for f in raw]
         frames = []
@@ -269,16 +303,15 @@ class FrameOpsMixin:
                 on_status(f"Loading frames ({i}/{total})...")
         return frames
 
-    def _load_mask_frames_for_videomama(
-        self, asset: ClipAsset, clip_name: str
-    ) -> list[np.ndarray]:
+    def _load_mask_frames_for_videomama(self, asset: ClipAsset, clip_name: str) -> list[np.ndarray]:
         """Load mask frames for VideoMaMa as uint8 grayscale [0, 255]."""
+
         def _threshold_mask(bgr_frame: np.ndarray) -> np.ndarray:
             gray = cv2.cvtColor(bgr_frame, cv2.COLOR_BGR2GRAY)
             _, binary = cv2.threshold(gray, 10, 255, cv2.THRESH_BINARY)
             return binary  # uint8
 
-        if asset.asset_type == 'video':
+        if asset.asset_type == "video":
             return read_video_frames(asset.path, processor=_threshold_mask)
         masks = []
         for fname in asset.get_frame_files():
@@ -298,7 +331,7 @@ class FrameOpsMixin:
         if clip.in_out_range is not None:
             lo = clip.in_out_range.in_point
             hi = clip.in_out_range.out_point
-            files = files[lo:hi + 1]
+            files = files[lo : hi + 1]
         return files
 
     def _load_named_sequence_frames(
@@ -313,7 +346,7 @@ class FrameOpsMixin:
     ) -> list[tuple[str, np.ndarray]]:
         """Load named image-sequence frames as uint8 RGB for tracker/VideoMaMa."""
         from . import read_image_frame
-        
+
         named_frames: list[tuple[str, np.ndarray]] = []
         total = len(file_names)
         for index, fname in enumerate(file_names):
@@ -323,9 +356,7 @@ class FrameOpsMixin:
             img = read_image_frame(fpath, gamma_correct_exr=gamma_correct_exr)
             if img is None:
                 raise FrameReadError(clip_name, index, fpath)
-            named_frames.append(
-                (fname, (np.clip(img, 0.0, 1.0) * 255.0).astype(np.uint8))
-            )
+            named_frames.append((fname, (np.clip(img, 0.0, 1.0) * 255.0).astype(np.uint8)))
             if on_status and index % 20 == 0 and index > 0:
                 on_status(f"Loading frames ({index}/{total})...")
         return named_frames
@@ -350,6 +381,7 @@ class FrameOpsMixin:
     ) -> None:
         """Persist provenance for dense VideoMaMa-ready mask tracks."""
         from ..clip_state import MASK_TRACK_MANIFEST
+
         manifest_path = os.path.join(clip.root_path, MASK_TRACK_MANIFEST)
         payload = {
             "source": source,
@@ -363,6 +395,7 @@ class FrameOpsMixin:
     def _remove_alpha_hint_dir(clip: ClipEntry) -> None:
         """Remove AlphaHint so a new mask/alpha run is authoritative."""
         import shutil
+
         alpha_dir = os.path.join(clip.root_path, "AlphaHint")
         if os.path.isdir(alpha_dir):
             shutil.rmtree(alpha_dir, ignore_errors=True)

--- a/backend/service/helpers.py
+++ b/backend/service/helpers.py
@@ -1,15 +1,13 @@
 """Module-level helpers and standalone functions for the service package."""
+
 from __future__ import annotations
 
 import importlib
-import json
 import logging
 import os
 import sys
 import warnings
-from typing import Optional
 
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +24,7 @@ def _configure_runtime_warnings() -> None:
 _configure_runtime_warnings()
 
 # Project paths — frozen-build aware
-if getattr(sys, 'frozen', False):
+if getattr(sys, "frozen", False):
     BASE_DIR = sys._MEIPASS
 else:
     BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -70,9 +68,7 @@ def _import_matanyone2_processor_class():
             last_error = exc
 
     expected = " or ".join(missing_roots)
-    raise ModuleNotFoundError(
-        f"MatAnyone2 module not found. Expected {expected}"
-    ) from last_error
+    raise ModuleNotFoundError(f"MatAnyone2 module not found. Expected {expected}") from last_error
 
 
 def export_masks_headless(clip) -> str | None:
@@ -114,7 +110,7 @@ def export_masks_headless(clip) -> str | None:
     if clip.in_out_range:
         lo = clip.in_out_range.in_point
         hi = clip.in_out_range.out_point
-        stems = stems[lo:hi + 1]
+        stems = stems[lo : hi + 1]
         start_idx = lo
 
     return model.export_masks(clip.root_path, stems, w, h, start_index=start_idx)

--- a/backend/service/inference.py
+++ b/backend/service/inference.py
@@ -1,4 +1,5 @@
 """Core CorridorKey inference pipeline — dispatcher, sequential, and finalization."""
+
 from __future__ import annotations
 
 import logging
@@ -8,7 +9,6 @@ from collections import deque
 from typing import Callable, Optional
 
 import cv2
-import numpy as np
 
 from ..clip_state import ClipEntry, ClipState
 from ..errors import (
@@ -60,16 +60,28 @@ class InferenceMixin(ParallelInferenceMixin):
 
             if len(engines) == 1:
                 return self._run_inference_sequential(
-                    clip, params, engines[0], job=job,
-                    on_progress=on_progress, on_warning=on_warning,
-                    on_status=on_status, skip_stems=skip_stems,
-                    output_config=output_config, frame_range=frame_range,
+                    clip,
+                    params,
+                    engines[0],
+                    job=job,
+                    on_progress=on_progress,
+                    on_warning=on_warning,
+                    on_status=on_status,
+                    skip_stems=skip_stems,
+                    output_config=output_config,
+                    frame_range=frame_range,
                 )
             return self._run_inference_parallel(
-                clip, params, engines, job=job,
-                on_progress=on_progress, on_warning=on_warning,
-                on_status=on_status, skip_stems=skip_stems,
-                output_config=output_config, frame_range=frame_range,
+                clip,
+                params,
+                engines,
+                job=job,
+                on_progress=on_progress,
+                on_warning=on_warning,
+                on_status=on_status,
+                skip_stems=skip_stems,
+                output_config=output_config,
+                frame_range=frame_range,
             )
         finally:
             self._end_inference()
@@ -89,13 +101,14 @@ class InferenceMixin(ParallelInferenceMixin):
     ) -> list:
         """Sequential frame loop — exact extraction of original run_inference."""
         from .core import FrameResult, OutputConfig
+
         t_start = time.monotonic()
         dirs = ensure_output_dirs(clip.output_dir)
         cfg = output_config or OutputConfig()
 
-        self._write_manifest(dirs['root'], cfg, params)
+        self._write_manifest(dirs["root"], cfg, params)
 
-        if clip.input_asset.asset_type == 'sequence' and clip.alpha_asset.asset_type == 'sequence':
+        if clip.input_asset.asset_type == "sequence" and clip.alpha_asset.asset_type == "sequence":
             num_frames = clip.input_asset.frame_count
             if clip.input_asset.frame_count != clip.alpha_asset.frame_count:
                 logger.warning(
@@ -117,18 +130,17 @@ class InferenceMixin(ParallelInferenceMixin):
         input_files: list[str] = []
         alpha_files: list[str] = []
 
-        if clip.input_asset.asset_type == 'video':
+        if clip.input_asset.asset_type == "video":
             input_cap = cv2.VideoCapture(clip.input_asset.path)
         else:
             input_files = clip.input_asset.get_frame_files()
 
-        if clip.alpha_asset.asset_type == 'video':
+        if clip.alpha_asset.asset_type == "video":
             alpha_cap = cv2.VideoCapture(clip.alpha_asset.path)
         else:
             alpha_files = clip.alpha_asset.get_frame_files()
         alpha_stem_lookup = (
-            {os.path.splitext(fname)[0]: fname for fname in alpha_files}
-            if alpha_files else None
+            {os.path.splitext(fname)[0]: fname for fname in alpha_files} if alpha_files else None
         )
 
         results: list[FrameResult] = []
@@ -170,7 +182,11 @@ class InferenceMixin(ParallelInferenceMixin):
 
                 try:
                     img, input_stem, is_linear = self._read_input_frame(
-                        clip, i, input_files, input_cap, params.input_is_linear,
+                        clip,
+                        i,
+                        input_files,
+                        input_cap,
+                        params.input_is_linear,
                     )
                     if img is None:
                         skipped.append(i)
@@ -182,7 +198,10 @@ class InferenceMixin(ParallelInferenceMixin):
                         continue
 
                     mask = self._read_alpha_frame(
-                        clip, i, alpha_files, alpha_cap,
+                        clip,
+                        i,
+                        alpha_files,
+                        alpha_cap,
                         input_stem=input_stem,
                         alpha_stem_lookup=alpha_stem_lookup,
                     )
@@ -192,12 +211,15 @@ class InferenceMixin(ParallelInferenceMixin):
                         continue
 
                     if mask.shape[:2] != img.shape[:2]:
-                        mask = cv2.resize(mask, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_LINEAR)
+                        mask = cv2.resize(
+                            mask, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_LINEAR
+                        )
 
                     t_frame = time.monotonic()
                     with self._gpu_lock:
                         res = engine.process_frame(
-                            img, mask,
+                            img,
+                            mask,
                             input_is_linear=is_linear,
                             fg_is_straight=True,
                             despill_strength=params.despill_strength,
@@ -220,9 +242,7 @@ class InferenceMixin(ParallelInferenceMixin):
                             on_status("")
                     total_t = sum(frame_times)
                     avg_fps = len(frame_times) / total_t if total_t > 0 else 0.0
-                    logger.debug(
-                        f"Frame {i}: {dt * 1000:.0f}ms ({avg_fps:.1f} fps avg)"
-                    )
+                    logger.debug(f"Frame {i}: {dt * 1000:.0f}ms ({avg_fps:.1f} fps avg)")
 
                     self._write_outputs(res, dirs, input_stem, clip.name, i, cfg)
                     results.append(FrameResult(i, input_stem, True))
@@ -255,8 +275,13 @@ class InferenceMixin(ParallelInferenceMixin):
                 alpha_cap.release()
 
         return self._finalize_inference(
-            clip, results, skipped, processed_count,
-            t_start, frame_range, num_frames,
+            clip,
+            results,
+            skipped,
+            processed_count,
+            t_start,
+            frame_range,
+            num_frames,
             on_warning=on_warning,
         )
 
@@ -291,8 +316,9 @@ class InferenceMixin(ParallelInferenceMixin):
             f"in {t_total:.1f}s ({t_total / max(processed, 1):.2f}s/frame, {avg_fps:.1f} fps avg)"
         )
 
-        is_full_clip = (frame_range is None or
-                        (frame_range[0] == 0 and frame_range[1] >= num_frames - 1))
+        is_full_clip = frame_range is None or (
+            frame_range[0] == 0 and frame_range[1] >= num_frames - 1
+        )
         if processed == range_count and is_full_clip:
             try:
                 clip.transition_to(ClipState.COMPLETE)
@@ -330,7 +356,7 @@ class InferenceMixin(ParallelInferenceMixin):
         # Read the specific input frame
         is_linear = params.input_is_linear
         input_stem = f"{frame_index:05d}"
-        if clip.input_asset.asset_type == 'video':
+        if clip.input_asset.asset_type == "video":
             img = read_video_frame_at(clip.input_asset.path, frame_index)
         else:
             input_files = clip.input_asset.get_frame_files()
@@ -343,7 +369,7 @@ class InferenceMixin(ParallelInferenceMixin):
             return None
 
         # Read the specific alpha frame
-        if clip.alpha_asset.asset_type == 'video':
+        if clip.alpha_asset.asset_type == "video":
             mask = read_video_mask_at(clip.alpha_asset.path, frame_index)
         else:
             alpha_files = clip.alpha_asset.get_frame_files()
@@ -367,7 +393,8 @@ class InferenceMixin(ParallelInferenceMixin):
 
         with self._gpu_lock:
             res = engine.process_frame(
-                img, mask,
+                img,
+                mask,
                 input_is_linear=is_linear,
                 fg_is_straight=True,
                 despill_strength=params.despill_strength,
@@ -380,5 +407,7 @@ class InferenceMixin(ParallelInferenceMixin):
                 edge_erode_px=params.edge_erode_px,
                 edge_blur_px=params.edge_blur_px,
             )
-        logger.debug(f"Clip '{clip.name}' frame {frame_index}: reprocess {time.monotonic() - t_start:.3f}s")
+        logger.debug(
+            f"Clip '{clip.name}' frame {frame_index}: reprocess {time.monotonic() - t_start:.3f}s"
+        )
         return res

--- a/backend/service/inference_parallel.py
+++ b/backend/service/inference_parallel.py
@@ -1,4 +1,5 @@
 """Parallel inference pipeline — reader/worker/writer thread architecture."""
+
 from __future__ import annotations
 
 import logging
@@ -40,24 +41,29 @@ class ParallelInferenceMixin:
     ) -> list:
         """Parallel frame pipeline: reader thread -> N workers -> writer thread."""
         from .core import FrameResult, OutputConfig
+
         N = len(engines)
         logger.info("Starting parallel inference with %d engines", N)
 
         t_start = time.monotonic()
         dirs = ensure_output_dirs(clip.output_dir)
         cfg = output_config or OutputConfig()
-        self._write_manifest(dirs['root'], cfg, params)
+        self._write_manifest(dirs["root"], cfg, params)
 
-        if clip.input_asset.asset_type == 'sequence' and clip.alpha_asset.asset_type == 'sequence':
+        if clip.input_asset.asset_type == "sequence" and clip.alpha_asset.asset_type == "sequence":
             num_frames = clip.input_asset.frame_count
             if clip.input_asset.frame_count != clip.alpha_asset.frame_count:
                 logger.warning(
                     "Clip '%s': sequence alpha count mismatch — input has %d, alpha has %d.",
-                    clip.name, clip.input_asset.frame_count, clip.alpha_asset.frame_count,
+                    clip.name,
+                    clip.input_asset.frame_count,
+                    clip.alpha_asset.frame_count,
                 )
         else:
             num_frames = validate_frame_counts(
-                clip.name, clip.input_asset.frame_count, clip.alpha_asset.frame_count,
+                clip.name,
+                clip.input_asset.frame_count,
+                clip.alpha_asset.frame_count,
             )
 
         if frame_range is not None:
@@ -98,7 +104,8 @@ class ParallelInferenceMixin:
                 frame_idx, img, mask, stem, is_linear = item
                 try:
                     res = eng.process_frame(
-                        img, mask,
+                        img,
+                        mask,
                         input_is_linear=is_linear,
                         fg_is_straight=True,
                         despill_strength=params.despill_strength,
@@ -130,18 +137,19 @@ class ParallelInferenceMixin:
             alpha_files: list[str] = []
 
             try:
-                if clip.input_asset.asset_type == 'video':
+                if clip.input_asset.asset_type == "video":
                     input_cap = cv2.VideoCapture(clip.input_asset.path)
                 else:
                     input_files = clip.input_asset.get_frame_files()
 
-                if clip.alpha_asset.asset_type == 'video':
+                if clip.alpha_asset.asset_type == "video":
                     alpha_cap = cv2.VideoCapture(clip.alpha_asset.path)
                 else:
                     alpha_files = clip.alpha_asset.get_frame_files()
                 alpha_stem_lookup = (
                     {os.path.splitext(fname)[0]: fname for fname in alpha_files}
-                    if alpha_files else None
+                    if alpha_files
+                    else None
                 )
 
                 for i in frame_indices:
@@ -149,10 +157,16 @@ class ParallelInferenceMixin:
                         break
 
                     img, input_stem, is_linear = self._read_input_frame(
-                        clip, i, input_files, input_cap, params.input_is_linear,
+                        clip,
+                        i,
+                        input_files,
+                        input_cap,
+                        params.input_is_linear,
                     )
                     if img is None:
-                        out_q.put((i, f"{i:05d}", None, FrameReadError(clip.name, i, "video read failed")))
+                        out_q.put(
+                            (i, f"{i:05d}", None, FrameReadError(clip.name, i, "video read failed"))
+                        )
                         continue
 
                     if input_stem in skip_stems:
@@ -160,15 +174,23 @@ class ParallelInferenceMixin:
                         continue
 
                     mask = self._read_alpha_frame(
-                        clip, i, alpha_files, alpha_cap,
-                        input_stem=input_stem, alpha_stem_lookup=alpha_stem_lookup,
+                        clip,
+                        i,
+                        alpha_files,
+                        alpha_cap,
+                        input_stem=input_stem,
+                        alpha_stem_lookup=alpha_stem_lookup,
                     )
                     if mask is None:
-                        out_q.put((i, input_stem, None, FrameReadError(clip.name, i, "alpha read failed")))
+                        out_q.put(
+                            (i, input_stem, None, FrameReadError(clip.name, i, "alpha read failed"))
+                        )
                         continue
 
                     if mask.shape[:2] != img.shape[:2]:
-                        mask = cv2.resize(mask, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_LINEAR)
+                        mask = cv2.resize(
+                            mask, (img.shape[1], img.shape[0]), interpolation=cv2.INTER_LINEAR
+                        )
 
                     in_q.put((i, img, mask, input_stem, is_linear))
             finally:
@@ -264,9 +286,9 @@ class ParallelInferenceMixin:
 
         # Launch all threads
         threads = (
-            [threading.Thread(target=reader, name="ck-reader")] +
-            [threading.Thread(target=worker, args=(i,), name=f"ck-worker-{i}") for i in range(N)] +
-            [threading.Thread(target=writer, name="ck-writer")]
+            [threading.Thread(target=reader, name="ck-reader")]
+            + [threading.Thread(target=worker, args=(i,), name=f"ck-worker-{i}") for i in range(N)]
+            + [threading.Thread(target=writer, name="ck-writer")]
         )
         for t in threads:
             t.start()
@@ -283,7 +305,12 @@ class ParallelInferenceMixin:
             raise JobCancelledError(clip.name, 0)
 
         return self._finalize_inference(
-            clip, results, skipped, processed_count_box[0],
-            t_start, frame_range, num_frames,
+            clip,
+            results,
+            skipped,
+            processed_count_box[0],
+            t_start,
+            frame_range,
+            num_frames,
             on_warning=on_warning,
         )

--- a/backend/service/model_manager.py
+++ b/backend/service/model_manager.py
@@ -3,6 +3,7 @@
 Implements the single-model-in-VRAM policy: only one heavy model
 stays loaded at a time. Switching triggers offload + gc + cache clear.
 """
+
 from __future__ import annotations
 
 import gc
@@ -11,7 +12,7 @@ import os
 import sys
 import time
 from enum import Enum
-from typing import Callable, Optional
+from typing import Callable
 
 from .helpers import BASE_DIR, _import_matanyone2_processor_class
 
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 class _ActiveModel(Enum):
     """Tracks which heavy model is currently loaded in VRAM."""
+
     NONE = "none"
     INFERENCE = "inference"
     GVM = "gvm"
@@ -37,8 +39,9 @@ class ModelManagerMixin:
         """Return current VRAM allocated in MB, or 0 if unavailable."""
         try:
             import torch
+
             if torch.cuda.is_available():
-                return torch.cuda.memory_allocated(0) / (1024 ** 2)
+                return torch.cuda.memory_allocated(0) / (1024**2)
         except Exception:
             pass
         return 0.0
@@ -55,11 +58,11 @@ class ModelManagerMixin:
         name = type(obj).__name__
         logger.debug(f"Offloading model: {name}")
         try:
-            if hasattr(obj, 'unload'):
+            if hasattr(obj, "unload"):
                 obj.unload()
-            elif hasattr(obj, 'to'):
-                obj.to('cpu')
-            elif hasattr(obj, 'cpu'):
+            elif hasattr(obj, "to"):
+                obj.to("cpu")
+            elif hasattr(obj, "cpu"):
                 obj.cpu()
             else:
                 logger.warning(f"Model {name} has no .to()/.cpu()/.unload() — VRAM may leak")
@@ -94,8 +97,10 @@ class ModelManagerMixin:
             vram_before_mb = self._vram_allocated_mb()
             if on_status:
                 on_status(f"Switching {self._active_model.value} -> {needed.value}...")
-            logger.info(f"Unloading {self._active_model.value} model for {needed.value}"
-                        f" (VRAM before: {vram_before_mb:.0f}MB)")
+            logger.info(
+                f"Unloading {self._active_model.value} model for {needed.value}"
+                f" (VRAM before: {vram_before_mb:.0f}MB)"
+            )
 
             t0 = time.monotonic()
             if on_status:
@@ -112,7 +117,7 @@ class ModelManagerMixin:
                 if gvm is not None:
                     self._safe_offload(gvm)
                     # Break circular references inside the diffusion pipeline
-                    for attr in ('pipe', 'vae', 'unet', 'scheduler'):
+                    for attr in ("pipe", "vae", "unet", "scheduler"):
                         try:
                             setattr(gvm, attr, None)
                         except Exception:
@@ -133,6 +138,7 @@ class ModelManagerMixin:
             logger.info(f"_safe_offload took {time.monotonic() - t0:.1f}s")
 
             import gc as _gc
+
             t0 = time.monotonic()
             # Two GC passes: first breaks cycles, second reclaims freed refs
             if on_status:
@@ -143,6 +149,7 @@ class ModelManagerMixin:
 
             try:
                 import torch
+
                 if torch.cuda.is_available():
                     t0 = time.monotonic()
                     if on_status:
@@ -162,6 +169,7 @@ class ModelManagerMixin:
             # doesn't choke on stale CUDA state from the previous model
             try:
                 import torch._dynamo
+
                 torch._dynamo.reset()
                 logger.info("torch._dynamo.reset() — cleared compilation cache")
             except Exception as e:
@@ -169,6 +177,7 @@ class ModelManagerMixin:
 
             try:
                 import torch._inductor
+
                 torch._inductor.codecache.PyCodeCache.clear()
                 logger.info("torch._inductor code cache cleared")
             except Exception as e:
@@ -194,7 +203,7 @@ class ModelManagerMixin:
 
         # Pool already has enough engines
         if len(self._engine_pool) >= self._pool_size:
-            return self._engine_pool[:self._pool_size]
+            return self._engine_pool[: self._pool_size]
 
         from CorridorKeyModule.backend import create_engine, resolve_backend
 
@@ -202,13 +211,14 @@ class ModelManagerMixin:
         requested_backend = None
         try:
             from PySide6.QtCore import QSettings
+
             requested_backend = QSettings().value("inference/backend", "auto", type=str)
             if requested_backend == "auto":
                 requested_backend = None  # let resolve_backend auto-detect
         except Exception:
             pass
         backend = resolve_backend(requested_backend)
-        opt_mode = os.environ.get('CORRIDORKEY_OPT_MODE', 'auto')
+        opt_mode = os.environ.get("CORRIDORKEY_OPT_MODE", "auto")
         _img_size = self._model_resolution
 
         # MLX: unified memory, single engine only
@@ -216,6 +226,7 @@ class ModelManagerMixin:
 
         # Create engines serially (warmup each before creating next)
         import torch
+
         for i in range(len(self._engine_pool), pool_size):
             if on_status:
                 on_status(f"Loading engine {i + 1}/{pool_size}...")
@@ -234,7 +245,9 @@ class ModelManagerMixin:
             except (RuntimeError, torch.cuda.OutOfMemoryError):
                 logger.warning(
                     "OOM creating engine %d/%d, using %d engine(s)",
-                    i + 1, pool_size, len(self._engine_pool),
+                    i + 1,
+                    pool_size,
+                    len(self._engine_pool),
                 )
                 gc.collect()
                 if backend == "torch":
@@ -254,6 +267,7 @@ class ModelManagerMixin:
             return self._gvm_processor
 
         from gvm_core import GVMProcessor
+
         logger.info("Loading GVM processor...")
         t0 = time.monotonic()
         self._gvm_processor = GVMProcessor(device=self._device)
@@ -297,6 +311,7 @@ class ModelManagerMixin:
 
         sys.path.insert(0, os.path.join(BASE_DIR, "VideoMaMaInferenceModule"))
         from VideoMaMaInferenceModule.inference import load_videomama_model
+
         logger.info("Loading VideoMaMa pipeline...")
         t0 = time.monotonic()
         self._videomama_pipeline = load_videomama_model(device=self._device)
@@ -322,8 +337,7 @@ class ModelManagerMixin:
         self._ensure_model(_ActiveModel.BIREFNET, on_status=on_status)
 
         # If already loaded with the same usage, reuse
-        if (self._birefnet_processor is not None
-                and self._birefnet_processor._usage == usage):
+        if self._birefnet_processor is not None and self._birefnet_processor._usage == usage:
             return self._birefnet_processor
 
         # Different variant requested — release the old one
@@ -332,10 +346,12 @@ class ModelManagerMixin:
             self._birefnet_processor = None
 
         from modules.BiRefNetModule.wrapper import BiRefNetProcessor
+
         logger.info(f"Loading BiRefNet ({usage})...")
         t0 = time.monotonic()
         self._birefnet_processor = BiRefNetProcessor(
-            device=self._device, usage=usage,
+            device=self._device,
+            usage=usage,
         )
         # Trigger actual model download/load now so VRAM is claimed
         self._birefnet_processor._ensure_loaded(on_status=on_status)
@@ -359,9 +375,11 @@ class ModelManagerMixin:
         self._birefnet_processor = None
         self._active_model = _ActiveModel.NONE
         import gc as _gc
+
         _gc.collect()
         try:
             import torch
+
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
         except ImportError:

--- a/backend/service/pipelines.py
+++ b/backend/service/pipelines.py
@@ -6,6 +6,7 @@ Split into two sub-modules for maintainability:
 
 This module provides the combined PipelinesMixin for backward compatibility.
 """
+
 from __future__ import annotations
 
 from .pipelines_auto import AutoPipelinesMixin
@@ -14,4 +15,5 @@ from .pipelines_guided import GuidedPipelinesMixin
 
 class PipelinesMixin(AutoPipelinesMixin, GuidedPipelinesMixin):
     """Combined mixin providing all specialized inference pipelines."""
+
     pass

--- a/backend/service/pipelines_auto.py
+++ b/backend/service/pipelines_auto.py
@@ -1,4 +1,5 @@
 """Auto-alpha pipelines — GVM and BiRefNet (no annotations required)."""
+
 from __future__ import annotations
 
 import logging
@@ -34,7 +35,7 @@ class AutoPipelinesMixin:
         if clip.input_asset is None:
             raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for GVM")
 
-        if self._device == 'cpu':
+        if self._device == "cpu":
             raise GPURequiredError("GVM Auto Alpha")
 
         t_start = time.monotonic()
@@ -69,7 +70,7 @@ class AutoPipelinesMixin:
                 num_frames_per_batch=1,
                 decode_chunk_size=1,
                 denoise_steps=1,
-                mode='matte',
+                mode="matte",
                 write_video=False,
                 direct_output_dir=alpha_dir,
                 progress_callback=_gvm_progress,
@@ -82,7 +83,7 @@ class AutoPipelinesMixin:
             raise CorridorKeyError(f"GVM failed for '{clip.name}': {e}") from e
 
         # Refresh alpha asset
-        clip.alpha_asset = ClipAsset(alpha_dir, 'sequence')
+        clip.alpha_asset = ClipAsset(alpha_dir, "sequence")
 
         if on_progress:
             on_progress(clip.name, 1, 1)
@@ -94,7 +95,9 @@ class AutoPipelinesMixin:
             if on_warning:
                 on_warning(f"State transition after GVM: {e}")
 
-        logger.info(f"GVM complete for '{clip.name}': {clip.alpha_asset.frame_count} alpha frames in {time.monotonic() - t_start:.1f}s")
+        logger.info(
+            f"GVM complete for '{clip.name}': {clip.alpha_asset.frame_count} alpha frames in {time.monotonic() - t_start:.1f}s"
+        )
 
     def run_birefnet(
         self,
@@ -113,7 +116,7 @@ class AutoPipelinesMixin:
         if clip.input_asset is None:
             raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for BiRefNet")
 
-        if self._device == 'cpu':
+        if self._device == "cpu":
             raise GPURequiredError("BiRefNet")
 
         def _status(msg: str) -> None:
@@ -171,6 +174,7 @@ class AutoPipelinesMixin:
                 self._active_model = _ActiveModel.NONE
                 try:
                     import torch as _torch
+
                     _torch.cuda.empty_cache()
                 except Exception:
                     pass
@@ -181,7 +185,7 @@ class AutoPipelinesMixin:
             raise
 
         # Phase 4: Finalize
-        clip.alpha_asset = ClipAsset(alpha_dir, 'sequence')
+        clip.alpha_asset = ClipAsset(alpha_dir, "sequence")
 
         try:
             clip.transition_to(ClipState.READY)

--- a/backend/service/pipelines_guided.py
+++ b/backend/service/pipelines_guided.py
@@ -1,4 +1,5 @@
 """Guided pipelines — SAM2, VideoMaMa, MatAnyone2 (require masks/annotations)."""
+
 from __future__ import annotations
 
 import logging
@@ -83,11 +84,14 @@ class GuidedPipelinesMixin:
         )
         _check_cancel()
         if not named_frames:
-            raise CorridorKeyError(f"Clip '{clip.name}' has no readable input frames for SAM2 tracking")
+            raise CorridorKeyError(
+                f"Clip '{clip.name}' has no readable input frames for SAM2 tracking"
+            )
 
         start_index = clip.in_out_range.in_point if clip.in_out_range is not None else 0
         allowed_indices = list(range(start_index, start_index + len(selected_files)))
         from . import load_annotation_prompt_frames
+
         prompt_frames = load_annotation_prompt_frames(
             clip.root_path,
             allowed_indices=allowed_indices,
@@ -108,10 +112,7 @@ class GuidedPipelinesMixin:
             )
             for prompt in prompt_frames
         ]
-        if not any(
-            prompt.positive_points or prompt.box is not None
-            for prompt in local_prompts
-        ):
+        if not any(prompt.positive_points or prompt.box is not None for prompt in local_prompts):
             message = "SAM2 tracking requires at least one non-empty foreground prompt"
             if on_warning:
                 on_warning(message)
@@ -225,6 +226,7 @@ class GuidedPipelinesMixin:
         start_index = clip.in_out_range.in_point if clip.in_out_range is not None else 0
         allowed_indices = list(range(start_index, start_index + len(selected_files)))
         from . import load_annotation_prompt_frames
+
         prompt_frames = load_annotation_prompt_frames(
             clip.root_path,
             allowed_indices=allowed_indices,
@@ -238,7 +240,11 @@ class GuidedPipelinesMixin:
             (item for item in prompt_frames if item.frame_index == preferred_frame_index),
             prompt_frames[0],
         )
-        if preferred_frame_index is not None and prompt.frame_index != preferred_frame_index and on_warning:
+        if (
+            preferred_frame_index is not None
+            and prompt.frame_index != preferred_frame_index
+            and on_warning
+        ):
             on_warning(
                 f"No prompts on frame {preferred_frame_index + 1}; previewing annotated frame {prompt.frame_index + 1} instead."
             )
@@ -259,7 +265,9 @@ class GuidedPipelinesMixin:
         )
         _check_cancel()
         if not named_frames:
-            raise CorridorKeyError(f"Clip '{clip.name}' has no readable input frames for SAM2 tracking")
+            raise CorridorKeyError(
+                f"Clip '{clip.name}' has no readable input frames for SAM2 tracking"
+            )
 
         from sam2_tracker import PromptFrame, SAM2NotInstalledError
 
@@ -321,16 +329,14 @@ class GuidedPipelinesMixin:
         if clip.mask_asset is None:
             raise CorridorKeyError(f"Clip '{clip.name}' missing mask asset for VideoMaMa")
 
-        if self._device == 'cpu':
+        if self._device == "cpu":
             raise GPURequiredError("VideoMaMa")
         if clip.input_asset.asset_type != "sequence":
             raise CorridorKeyError("VideoMaMa currently requires an extracted image sequence")
         ann_path = os.path.join(clip.root_path, "annotations.json")
         has_annotations = os.path.isfile(ann_path) and os.path.getsize(ann_path) > 2
         if has_annotations and not mask_sequence_is_videomama_ready(clip.root_path):
-            raise CorridorKeyError(
-                "VideoMaMa requires dense tracked masks. Run Track Mask first."
-            )
+            raise CorridorKeyError("VideoMaMa requires dense tracked masks. Run Track Mask first.")
 
         def _status(msg: str) -> None:
             logger.info(f"VideoMaMa [{clip.name}]: {msg}")
@@ -370,7 +376,7 @@ class GuidedPipelinesMixin:
         # Phase 3: Load + stem-match masks
         _status("Loading masks...")
         mask_stems: dict[str, np.ndarray] = {}
-        if clip.mask_asset.asset_type == 'sequence':
+        if clip.mask_asset.asset_type == "sequence":
             mask_files = clip.mask_asset.get_frame_files()
             for i, fname in enumerate(mask_files):
                 _check_cancel("mask load")
@@ -402,8 +408,9 @@ class GuidedPipelinesMixin:
         # Resume logic
         existing_alpha = []
         if os.path.isdir(alpha_dir):
-            existing_alpha = [f for f in os.listdir(alpha_dir)
-                              if f.lower().endswith(('.png', '.jpg', '.jpeg'))]
+            existing_alpha = [
+                f for f in os.listdir(alpha_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))
+            ]
         n_existing = len(existing_alpha)
         completed_chunks = n_existing // chunk_size
         start_chunk = max(0, completed_chunks - 1)
@@ -417,8 +424,10 @@ class GuidedPipelinesMixin:
             for fname in existing_alpha:
                 if fname not in keep:
                     os.remove(os.path.join(alpha_dir, fname))
-            logger.info(f"VideoMaMa resuming for '{clip.name}': {n_existing} alpha frames existed, "
-                        f"rolling back to chunk {start_chunk} (frame {start_frame})")
+            logger.info(
+                f"VideoMaMa resuming for '{clip.name}': {n_existing} alpha frames existed, "
+                f"rolling back to chunk {start_chunk} (frame {start_frame})"
+            )
 
         # Phase 4: Inference (per-chunk)
         sys.path.insert(0, os.path.join(BASE_DIR, "VideoMaMaInferenceModule"))
@@ -428,8 +437,9 @@ class GuidedPipelinesMixin:
         _status(f"Running inference (chunk 1/{total_chunks})...")
         frames_written = start_frame
         for chunk_idx, chunk_output in enumerate(
-            run_inference(pipeline, input_frames, mask_frames,
-                          chunk_size=chunk_size, on_status=on_status)
+            run_inference(
+                pipeline, input_frames, mask_frames, chunk_size=chunk_size, on_status=on_status
+            )
         ):
             _check_cancel("inference")
 
@@ -459,13 +469,15 @@ class GuidedPipelinesMixin:
                 if not cv2.imwrite(out_path, out_bgr):
                     raise WriteFailureError(clip.name, frames_written, out_path)
                 frames_written += 1
-            logger.debug(f"Clip '{clip.name}' chunk {chunk_idx}: {len(chunk_output)} frames in {time.monotonic() - t_chunk:.3f}s")
+            logger.debug(
+                f"Clip '{clip.name}' chunk {chunk_idx}: {len(chunk_output)} frames in {time.monotonic() - t_chunk:.3f}s"
+            )
 
             if on_progress:
                 on_progress(clip.name, frames_written, num_frames)
 
         # Refresh alpha asset
-        clip.alpha_asset = ClipAsset(alpha_dir, 'sequence')
+        clip.alpha_asset = ClipAsset(alpha_dir, "sequence")
 
         # Transition MASKED -> READY
         try:
@@ -474,7 +486,9 @@ class GuidedPipelinesMixin:
             if on_warning:
                 on_warning(f"State transition after VideoMaMa: {e}")
 
-        logger.info(f"VideoMaMa complete for '{clip.name}': {frames_written} alpha frames in {time.monotonic() - t_start:.1f}s")
+        logger.info(
+            f"VideoMaMa complete for '{clip.name}': {frames_written} alpha frames in {time.monotonic() - t_start:.1f}s"
+        )
 
     def run_matanyone2(
         self,
@@ -493,7 +507,7 @@ class GuidedPipelinesMixin:
             raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for MatAnyone2")
         if clip.mask_asset is None:
             raise CorridorKeyError(f"Clip '{clip.name}' missing mask asset for MatAnyone2")
-        if self._device == 'cpu':
+        if self._device == "cpu":
             raise GPURequiredError("MatAnyone2")
         if clip.input_asset.asset_type != "sequence":
             raise CorridorKeyError("MatAnyone2 requires an extracted image sequence")
@@ -564,6 +578,7 @@ class GuidedPipelinesMixin:
                 self._active_model = _ActiveModel.NONE
                 try:
                     import torch as _torch
+
                     _torch.cuda.empty_cache()
                 except Exception:
                     pass
@@ -574,7 +589,7 @@ class GuidedPipelinesMixin:
             raise
 
         # Phase 5: Finalize
-        clip.alpha_asset = ClipAsset(alpha_dir, 'sequence')
+        clip.alpha_asset = ClipAsset(alpha_dir, "sequence")
 
         try:
             clip.transition_to(ClipState.READY)

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -2,6 +2,7 @@
 
 All validators either return cleaned data or raise typed exceptions from errors.py.
 """
+
 from __future__ import annotations
 
 import os
@@ -149,11 +150,11 @@ def ensure_output_dirs(output_root: str) -> dict[str, str]:
         Dict with keys: 'root', 'fg', 'matte', 'comp', 'processed'
     """
     dirs = {
-        'root': output_root,
-        'fg': os.path.join(output_root, "FG"),
-        'matte': os.path.join(output_root, "Matte"),
-        'comp': os.path.join(output_root, "Comp"),
-        'processed': os.path.join(output_root, "Processed"),
+        "root": output_root,
+        "fg": os.path.join(output_root, "FG"),
+        "matte": os.path.join(output_root, "Matte"),
+        "comp": os.path.join(output_root, "Comp"),
+        "processed": os.path.join(output_root, "Processed"),
     }
     for d in dirs.values():
         os.makedirs(d, exist_ok=True)

--- a/clip_manager.py
+++ b/clip_manager.py
@@ -15,7 +15,7 @@ import numpy as np
 warnings.filterwarnings("ignore")
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # Core Paths
@@ -28,12 +28,15 @@ OUTPUT_DIR = os.path.join(BASE_DIR, "Output")
 WIN_DRIVE_ROOT = "V:\\"
 LINUX_MOUNT_ROOT = "/mnt/ssd-storage"
 
+
 # --- Helpers ---
 def is_image_file(filename):
-    return filename.lower().endswith(('.png', '.jpg', '.jpeg', '.exr', '.tif', '.tiff', '.bmp'))
+    return filename.lower().endswith((".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff", ".bmp"))
+
 
 def is_video_file(filename):
-    return filename.lower().endswith(('.mp4', '.mov', '.avi', '.mkv'))
+    return filename.lower().endswith((".mp4", ".mov", ".avi", ".mkv"))
+
 
 def map_path(win_path):
     r"""
@@ -41,39 +44,41 @@ def map_path(win_path):
     """
     # Normalize slashes
     win_path = win_path.strip()
-    
+
     # Check if it starts with the drive letter
     if win_path.upper().startswith(WIN_DRIVE_ROOT.upper()):
         # Remove drive letter
-        rel_path = win_path[len(WIN_DRIVE_ROOT):]
+        rel_path = win_path[len(WIN_DRIVE_ROOT) :]
         # Flip slashes
-        rel_path = rel_path.replace('\\', '/')
+        rel_path = rel_path.replace("\\", "/")
         # Combine
         linux_path = os.path.join(LINUX_MOUNT_ROOT, rel_path)
         return linux_path
-    
+
     # If not on V:, maybe it's already a linux path or invalid?
     return win_path
+
 
 # --- Classes ---
 class ClipAsset:
     def __init__(self, path, asset_type):
         self.path = path
-        self.type = asset_type # 'sequence' or 'video'
+        self.type = asset_type  # 'sequence' or 'video'
         self.frame_count = 0
         self._calculate_length()
 
     def _calculate_length(self):
-        if self.type == 'sequence':
+        if self.type == "sequence":
             files = sorted([f for f in os.listdir(self.path) if is_image_file(f)])
             self.frame_count = len(files)
-        elif self.type == 'video':
+        elif self.type == "video":
             cap = cv2.VideoCapture(self.path)
             if not cap.isOpened():
-                self.frame_count = 0 
+                self.frame_count = 0
             else:
                 self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
             cap.release()
+
 
 class ClipEntry:
     def __init__(self, name, root_path):
@@ -81,165 +86,192 @@ class ClipEntry:
         self.root_path = root_path
         self.input_asset = None
         self.alpha_asset = None
-        
+
     def find_assets(self):
         # 1. Look for Input
         input_dir = os.path.join(self.root_path, "Input")
-        
+
         # Check for directory first
         if os.path.isdir(input_dir):
             if not os.listdir(input_dir):
                 raise ValueError(f"Clip '{self.name}': 'Input' directory is empty.")
-            self.input_asset = ClipAsset(input_dir, 'sequence')
+            self.input_asset = ClipAsset(input_dir, "sequence")
         else:
             # Check for video file (Case-Insensitive)
             candidates = glob.glob(os.path.join(self.root_path, "[Ii]nput.*"))
             candidates = [c for c in candidates if is_video_file(c)]
-            
+
             if candidates:
-                self.input_asset = ClipAsset(candidates[0], 'video')
+                self.input_asset = ClipAsset(candidates[0], "video")
             else:
                 # Fallback: Look for ANY video file in the directory
                 all_files = glob.glob(os.path.join(self.root_path, "*"))
                 video_files = [f for f in all_files if is_video_file(f)]
-                
+
                 if video_files:
-                    logger.info(f"Clip '{self.name}': Using '{os.path.basename(video_files[0])}' as Input.")
-                    self.input_asset = ClipAsset(video_files[0], 'video')
+                    logger.info(
+                        f"Clip '{self.name}': Using '{os.path.basename(video_files[0])}' as Input."
+                    )
+                    self.input_asset = ClipAsset(video_files[0], "video")
                 else:
-                    raise ValueError(f"Clip '{self.name}': No 'Input' directory or video file found.")
-        
+                    raise ValueError(
+                        f"Clip '{self.name}': No 'Input' directory or video file found."
+                    )
+
         if self.input_asset.frame_count == 0:
-             raise ValueError(f"Clip '{self.name}': Input asset has 0 frames or could not be read.")
+            raise ValueError(f"Clip '{self.name}': Input asset has 0 frames or could not be read.")
 
         # 2. Look for Alpha
         # Check for 'AlphaHint' or 'alphahint' directory
         alpha_dir_upper = os.path.join(self.root_path, "AlphaHint")
         alpha_dir_lower = os.path.join(self.root_path, "alphahint")
-        
+
         target_alpha_dir = None
-        if os.path.isdir(alpha_dir_upper): target_alpha_dir = alpha_dir_upper
-        elif os.path.isdir(alpha_dir_lower): target_alpha_dir = alpha_dir_lower
-        
+        if os.path.isdir(alpha_dir_upper):
+            target_alpha_dir = alpha_dir_upper
+        elif os.path.isdir(alpha_dir_lower):
+            target_alpha_dir = alpha_dir_lower
+
         if target_alpha_dir:
             if not os.listdir(target_alpha_dir):
-                logging.warning(f"Clip '{self.name}': AlphaHint directory exists but is empty. Marking for generation.")
+                logging.warning(
+                    f"Clip '{self.name}': AlphaHint directory exists but is empty. Marking for generation."
+                )
                 self.alpha_asset = None
             else:
-                self.alpha_asset = ClipAsset(target_alpha_dir, 'sequence')
+                self.alpha_asset = ClipAsset(target_alpha_dir, "sequence")
         else:
             # Check for video file (Case-Insensitive)
             # Match AlphaHint.* or alphahint.*
             candidates = glob.glob(os.path.join(self.root_path, "[Aa]lpha[Hh]int.*"))
             candidates = [c for c in candidates if is_video_file(c)]
-            
+
             if candidates:
-                self.alpha_asset = ClipAsset(candidates[0], 'video')
+                self.alpha_asset = ClipAsset(candidates[0], "video")
             else:
-                self.alpha_asset = None # Missing, needs generation
+                self.alpha_asset = None  # Missing, needs generation
 
     def validate_pair(self):
         if self.input_asset and self.alpha_asset:
             if self.input_asset.frame_count != self.alpha_asset.frame_count:
-                raise ValueError(f"Clip '{self.name}': Frame count mismatch! Input: {self.input_asset.frame_count}, Alpha: {self.alpha_asset.frame_count}")
+                raise ValueError(
+                    f"Clip '{self.name}': Frame count mismatch! Input: {self.input_asset.frame_count}, Alpha: {self.alpha_asset.frame_count}"
+                )
+
 
 # --- Logic ---
 
-def get_gvm_processor(device='cuda'):
+
+def get_gvm_processor(device="cuda"):
     try:
         from gvm_core import GVMProcessor
+
         return GVMProcessor(device=device)
     except ImportError:
-        raise ImportError("Could not import gvm_core. Please ensure 'gvm_core' is in the project root and requirements are installed.")
+        raise ImportError(
+            "Could not import gvm_core. Please ensure 'gvm_core' is in the project root and requirements are installed."
+        )
     except Exception as e:
         raise RuntimeError(f"Failed to initialize GVM Processor: {e}")
 
-def get_corridor_key_engine(device='cuda'):
+
+def get_corridor_key_engine(device="cuda"):
     try:
         from CorridorKeyModule.inference_engine import CorridorKeyEngine
-        
+
         # Auto-detect checkpoint
         ckpt_dir = os.path.join(BASE_DIR, "CorridorKeyModule/checkpoints")
         ckpt_files = glob.glob(os.path.join(ckpt_dir, "*.pth"))
-        
+
         if len(ckpt_files) == 0:
             raise FileNotFoundError(f"No .pth checkpoint found in {ckpt_dir}")
         elif len(ckpt_files) > 1:
-            raise ValueError(f"Multiple checkpoints found in {ckpt_dir}. Please ensure only one exists: {[os.path.basename(f) for f in ckpt_files]}")
-            
+            raise ValueError(
+                f"Multiple checkpoints found in {ckpt_dir}. Please ensure only one exists: {[os.path.basename(f) for f in ckpt_files]}"
+            )
+
         ckpt_path = ckpt_files[0]
         logger.info(f"Using checkpoint: {os.path.basename(ckpt_path)}")
-        
+
         return CorridorKeyEngine(checkpoint_path=ckpt_path, device=device, img_size=2048)
     except Exception as e:
         logger.error(f"Failed to initialize CorridorKey Engine: {e}")
         sys.exit(1)
 
+
 def generate_alphas(clips):
     clips_to_process = [c for c in clips if c.alpha_asset is None]
-    
+
     if not clips_to_process:
         logger.info("All clips have valid Alpha assets. No generation needed.")
         return
 
     logger.info(f"Found {len(clips_to_process)} clips missing Alpha.")
-    
+
     import torch
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
     try:
         processor = get_gvm_processor(device=device)
     except ImportError as e:
         logger.error(f"GVM Import Error: {e}")
-        logger.error("Skipping GVM generation. Please install GVM requirements if you wish to use this feature.")
+        logger.error(
+            "Skipping GVM generation. Please install GVM requirements if you wish to use this feature."
+        )
         return
     except Exception as e:
         logger.error(f"GVM Initialization Error: {e}")
         return
-    
+
     for clip in clips_to_process:
         logger.info(f"Generating Alpha for: {clip.name}")
-        
+
         alpha_output_dir = os.path.join(clip.root_path, "AlphaHint")
         if os.path.exists(alpha_output_dir):
             shutil.rmtree(alpha_output_dir)
         os.makedirs(alpha_output_dir, exist_ok=True)
-        
+
         try:
             processor.process_sequence(
                 input_path=clip.input_asset.path,
                 output_dir=None,
-                num_frames_per_batch=1, 
+                num_frames_per_batch=1,
                 decode_chunk_size=1,
                 denoise_steps=1,
-                mode='matte',
+                mode="matte",
                 write_video=False,
-                direct_output_dir=alpha_output_dir
+                direct_output_dir=alpha_output_dir,
             )
-            
+
             # Post-Process: Naming Convention
-            generated_files = sorted([f for f in os.listdir(alpha_output_dir) if f.endswith('.png')])
-            
+            generated_files = sorted(
+                [f for f in os.listdir(alpha_output_dir) if f.endswith(".png")]
+            )
+
             if not generated_files:
-                 logger.error(f"GVM finished but no PNGs found in {alpha_output_dir}")
-                 continue
-            
-            if clip.input_asset.type == 'sequence':
-                in_files = sorted([f for f in os.listdir(clip.input_asset.path) if is_image_file(f)])
+                logger.error(f"GVM finished but no PNGs found in {alpha_output_dir}")
+                continue
+
+            if clip.input_asset.type == "sequence":
+                in_files = sorted(
+                    [f for f in os.listdir(clip.input_asset.path) if is_image_file(f)]
+                )
                 stems = [os.path.splitext(f)[0] for f in in_files]
             else:
                 base_name = os.path.splitext(os.path.basename(clip.input_asset.path))[0]
                 stems = [base_name] * len(generated_files)
 
             for i, gvm_file in enumerate(generated_files):
-                if i >= len(stems): break 
-                
+                if i >= len(stems):
+                    break
+
                 stem = stems[i]
                 new_name = f"{stem}_alphaHint_{i:04d}.png"
-                
+
                 old_path = os.path.join(alpha_output_dir, gvm_file)
                 new_path = os.path.join(alpha_output_dir, new_name)
-                
+
                 if old_path != new_path:
                     os.rename(old_path, new_path)
 
@@ -248,7 +280,9 @@ def generate_alphas(clips):
         except Exception as e:
             logger.error(f"Error generating alpha for {clip.name}: {e}")
             import traceback
+
             traceback.print_exc()
+
 
 def run_videomama(clips, chunk_size=50):
     """
@@ -257,30 +291,30 @@ def run_videomama(clips, chunk_size=50):
     # Process if:
     # 1. Has VideoMamaMaskHint (File or Folder, Case-Insensitive)
     # 2. AND (Alpha is Missing OR Alpha is a Video File we want to upgrade)
-    
+
     clips_to_process = []
-    clip_mask_paths = {} # Store the resolved mask path for each clip
-    
+    clip_mask_paths = {}  # Store the resolved mask path for each clip
+
     for c in clips:
         # Search for 'videomamamaskhint' asset (Strict: videomamamaskhint.ext or VideoMamaMaskHint/)
         candidates = []
         for f in os.listdir(c.root_path):
-             stem, _ = os.path.splitext(f)
-             if stem.lower() == "videomamamaskhint":
-                 candidates.append(f)
-        
+            stem, _ = os.path.splitext(f)
+            if stem.lower() == "videomamamaskhint":
+                candidates.append(f)
+
         mask_asset_path = None
         has_mask = False
-        
+
         # Priority: Directory > Video File
         # Check directories first
         for cand in candidates:
-             path = os.path.join(c.root_path, cand)
-             if os.path.isdir(path) and len(os.listdir(path)) > 0:
-                 has_mask = True
-                 mask_asset_path = path
-                 break 
-        
+            path = os.path.join(c.root_path, cand)
+            if os.path.isdir(path) and len(os.listdir(path)) > 0:
+                has_mask = True
+                mask_asset_path = path
+                break
+
         # If no directory, check files
         if not has_mask:
             for cand in candidates:
@@ -289,55 +323,59 @@ def run_videomama(clips, chunk_size=50):
                     has_mask = True
                     mask_asset_path = path
                     break
-        
-        if not has_mask: continue
-        
+
+        if not has_mask:
+            continue
+
         # Store for later
         clip_mask_paths[c.name] = mask_asset_path
 
         if c.alpha_asset is None:
             clips_to_process.append(c)
-        elif c.alpha_asset.type == 'video':
+        elif c.alpha_asset.type == "video":
             clips_to_process.append(c)
-            
+
     if not clips_to_process:
-        logger.info(f"No candidates for VideoMaMa (looking for VideoMamaMaskHint + [NoAlpha OR VideoAlpha]).")
+        logger.info(
+            "No candidates for VideoMaMa (looking for VideoMamaMaskHint + [NoAlpha OR VideoAlpha])."
+        )
         return
 
     logger.info(f"Found {len(clips_to_process)} clips for VideoMaMa processing.")
-    
+
     # Import locally...
     try:
         sys.path.append(os.path.join(BASE_DIR, "VideoMaMaInferenceModule"))
         from VideoMaMaInferenceModule.inference import load_videomama_model, run_inference
-        from VideoMaMaInferenceModule.pipeline import VideoInferencePipeline
     except ImportError as e:
         logger.error(f"Failed to import VideoMaMa: {e}")
         return
 
     import torch
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
     logger.info("Loading VideoMaMa Pipeline...")
     pipeline = load_videomama_model(device=device)
-    
+
     for clip in clips_to_process:
         logger.info(f"Running VideoMaMa on: {clip.name}")
-        
+
         # Retrieve resolved path
         mask_hint_path = clip_mask_paths[clip.name]
         logger.info(f"  Using VideoMamaMaskHint: {os.path.basename(mask_hint_path)}")
-        
+
         alpha_output_dir = os.path.join(clip.root_path, "AlphaHint")
-        
+
         # Load Inputs
         # 1. Input Frames (RGB)
         input_frames = []
-        if clip.input_asset.type == 'video':
+        if clip.input_asset.type == "video":
             cap = cv2.VideoCapture(clip.input_asset.path)
             while True:
                 ret, frame = cap.read()
-                if not ret: break
+                if not ret:
+                    break
                 input_frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
             cap.release()
         else:
@@ -345,13 +383,13 @@ def run_videomama(clips, chunk_size=50):
             for f in files:
                 fpath = os.path.join(clip.input_asset.path, f)
                 # Handle EXR (Float 0-1) vs Standard (Int 0-255)
-                if f.lower().endswith('.exr'):
+                if f.lower().endswith(".exr"):
                     img = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
                     if img is not None:
                         # Normalize Float 0-1
                         img = np.clip(img, 0.0, 1.0)
                         # Linear -> sRGB (Gamma 2.2 Approximation) for VideoMaMa
-                        img = img ** (1.0/2.2)
+                        img = img ** (1.0 / 2.2)
                         # 0-255 uint8
                         img = (img * 255.0).astype(np.uint8)
                         # Ensure 3 channels
@@ -364,12 +402,14 @@ def run_videomama(clips, chunk_size=50):
 
                 if img is not None:
                     if len(input_frames) == 0:
-                        logger.info(f"Debug Input Frame 0 stats: Min={img.min()}, Max={img.max()}, Mean={img.mean()}")
+                        logger.info(
+                            f"Debug Input Frame 0 stats: Min={img.min()}, Max={img.max()}, Mean={img.mean()}"
+                        )
                     input_frames.append(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
-                    
+
         # 2. Mask Frames
         mask_frames = []
-        
+
         # Check if VideoMamaMaskHint is a directory or a file (video)
         if os.path.isdir(mask_hint_path):
             # Directory of Images
@@ -377,12 +417,13 @@ def run_videomama(clips, chunk_size=50):
             for f in mask_files:
                 fpath = os.path.join(mask_hint_path, f)
                 m = None
-                
+
                 # Handle EXR Masks
-                if f.lower().endswith('.exr'):
+                if f.lower().endswith(".exr"):
                     m = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
                     if m is not None:
-                        if m.ndim == 3: m = m[:, :, 0]
+                        if m.ndim == 3:
+                            m = m[:, :, 0]
                         m = np.clip(m, 0.0, 1.0)
                         m = (m * 255.0).astype(np.uint8)
                 else:
@@ -393,24 +434,27 @@ def run_videomama(clips, chunk_size=50):
                     # Force Binary Thresholding
                     _, m = cv2.threshold(m, 10, 255, cv2.THRESH_BINARY)
                     mask_frames.append(m)
-                    
+
         elif os.path.isfile(mask_hint_path):
-             # Handle Video File
-             cap = cv2.VideoCapture(mask_hint_path)
-             while True:
-                 ret, frame = cap.read()
-                 if not ret: break
-                 # Convert to Grayscale
-                 m = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-                 # Force Binary Thresholding
-                 _, m = cv2.threshold(m, 10, 255, cv2.THRESH_BINARY)
-                 mask_frames.append(m)
-             cap.release()
-             
+            # Handle Video File
+            cap = cv2.VideoCapture(mask_hint_path)
+            while True:
+                ret, frame = cap.read()
+                if not ret:
+                    break
+                # Convert to Grayscale
+                m = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+                # Force Binary Thresholding
+                _, m = cv2.threshold(m, 10, 255, cv2.THRESH_BINARY)
+                mask_frames.append(m)
+            cap.release()
+
         if mask_frames:
-             m0 = mask_frames[0]
-             logger.info(f"Debug Mask Frame 0 stats (Thresholded): Min={m0.min()}, Max={m0.max()}, Mean={m0.mean()}")
-        
+            m0 = mask_frames[0]
+            logger.info(
+                f"Debug Mask Frame 0 stats (Thresholded): Min={m0.min()}, Max={m0.max()}, Mean={m0.mean()}"
+            )
+
         # Validate Lengths
         num_frames = min(len(input_frames), len(mask_frames))
         input_frames = input_frames[:num_frames]
@@ -419,7 +463,7 @@ def run_videomama(clips, chunk_size=50):
         if num_frames == 0:
             logger.error(f"Skipping {clip.name}: No valid frame pairs found.")
             continue
-            
+
         # Run Inference
         try:
             # Prepare Output Directory First
@@ -427,78 +471,95 @@ def run_videomama(clips, chunk_size=50):
             if os.path.exists(alpha_output_dir) and not os.path.isdir(alpha_output_dir):
                 logger.warning(f"Removing file '{alpha_output_dir}' to create directory.")
                 os.remove(alpha_output_dir)
-            
+
             # If there was a Video Alpha Asset (e.g. AlphaHint.mp4), rename it to backup so it doesn't conflict
-            if clip.alpha_asset and clip.alpha_asset.type == 'video':
+            if clip.alpha_asset and clip.alpha_asset.type == "video":
                 old_path = clip.alpha_asset.path
                 if os.path.exists(old_path):
                     dir_name = os.path.dirname(old_path)
                     base, ext = os.path.splitext(os.path.basename(old_path))
                     backup_path = os.path.join(dir_name, f"{base}_backup{ext}")
-                    logger.info(f"Backing up existing Alpha Video: {os.path.basename(old_path)} -> {os.path.basename(backup_path)}")
+                    logger.info(
+                        f"Backing up existing Alpha Video: {os.path.basename(old_path)} -> {os.path.basename(backup_path)}"
+                    )
                     os.rename(old_path, backup_path)
                     # Clear it from memory so we rely on the new one
                     clip.alpha_asset = None
 
             os.makedirs(alpha_output_dir, exist_ok=True)
-            
+
             # Name setup
-            if clip.input_asset.type == 'sequence':
-                 in_names = sorted([os.path.splitext(f)[0] for f in os.listdir(clip.input_asset.path) if is_image_file(f)])
+            if clip.input_asset.type == "sequence":
+                in_names = sorted(
+                    [
+                        os.path.splitext(f)[0]
+                        for f in os.listdir(clip.input_asset.path)
+                        if is_image_file(f)
+                    ]
+                )
             else:
-                 stem = os.path.splitext(os.path.basename(clip.input_asset.path))[0]
-                 in_names = [f"{stem}_{i:05d}" for i in range(num_frames)]
-            
+                stem = os.path.splitext(os.path.basename(clip.input_asset.path))[0]
+                in_names = [f"{stem}_{i:05d}" for i in range(num_frames)]
+
             total_saved = 0
-            
+
             # Iterate generator
-            for chunk_frames in run_inference(pipeline, input_frames, mask_frames, chunk_size=chunk_size):
+            for chunk_frames in run_inference(
+                pipeline, input_frames, mask_frames, chunk_size=chunk_size
+            ):
                 for frame in chunk_frames:
-                    if total_saved >= len(in_names): break
-                    
+                    if total_saved >= len(in_names):
+                        break
+
                     if total_saved == 0:
-                        logger.info(f"Debug Output Frame 0 stats: Min={frame.min()}, Max={frame.max()}, Mean={frame.mean()}, Shape={frame.shape}, Dtype={frame.dtype}")
-                    
+                        logger.info(
+                            f"Debug Output Frame 0 stats: Min={frame.min()}, Max={frame.max()}, Mean={frame.mean()}, Shape={frame.shape}, Dtype={frame.dtype}"
+                        )
+
                     name = in_names[total_saved]
                     out_path = os.path.join(alpha_output_dir, f"{name}.png")
-                    
+
                     # Convert to BGR and Save
                     cv2.imwrite(out_path, cv2.cvtColor(frame, cv2.COLOR_RGB2BGR))
                     total_saved += 1
-                
+
                 logger.info(f"  Saved {total_saved}/{num_frames} frames...")
 
             logger.info(f"VideoMaMa Complete: Saved {total_saved} frames to AlphaHint.")
-            
+
             # Update clip state in memory (dummy) - re-scan will pick it up properly
-            clip.alpha_asset = ClipAsset(alpha_output_dir, 'sequence')
-            
+            clip.alpha_asset = ClipAsset(alpha_output_dir, "sequence")
+
         except Exception as e:
             logger.error(f"VideoMaMa failed for {clip.name}: {e}")
             import traceback
+
             traceback.print_exc()
+
 
 def run_inference(clips):
     ready_clips = [c for c in clips if c.input_asset and c.alpha_asset]
-    
+
     if not ready_clips:
-        logger.info("No clips found with both Input and Alpha assets. Run generate_coarse_alpha first?")
+        logger.info(
+            "No clips found with both Input and Alpha assets. Run generate_coarse_alpha first?"
+        )
         return
 
     logger.info(f"Found {len(ready_clips)} clips ready for inference.")
-    
+
     # --- User Prompts ---
     print("\n--- Inference Settings ---")
-    
+
     # 1. Gamma Prompt
     user_input_is_linear = False
     gamma_choice = input("Is the input sequence Linear (l) or sRGB (s)? [l/s]: ").strip().lower()
-    if gamma_choice == 'l':
+    if gamma_choice == "l":
         user_input_is_linear = True
         logger.info("User selected: Linear Input")
     else:
         logger.info("User selected: sRGB Input (or default)")
-        
+
     # 2. Despill Prompt
     despill_val = input("Enter Despill Strength (0-10, 10 is max despill) [default 10]: ").strip()
     try:
@@ -506,28 +567,36 @@ def run_inference(clips):
         despill_int = max(0, min(10, despill_int))
     except ValueError:
         despill_int = 10
-    
+
     despill_strength = despill_int / 10.0
     logger.info(f"User selected: Despill Strength {despill_int}/10 ({despill_strength})")
     # 3. Auto-Despeckle Prompt
     auto_despeckle = True
     despeckle_size = 400
-    despeckle_choice = input("Enable Auto-Despeckle (removes tracking dots in Processed/Comp)? [Y/n]: ").strip().lower()
-    if despeckle_choice == 'n':
+    despeckle_choice = (
+        input("Enable Auto-Despeckle (removes tracking dots in Processed/Comp)? [Y/n]: ")
+        .strip()
+        .lower()
+    )
+    if despeckle_choice == "n":
         auto_despeckle = False
         logger.info("User selected: Auto-Despeckle OFF")
     else:
         logger.info("User selected: Auto-Despeckle ON (default)")
-        size_val = input("Enter Auto-Despeckle Size (min pixels for a spot) [default 400]: ").strip()
+        size_val = input(
+            "Enter Auto-Despeckle Size (min pixels for a spot) [default 400]: "
+        ).strip()
         try:
             val_int = int(size_val)
             despeckle_size = max(0, val_int)
         except ValueError:
             despeckle_size = 400
         logger.info(f"User selected: Auto-Despeckle Size {despeckle_size}px")
-        
+
     # 4. Refiner Strength Prompt
-    refiner_val = input("Enter Refiner Strength (multiplier) [default 1.0] (experimental): ").strip()
+    refiner_val = input(
+        "Enter Refiner Strength (multiplier) [default 1.0] (experimental): "
+    ).strip()
     if refiner_val == "":
         refiner_scale = 1.0
     else:
@@ -538,113 +607,123 @@ def run_inference(clips):
     logger.info(f"User selected: Refiner Strength {refiner_scale}")
 
     print("--------------------------\n")
-    
+
     # Ensure Output Directory exists
     if not os.path.exists(OUTPUT_DIR):
         os.makedirs(OUTPUT_DIR, exist_ok=True)
 
     import torch
     import numpy as np
-    
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     engine = get_corridor_key_engine(device=device)
 
     for clip in ready_clips:
         logger.info(f"Running Inference on: {clip.name}")
-        
+
         # Setup Outputs in ClipFolder/Output/...
         clip_out_root = os.path.join(clip.root_path, "Output")
         fg_dir = os.path.join(clip_out_root, "FG")
         matte_dir = os.path.join(clip_out_root, "Matte")
         comp_dir = os.path.join(clip_out_root, "Comp")
         proc_dir = os.path.join(clip_out_root, "Processed")
-        
+
         for d in [fg_dir, matte_dir, comp_dir, proc_dir]:
             os.makedirs(d, exist_ok=True)
-            
+
         input_count = clip.input_asset.frame_count
         alpha_count = clip.alpha_asset.frame_count
         if input_count != alpha_count:
-            logger.warning(f"Clip '{clip.name}': frame count mismatch — input has {input_count}, alpha has {alpha_count}. Truncating to {min(input_count, alpha_count)}.")
+            logger.warning(
+                f"Clip '{clip.name}': frame count mismatch — input has {input_count}, alpha has {alpha_count}. Truncating to {min(input_count, alpha_count)}."
+            )
         num_frames = min(input_count, alpha_count)
         skipped_frames = []
-        
+
         input_cap = None
         alpha_cap = None
         input_files = []
         alpha_files = []
-        
-        if clip.input_asset.type == 'video':
+
+        if clip.input_asset.type == "video":
             input_cap = cv2.VideoCapture(clip.input_asset.path)
         else:
             input_files = sorted([f for f in os.listdir(clip.input_asset.path) if is_image_file(f)])
-            
-        if clip.alpha_asset.type == 'video':
+
+        if clip.alpha_asset.type == "video":
             alpha_cap = cv2.VideoCapture(clip.alpha_asset.path)
         else:
             alpha_files = sorted([f for f in os.listdir(clip.alpha_asset.path) if is_image_file(f)])
-            
+
         for i in range(num_frames):
             if i % 10 == 0:
-                 print(f"  Frame {i}/{num_frames}...", end='\r')
-                 
+                print(f"  Frame {i}/{num_frames}...", end="\r")
+
             # 1. Read Input
             img_srgb = None
             input_stem = f"{i:05d}"
-            
+
             # Use the user-defined gamma
             input_is_linear = user_input_is_linear
-            
+
             if input_cap:
                 ret, frame = input_cap.read()
-                if not ret: break
+                if not ret:
+                    break
                 img_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                 img_srgb = img_rgb.astype(np.float32) / 255.0
-                input_stem = f"{i:05d}" 
+                input_stem = f"{i:05d}"
             else:
                 fpath = os.path.join(clip.input_asset.path, input_files[i])
                 input_stem = os.path.splitext(input_files[i])[0]
-                
-                is_exr = fpath.lower().endswith('.exr')
+
+                is_exr = fpath.lower().endswith(".exr")
                 if is_exr:
                     img_linear = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
                     if img_linear is None:
-                        logger.warning(f"Clip '{clip.name}': failed to read input frame {i} ({fpath}), skipping.")
+                        logger.warning(
+                            f"Clip '{clip.name}': failed to read input frame {i} ({fpath}), skipping."
+                        )
                         skipped_frames.append(i)
                         continue
                     img_linear_rgb = cv2.cvtColor(img_linear, cv2.COLOR_BGR2RGB)
                     # Support overriding EXR behavior if user picked 's'
-                    img_srgb = np.maximum(img_linear_rgb, 0.0) 
+                    img_srgb = np.maximum(img_linear_rgb, 0.0)
                 else:
                     img_bgr = cv2.imread(fpath)
                     if img_bgr is None:
-                        logger.warning(f"Clip '{clip.name}': failed to read input frame {i} ({fpath}), skipping.")
+                        logger.warning(
+                            f"Clip '{clip.name}': failed to read input frame {i} ({fpath}), skipping."
+                        )
                         skipped_frames.append(i)
                         continue
                     img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
                     img_srgb = img_rgb.astype(np.float32) / 255.0
-            
+
             # 2. Read Alpha (Mask)
             mask_linear = None
             if alpha_cap:
                 ret, frame = alpha_cap.read()
-                if not ret: break
-                mask_linear = frame[:, :, 2].astype(np.float32) / 255.0 
+                if not ret:
+                    break
+                mask_linear = frame[:, :, 2].astype(np.float32) / 255.0
             else:
                 fpath = os.path.join(clip.alpha_asset.path, alpha_files[i])
                 mask_in = cv2.imread(fpath, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED)
-                
+
                 if mask_in is None:
-                    logger.warning(f"Clip '{clip.name}': failed to read alpha frame {i} ({fpath}), skipping.")
+                    logger.warning(
+                        f"Clip '{clip.name}': failed to read alpha frame {i} ({fpath}), skipping."
+                    )
                     skipped_frames.append(i)
                     continue
-                
+
                 if mask_in.ndim == 3:
-                     # Always extract first channel regardless of channel count (3ch, 4ch, 2ch EXR)
-                     mask_linear = mask_in[:, :, 0]
+                    # Always extract first channel regardless of channel count (3ch, 4ch, 2ch EXR)
+                    mask_linear = mask_in[:, :, 0]
                 else:
                     mask_linear = mask_in
-                
+
                 if mask_linear.dtype == np.uint8:
                     mask_linear = mask_linear.astype(np.float32) / 255.0
                 elif mask_linear.dtype == np.uint16:
@@ -653,24 +732,28 @@ def run_inference(clips):
                     mask_linear = mask_linear.astype(np.float32)
 
             if mask_linear.shape[:2] != img_srgb.shape[:2]:
-                 mask_linear = cv2.resize(mask_linear, (img_srgb.shape[1], img_srgb.shape[0]), interpolation=cv2.INTER_LINEAR)
-            
+                mask_linear = cv2.resize(
+                    mask_linear,
+                    (img_srgb.shape[1], img_srgb.shape[0]),
+                    interpolation=cv2.INTER_LINEAR,
+                )
+
             # 3. Process
             USE_STRAIGHT_MODEL = True
             res = engine.process_frame(
-                img_srgb, 
-                mask_linear, 
-                input_is_linear=input_is_linear, 
+                img_srgb,
+                mask_linear,
+                input_is_linear=input_is_linear,
                 fg_is_straight=USE_STRAIGHT_MODEL,
                 despill_strength=despill_strength,
                 auto_despeckle=auto_despeckle,
                 despeckle_size=despeckle_size,
-                refiner_scale=refiner_scale
+                refiner_scale=refiner_scale,
             )
-            
-            pred_fg = res['fg'] # sRGB
-            pred_alpha = res['alpha'] # Linear
-            
+
+            pred_fg = res["fg"]  # sRGB
+            pred_alpha = res["alpha"]  # Linear
+
             # 4. Save (EXR DWAB Half-Float via OpenEXR library)
             from backend.frame_io import write_exr_dwab
 
@@ -682,46 +765,58 @@ def run_inference(clips):
                 logger.error(f"Clip '{clip.name}': failed to write FG frame {i} ({fg_path})")
 
             # Save Matte
-            if pred_alpha.ndim == 3: pred_alpha = pred_alpha[:, :, 0]
+            if pred_alpha.ndim == 3:
+                pred_alpha = pred_alpha[:, :, 0]
             # Matte is single channel linear float
             matte_path = os.path.join(matte_dir, f"{input_stem}.exr")
             if not write_exr_dwab(matte_path, pred_alpha):
                 logger.error(f"Clip '{clip.name}': failed to write Matte frame {i} ({matte_path})")
 
             # 5. Generate Reference Comp
-            comp_srgb = res['comp']
+            comp_srgb = res["comp"]
             # Save Comp (PNG 8-bit)
-            comp_bgr = cv2.cvtColor((np.clip(comp_srgb, 0.0, 1.0) * 255.0).astype(np.uint8), cv2.COLOR_RGB2BGR)
+            comp_bgr = cv2.cvtColor(
+                (np.clip(comp_srgb, 0.0, 1.0) * 255.0).astype(np.uint8), cv2.COLOR_RGB2BGR
+            )
             comp_path = os.path.join(comp_dir, f"{input_stem}.png")
             if not cv2.imwrite(comp_path, comp_bgr):
                 logger.error(f"Clip '{clip.name}': failed to write Comp frame {i} ({comp_path})")
 
             # 6. Save Processed (RGBA EXR)
-            if 'processed' in res:
+            if "processed" in res:
                 # Result is RGBA
-                proc_rgba = res['processed']
+                proc_rgba = res["processed"]
                 # Convert to BGRA for write_exr_dwab
                 proc_bgra = cv2.cvtColor(proc_rgba, cv2.COLOR_RGBA2BGRA)
                 proc_path = os.path.join(proc_dir, f"{input_stem}.exr")
                 if not write_exr_dwab(proc_path, proc_bgra):
-                    logger.error(f"Clip '{clip.name}': failed to write Processed frame {i} ({proc_path})")
+                    logger.error(
+                        f"Clip '{clip.name}': failed to write Processed frame {i} ({proc_path})"
+                    )
 
         print("")
-        if input_cap: input_cap.release()
-        if alpha_cap: alpha_cap.release()
+        if input_cap:
+            input_cap.release()
+        if alpha_cap:
+            alpha_cap.release()
         if skipped_frames:
-            logger.warning(f"Clip '{clip.name}': {len(skipped_frames)} frame(s) skipped due to read failures: {skipped_frames[:20]}{'...' if len(skipped_frames) > 20 else ''}")
-        logger.info(f"Clip {clip.name} Complete. Processed {num_frames - len(skipped_frames)}/{num_frames} frames.")
+            logger.warning(
+                f"Clip '{clip.name}': {len(skipped_frames)} frame(s) skipped due to read failures: {skipped_frames[:20]}{'...' if len(skipped_frames) > 20 else ''}"
+            )
+        logger.info(
+            f"Clip {clip.name} Complete. Processed {num_frames - len(skipped_frames)}/{num_frames} frames."
+        )
+
 
 def organize_target(target_dir):
     """
-    Organizes a specific folder. 
+    Organizes a specific folder.
     1. If loose video -> Rename to Input.ext (if safe).
     2. If sequence -> Move to Input/.
     3. Ensure AlphaHint and VideoMamaMaskHint folders exist.
     """
     logger.info(f"Organizing Target: {target_dir}")
-    
+
     if not os.path.exists(target_dir):
         logger.error(f"Target directory not found: {target_dir}")
         return
@@ -730,35 +825,42 @@ def organize_target(target_dir):
     # Strategy: Find largest video file that ISN'T named Input.*
     candidates = [f for f in os.listdir(target_dir) if is_video_file(f)]
     candidates = [f for f in candidates if not os.path.splitext(f)[0].lower() == "input"]
-    
+
     if candidates and not os.path.exists(os.path.join(target_dir, "Input")):
         # If multiple, pick largest (heuristic for 'Main Plate')
         candidates.sort(key=lambda f: os.path.getsize(os.path.join(target_dir, f)), reverse=True)
         main_clip = candidates[0]
         ext = os.path.splitext(main_clip)[1]
-        
+
         try:
-            shutil.move(os.path.join(target_dir, main_clip), os.path.join(target_dir, f"Input{ext}"))
+            shutil.move(
+                os.path.join(target_dir, main_clip), os.path.join(target_dir, f"Input{ext}")
+            )
             logger.info(f"Renamed '{main_clip}' to 'Input{ext}'")
         except Exception as e:
             logger.error(f"Failed to rename '{main_clip}': {e}")
-            
+
     # Check for Image Sequence (Flat)
     # Only if Input folder doesn't exist and Input video doesn't exist
     has_input_dir = os.path.isdir(os.path.join(target_dir, "Input"))
-    has_input_video = any(is_video_file(f) and os.path.basename(f).lower().startswith("input") for f in os.listdir(target_dir))
-    
+    has_input_video = any(
+        is_video_file(f) and os.path.basename(f).lower().startswith("input")
+        for f in os.listdir(target_dir)
+    )
+
     if not has_input_dir and not has_input_video:
         all_files = sorted(glob.glob(os.path.join(target_dir, "*")))
         image_files = [f for f in all_files if is_image_file(f)]
-        
+
         if len(image_files) > 0:
             try:
                 input_subdir = os.path.join(target_dir, "Input")
                 os.makedirs(input_subdir)
                 for img in image_files:
                     shutil.move(img, os.path.join(input_subdir, os.path.basename(img)))
-                logger.info(f"Organized: Moved {len(image_files)} images in '{os.path.basename(target_dir)}' to 'Input/'")
+                logger.info(
+                    f"Organized: Moved {len(image_files)} images in '{os.path.basename(target_dir)}' to 'Input/'"
+                )
             except Exception as e:
                 logger.error(f"Failed to organize sequence in '{target_dir}': {e}")
 
@@ -771,6 +873,7 @@ def organize_target(target_dir):
             # with open(os.path.join(hint_path, "_place_sequence_here.txt"), 'w') as f:
             #     f.write("Place your image sequence here.")
 
+
 def organize_clips(clips_dir):
     """
     Legacy wrapper for backward compatibility with 'ClipsForInference' folder.
@@ -781,55 +884,62 @@ def organize_clips(clips_dir):
         return
 
     logger.info(f"Organizing Clips Directory: {clips_dir}")
-    
+
     # Check for loose videos in root
-    loose_videos = [f for f in os.listdir(clips_dir) if is_video_file(f) and os.path.isfile(os.path.join(clips_dir, f))]
-    
+    loose_videos = [
+        f
+        for f in os.listdir(clips_dir)
+        if is_video_file(f) and os.path.isfile(os.path.join(clips_dir, f))
+    ]
+
     # Organize loose videos first
     for v in loose_videos:
-         clip_name = os.path.splitext(v)[0]
-         ext = os.path.splitext(v)[1]
-         target_folder = os.path.join(clips_dir, clip_name)
-         
-         if os.path.exists(target_folder):
-             logger.warning(f"Skipping loose video '{v}': Target folder '{clip_name}' already exists.")
-             continue
-             
-         try:
-             os.makedirs(target_folder)
-             target_file = os.path.join(target_folder, f"Input{ext}")
-             shutil.move(os.path.join(clips_dir, v), target_file)
-             logger.info(f"Organized: Moved '{v}' to '{clip_name}/Input{ext}'")
-             
-             # Also initialize hints immediately
-             for hint in ["AlphaHint", "VideoMamaMaskHint"]:
+        clip_name = os.path.splitext(v)[0]
+        ext = os.path.splitext(v)[1]
+        target_folder = os.path.join(clips_dir, clip_name)
+
+        if os.path.exists(target_folder):
+            logger.warning(
+                f"Skipping loose video '{v}': Target folder '{clip_name}' already exists."
+            )
+            continue
+
+        try:
+            os.makedirs(target_folder)
+            target_file = os.path.join(target_folder, f"Input{ext}")
+            shutil.move(os.path.join(clips_dir, v), target_file)
+            logger.info(f"Organized: Moved '{v}' to '{clip_name}/Input{ext}'")
+
+            # Also initialize hints immediately
+            for hint in ["AlphaHint", "VideoMamaMaskHint"]:
                 os.makedirs(os.path.join(target_folder, hint), exist_ok=True)
-         except Exception as e:
-             logger.error(f"Failed to organize video '{v}': {e}")
-             
+        except Exception as e:
+            logger.error(f"Failed to organize video '{v}': {e}")
+
     # Now iterate all subdirectories and run organize_target
     for entry in os.listdir(clips_dir):
         full_path = os.path.join(clips_dir, entry)
         if os.path.isdir(full_path) and entry not in ["IgnoredClips", "Output"]:
             organize_target(full_path)
 
+
 def interactive_wizard(win_path):
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print(" CORRIDOR KEY - SMART WIZARD")
-    print("="*60)
-    
+    print("=" * 60)
+
     # 1. Map Path
     linux_path = map_path(win_path)
     print(f"Windows Path: {win_path}")
     print(f"Linux Path:   {linux_path}")
-    
+
     if not os.path.exists(linux_path):
-        print(f"\n[ERROR] Path does not exist!")
+        print("\n[ERROR] Path does not exist!")
         return
 
     # If user dragged a single video file, use its parent directory
     if os.path.isfile(linux_path) and is_video_file(linux_path):
-        print(f"\nDetected single video file — using parent directory.")
+        print("\nDetected single video file — using parent directory.")
         linux_path = os.path.dirname(linux_path)
         print(f"Working in: {linux_path}")
     elif os.path.isfile(linux_path):
@@ -840,111 +950,140 @@ def interactive_wizard(win_path):
     # We treat linux_path as the ROOT containing SHOTS
     # Or is linux_path the SHOT itself?
     # HEURISTIC: If it contains "Input", it's a shot. If it contains folders, it's a project.
-    
+
     # Let's assume it's a folder containing CLIPS (Batch Mode)
     # But if the user drops it IN a shot folder, we should handle that too.
-    
+
     target_is_shot = False
-    if os.path.exists(os.path.join(linux_path, "Input")) or glob.glob(os.path.join(linux_path, "Input.*")):
-         target_is_shot = True
-    
+    if os.path.exists(os.path.join(linux_path, "Input")) or glob.glob(
+        os.path.join(linux_path, "Input.*")
+    ):
+        target_is_shot = True
+
     work_dirs = []
     if target_is_shot:
         work_dirs = [linux_path]
     else:
         # Scan subfolders
-        work_dirs = [os.path.join(linux_path, d) for d in os.listdir(linux_path) if os.path.isdir(os.path.join(linux_path, d))]
+        work_dirs = [
+            os.path.join(linux_path, d)
+            for d in os.listdir(linux_path)
+            if os.path.isdir(os.path.join(linux_path, d))
+        ]
         # Filter out output/hints
-        work_dirs = [d for d in work_dirs if os.path.basename(d) not in ["Output", "AlphaHint", "VideoMamaMaskHint", ".ipynb_checkpoints"]]
-    
+        work_dirs = [
+            d
+            for d in work_dirs
+            if os.path.basename(d)
+            not in ["Output", "AlphaHint", "VideoMamaMaskHint", ".ipynb_checkpoints"]
+        ]
+
     print(f"\nFound {len(work_dirs)} potential clip folders.")
-    
+
     # Check for loose videos in root
-    loose_videos = [f for f in os.listdir(linux_path) if is_video_file(f) and os.path.isfile(os.path.join(linux_path, f))]
-    
+    loose_videos = [
+        f
+        for f in os.listdir(linux_path)
+        if is_video_file(f) and os.path.isfile(os.path.join(linux_path, f))
+    ]
+
     # Check if existing folders need organization
     dirs_needing_org = []
     for d in work_dirs:
         # Check for Input
-        has_input = os.path.exists(os.path.join(d, "Input")) or glob.glob(os.path.join(d, "Input.*"))
+        has_input = os.path.exists(os.path.join(d, "Input")) or glob.glob(
+            os.path.join(d, "Input.*")
+        )
         # Check for hints
         has_alpha = os.path.exists(os.path.join(d, "AlphaHint"))
         has_mask = os.path.exists(os.path.join(d, "VideoMamaMaskHint"))
-        
+
         if not has_input or not has_alpha or not has_mask:
             dirs_needing_org.append(d)
 
     if loose_videos or dirs_needing_org:
         if loose_videos:
             print(f"Found {len(loose_videos)} loose video files that need organization:")
-            for v in loose_videos: print(f"  - {v}")
-        
+            for v in loose_videos:
+                print(f"  - {v}")
+
         if dirs_needing_org:
             print(f"Found {len(dirs_needing_org)} folders that might need setup (Hints/Input):")
             # Limit output if too many
             if len(dirs_needing_org) < 10:
-                for d in dirs_needing_org: print(f"  - {os.path.basename(d)}")
+                for d in dirs_needing_org:
+                    print(f"  - {os.path.basename(d)}")
             else:
-                 print(f"  - ...and {len(dirs_needing_org)} others.")
+                print(f"  - ...and {len(dirs_needing_org)} others.")
 
         # 3. Organize Loop
         yn = input("\n[1] Organize Clips & Create Hint Folders? [y/N]: ").strip().lower()
-        if yn == 'y':
+        if yn == "y":
             # Organize loose videos first
             for v in loose_videos:
-                 clip_name = os.path.splitext(v)[0]
-                 ext = os.path.splitext(v)[1]
-                 target_folder = os.path.join(linux_path, clip_name)
-                 
-                 if os.path.exists(target_folder):
-                     logger.warning(f"Skipping loose video '{v}': Target folder '{clip_name}' already exists.")
-                     continue
-                     
-                 try:
-                     os.makedirs(target_folder)
-                     target_file = os.path.join(target_folder, f"Input{ext}")
-                     shutil.move(os.path.join(linux_path, v), target_file)
-                     logger.info(f"Organized: Moved '{v}' to '{clip_name}/Input{ext}'")
-                     
-                     # Also initialize hints immediately
-                     for hint in ["AlphaHint", "VideoMamaMaskHint"]:
+                clip_name = os.path.splitext(v)[0]
+                ext = os.path.splitext(v)[1]
+                target_folder = os.path.join(linux_path, clip_name)
+
+                if os.path.exists(target_folder):
+                    logger.warning(
+                        f"Skipping loose video '{v}': Target folder '{clip_name}' already exists."
+                    )
+                    continue
+
+                try:
+                    os.makedirs(target_folder)
+                    target_file = os.path.join(target_folder, f"Input{ext}")
+                    shutil.move(os.path.join(linux_path, v), target_file)
+                    logger.info(f"Organized: Moved '{v}' to '{clip_name}/Input{ext}'")
+
+                    # Also initialize hints immediately
+                    for hint in ["AlphaHint", "VideoMamaMaskHint"]:
                         os.makedirs(os.path.join(target_folder, hint), exist_ok=True)
-                 except Exception as e:
-                     logger.error(f"Failed to organize video '{v}': {e}")
-        
+                except Exception as e:
+                    logger.error(f"Failed to organize video '{v}': {e}")
+
             # Organize existing folders
             for d in work_dirs:
                 organize_target(d)
             print("Organization Complete.")
-            
+
             # Re-scan in case structure changed
             # If it was a shot, it's still a shot (unless we messed it up)
             # If it wasn't a shot, we re-scan subdirs
             if not target_is_shot:
-                 work_dirs = [os.path.join(linux_path, d) for d in os.listdir(linux_path) if os.path.isdir(os.path.join(linux_path, d))]
-                 work_dirs = [d for d in work_dirs if os.path.basename(d) not in ["Output", "AlphaHint", "VideoMamaMaskHint"]]
+                work_dirs = [
+                    os.path.join(linux_path, d)
+                    for d in os.listdir(linux_path)
+                    if os.path.isdir(os.path.join(linux_path, d))
+                ]
+                work_dirs = [
+                    d
+                    for d in work_dirs
+                    if os.path.basename(d) not in ["Output", "AlphaHint", "VideoMamaMaskHint"]
+                ]
 
     # 4. Status Check Loop
     while True:
         ready = []
         masked = []
         raw = []
-        
+
         for d in work_dirs:
             entry = ClipEntry(os.path.basename(d), d)
             try:
-                entry.find_assets() # This checks Input and AlphaHint
-            except:
-                pass # Might act up if Input missing
-            
+                entry.find_assets()  # This checks Input and AlphaHint
+            except Exception:
+                pass  # Might act up if Input missing
+
             # Check VideoMamaMaskHint (Strict: videomamamaskhint.ext or VideoMamaMaskHint/)
             has_mask = False
             mask_dir = os.path.join(d, "VideoMamaMaskHint")
-            
+
             # 1. Directory Check
             if os.path.isdir(mask_dir) and len(os.listdir(mask_dir)) > 0:
                 has_mask = True
-            
+
             # 2. File Check (Strict Stem Match)
             if not has_mask:
                 for f in os.listdir(d):
@@ -952,44 +1091,46 @@ def interactive_wizard(win_path):
                     if stem.lower() == "videomamamaskhint" and is_video_file(f):
                         has_mask = True
                         break
-                
+
             if entry.alpha_asset:
                 ready.append(entry)
             elif has_mask:
                 masked.append(entry)
             else:
                 raw.append(entry)
-                
-        print("\n" + "-"*40)
-        print(f"STATUS REPORT:")
+
+        print("\n" + "-" * 40)
+        print("STATUS REPORT:")
         print(f"  READY (AlphaHint found): {len(ready)}")
-        for c in ready: print(f"    - {c.name}")
-        
+        for c in ready:
+            print(f"    - {c.name}")
+
         print(f"  MASKED (VideoMamaMaskHint found): {len(masked)}")
-        for c in masked: print(f"    - {c.name}")
-        
+        for c in masked:
+            print(f"    - {c.name}")
+
         print(f"  RAW (Input only):        {len(raw)}")
-        for c in raw: print(f"    - {c.name}")
-        print("-"*40 + "\n")
-        
+        for c in raw:
+            print(f"    - {c.name}")
+        print("-" * 40 + "\n")
+
         # Combine checks for actions
         missing_alpha = masked + raw
-        total_missing = len(missing_alpha)
-        
+
         print("\nACTIONS:")
         if missing_alpha:
             print(f"  [v] Run VideoMaMa (Found {len(masked)} ready with masks)")
             print(f"  [g] Run GVM (Auto-Matte on {len(raw)} clips without Mask Hint)")
-        
+
         if ready:
             print(f"  [i] Run Inference (on {len(ready)} ready clips)")
-            
+
         print("  [r] Re-Scan Folders")
         print("  [q] Quit")
-        
+
         choice = input("\nSelect Action: ").strip().lower()
-        
-        if choice == 'v':
+
+        if choice == "v":
             # VideoMaMa
             print("\n--- VideoMaMa ---")
             print("Scanning for VideoMamaMaskHints...")
@@ -998,31 +1139,31 @@ def interactive_wizard(win_path):
             input("VideoMaMa batch complete. Press Enter to Re-Scan...")
             continue
 
-        elif choice == 'g':
+        elif choice == "g":
             # GVM
             print("\n--- GVM Auto-Matte ---")
             print(f"This will generate alphas for {len(raw)} clips that have NO Mask Hint.")
-            
+
             yn = input("Proceed with GVM? [y/N]: ").strip().lower()
-            if yn == 'y':
+            if yn == "y":
                 generate_alphas(raw)
                 input("GVM batch complete. Press Enter to Re-Scan...")
             continue
-            
-        elif choice == 'i':
+
+        elif choice == "i":
             # Inference
             print("\n--- Corridor Key Inference ---")
             run_inference(ready)
             input("Inference batch complete. Press Enter to Re-Scan...")
             continue
-            
-        elif choice == 'r':
+
+        elif choice == "r":
             print("\nRe-scanning...")
             continue
-            
-        elif choice == 'q':
+
+        elif choice == "q":
             break
-            
+
         else:
             print("Invalid selection.")
             continue
@@ -1039,16 +1180,16 @@ def scan_clips():
     organize_clips(CLIPS_DIR)
 
     clip_dirs = [d for d in os.listdir(CLIPS_DIR) if os.path.isdir(os.path.join(CLIPS_DIR, d))]
-    
+
     valid_clips = []
     invalid_clips = []
 
     for d in clip_dirs:
-        if d.startswith('.') or d.startswith('_') or d == "IgnoredClips": 
+        if d.startswith(".") or d.startswith("_") or d == "IgnoredClips":
             continue
-            
+
         full_path = os.path.join(CLIPS_DIR, d)
-        
+
         try:
             entry = ClipEntry(d, full_path)
             entry.find_assets()
@@ -1057,36 +1198,41 @@ def scan_clips():
         except ValueError as ve:
             invalid_clips.append((d, str(ve)))
         except Exception as e:
-             invalid_clips.append((d, f"Unexpected error: {e}"))
+            invalid_clips.append((d, f"Unexpected error: {e}"))
 
     if invalid_clips:
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print(" INVALID OR SKIPPED CLIPS")
-        print("="*60)
+        print("=" * 60)
         for name, reason in invalid_clips:
             print(f"- {name}: {reason}")
-        print("="*60 + "\n")
+        print("=" * 60 + "\n")
     else:
         print("\nAll clip folders appear valid.\n")
 
     return valid_clips
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="CorridorKey Clip Manager")
-    parser.add_argument("--action", choices=['generate_alphas', 'run_inference', 'list', 'wizard'], required=True)
-    parser.add_argument("--win_path", help=r"Windows Path (example: V:\...) for Wizard Mode", default=None)
-    
+    parser.add_argument(
+        "--action", choices=["generate_alphas", "run_inference", "list", "wizard"], required=True
+    )
+    parser.add_argument(
+        "--win_path", help=r"Windows Path (example: V:\...) for Wizard Mode", default=None
+    )
+
     args = parser.parse_args()
-    
-    if args.action == 'list':
+
+    if args.action == "list":
         scan_clips()
-    elif args.action == 'generate_alphas':
+    elif args.action == "generate_alphas":
         clips = scan_clips()
         generate_alphas(clips)
-    elif args.action == 'run_inference':
+    elif args.action == "run_inference":
         clips = scan_clips()
         run_inference(clips)
-    elif args.action == 'wizard':
+    elif args.action == "wizard":
         if not args.win_path:
             print("Error: --win_path required for wizard.")
         else:

--- a/device_utils.py
+++ b/device_utils.py
@@ -1,0 +1,53 @@
+"""ROCm / AMD GPU environment helpers (optional; safe on NVIDIA CUDA and CPU).
+
+`setup_rocm_env()` is invoked from `main._try_setup_rocm_env()` at process start.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_stderr_info_logging() -> None:
+    """Emit HIP INFO lines to stderr before main.setup_logging() configures the root logger."""
+    if logger.handlers:
+        return
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+
+def setup_rocm_env() -> None:
+    """Configure ROCm-related env when PyTorch is built with HIP.
+
+    If ``torch.version.hip`` is missing, returns without side effects (CUDA or CPU builds).
+    Uses :func:`os.environ.setdefault` for ``HSA_OVERRIDE_GFX_VERSION`` so runtime overrides win.
+    """
+    import torch
+
+    hip = getattr(torch.version, "hip", None)
+    if not hip:
+        logger.debug("ROCm: HIP not present in this PyTorch build (torch.version.hip is None)")
+        return
+
+    _ensure_stderr_info_logging()
+
+    logger.info("ROCm: HIP-enabled PyTorch (HIP version %s)", hip)
+    try:
+        if torch.cuda.is_available():
+            logger.info("ROCm: using device %s", torch.cuda.get_device_name(0))
+        else:
+            logger.warning(
+                "ROCm: HIP build but CUDA API reports no device (check drivers and ROCm stack)"
+            )
+    except Exception as exc:
+        logger.debug("ROCm: device query skipped: %s", exc)
+
+    os.environ.setdefault("HSA_OVERRIDE_GFX_VERSION", "10.3.0")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     x11vnc \
     novnc \
     websockify \
-    xvfb \
     python3-pil \
     python3-netifaces \
     libgl1 \
@@ -48,7 +47,8 @@ RUN uv python install 3.11
 RUN sed -i 's|</body>|<a href="http://localhost:6081" target="_blank" style="position:fixed;bottom:20px;right:20px;z-index:9999;background:#4caf50;color:white;padding:10px 18px;border-radius:6px;font-size:14px;text-decoration:none;box-shadow:0 2px 6px rgba(0,0,0,0.5)">& Upload Clips</a></body>|' /usr/share/novnc/vnc.html 
 RUN echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=/vnc.html?autoconnect=true&reconnect=true&reconnect_delay=2000&resize=scale"></head></html>' > /usr/share/novnc/index.html
 
-RUN curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | bash
+# Pinned filebrowser/get install script (avoid floating master); bump commit when changing installer.
+RUN curl -fsSL https://raw.githubusercontent.com/filebrowser/get/2aab36cbd9def8513160e31d753abc5a2e2aef0c/get.sh | bash
 
 COPY . /opt/corridorkey-src
 COPY docker/supervisord.conf /etc/supervisor/conf.d/corridorkey-vnc.conf

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,99 @@
+# syntax=docker/dockerfile:1
+# AMD / ROCm GPU — isolated from docker/Dockerfile (NVIDIA stack unchanged).
+# PyTorch ROCm wheels only inside this image: uv sync then uv pip … --reinstall (no pyproject ROCm extra).
+#
+# Targets:
+#   rocm-runtime (default) — `uv run python main.py` (single process; use host display or SSH X11 as needed).
+#   rocm-vnc              — same app + noVNC / x11vnc / filebrowser (parity with default docker/Dockerfile UX).
+
+FROM rocm/pytorch:rocm6.1-py3.10-ubuntu22.04 AS rocm-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HSA_OVERRIDE_GFX_VERSION=10.3.0
+ENV HF_HUB_DISABLE_PROGRESS_BARS=1
+# Hardlinks across image layers break in some graph drivers; matches docker/entrypoint.sh installer.
+ENV UV_LINK_MODE=copy
+ENV PATH="/opt/conda/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    git \
+    curl \
+    python3-tk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Official static binary (path is /uv in ghcr.io/astral-sh/uv:latest)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN uv --version
+
+WORKDIR /opt/corridorkey
+COPY . .
+
+# PATH puts conda first; pin interpreter so uv does not pick a different python3 from the base image.
+RUN uv sync --no-dev --python "$(command -v python3)"
+
+# ROCm stack + Triton (required by many torch.compile / inductor paths on AMD)
+RUN uv pip install --python /opt/corridorkey/.venv/bin/python \
+    torch==2.9.1 \
+    torchvision==0.24.1 \
+    pytorch-triton-rocm \
+    --index-url https://download.pytorch.org/whl/rocm6.1 \
+    --reinstall
+
+# --- Browser / noVNC stack (optional build target) — mirrors docker/Dockerfile services ---
+FROM rocm-base AS rocm-vnc
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb \
+    x11vnc \
+    novnc \
+    websockify \
+    python3-pil \
+    python3-netifaces \
+    libgl1 \
+    libglib2.0-0 \
+    libxkbcommon-x11-0 \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-randr0 \
+    libxcb-render-util0 \
+    libxcb-shape0 \
+    libxcb-xinerama0 \
+    libxcb-xfixes0 \
+    libxcb-cursor0 \
+    libdbus-1-3 \
+    libfontconfig1 \
+    libfreetype6 \
+    libegl1 \
+    libgles2 \
+    libpulse0 \
+    libasound2-dev \
+    libopenexr-dev \
+    supervisor \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i 's|</body>|<a href="http://localhost:6081" target="_blank" style="position:fixed;bottom:20px;right:20px;z-index:9999;background:#4caf50;color:white;padding:10px 18px;border-radius:6px;font-size:14px;text-decoration:none;box-shadow:0 2px 6px rgba(0,0,0,0.5)">& Upload Clips</a></body>|' /usr/share/novnc/vnc.html
+RUN echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=/vnc.html?autoconnect=true&reconnect=true&reconnect_delay=2000&resize=scale"></head></html>' > /usr/share/novnc/index.html
+
+# Pinned filebrowser/get install script (avoid floating master); bump commit when changing installer.
+RUN curl -fsSL https://raw.githubusercontent.com/filebrowser/get/2aab36cbd9def8513160e31d753abc5a2e2aef0c/get.sh | bash
+
+COPY docker/supervisord.conf /etc/supervisor/conf.d/corridorkey-vnc.conf
+COPY docker/entrypoint-rocm-vnc.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 6080 6081 5900
+ENV DISPLAY=:1
+ENV QT_QPA_PLATFORM=xcb
+ENV CORRIDORKEY_CONTAINER_MODE=1
+ENV CORRIDORKEY_RESOLUTION=1920x1080x24
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# --- Default image: minimal entrypoint (no supervisor) ---
+FROM rocm-base AS rocm-runtime
+
+CMD ["uv", "run", "python", "main.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,6 +7,10 @@ Run the GUI in a browser via noVNC, with persistent volumes for projects, models
 - Docker Engine + Docker Compose plugin
 - NVIDIA users: working NVIDIA Container Toolkit (for GPU service)
 
+### AMD GPU (ROCm)
+
+Compose below defaults to **CPU**; **NVIDIA** uses the **`gpu`** profile. For **AMD** hosts, use the **`rocm`** profile (or build from the repo root) — see **[docs/ROCm_Setup.md](../docs/ROCm_Setup.md)** (and **[docs/ROCm_PR_handoff.md](../docs/ROCm_PR_handoff.md)** for a full change list and review checklist).
+
 ## Start
 
 From the `docker/` directory:
@@ -23,15 +27,21 @@ GPU:
 docker compose --profile gpu up -d corridorkey-gpu --build
 ```
 
-First run will take several minutes (installs Python dependencies + downloads models). Subsequent starts are fast.
+AMD (ROCm) — builds **`rocm-vnc`** (browser UI + **baked** `.venv` at image build time; no `1-install.sh`). Requires `/dev/kfd` and `/dev/dri` on the host. See **[docs/ROCm_Setup.md](../docs/ROCm_Setup.md)** for differences vs the NVIDIA volume-based install.
 
-To see logs during first run: omit `-d` to run in the foreground.
+```bash
+docker compose --profile rocm up -d corridorkey-rocm --build
+```
+
+**CPU / GPU (`corridorkey-cpu`, `corridorkey-gpu`):** first start can take several minutes (`entrypoint.sh` runs `1-install.sh`, may pull models per env flags). **ROCm (`corridorkey-rocm`):** dependencies are baked at **image build** time; container start is usually quick unless you trigger a heavy rebuild.
+
+To see logs during startup: omit `-d` to run in the foreground.
 
 ## Access the app
 
 - Web UI (noVNC): http://localhost:6080
 - Upload UI (file browser): http://localhost:6081
-- Raw VNC (optional): localhost:5900
+- Raw VNC (optional): localhost:5900 (password **EZ-CorridorKey**)
 
 ## Upload files
 
@@ -55,6 +65,13 @@ Start again:
 docker compose start
 ```
 
+**GPU** and **ROCm** services use Compose **profiles**. To start a stopped profiled container, pass the same profile (and service name) you used when creating it:
+
+```bash
+docker compose --profile gpu start corridorkey-gpu
+docker compose --profile rocm start corridorkey-rocm
+```
+
 Stop and remove containers (keep volumes/data):
 
 ```bash
@@ -68,17 +85,22 @@ git pull
 docker compose --profile gpu up -d corridorkey-gpu --build --force-recreate
 ```
 
-For CPU, replace service with `corridorkey-cpu`.
+For CPU, replace the service name with `corridorkey-cpu` (omit `--profile gpu`). For AMD:
+
+```bash
+docker compose --profile rocm up -d corridorkey-rocm --build --force-recreate
+```
 
 ## Environment changes
 
-If you change environment values in `docker-compose.yml`, recreate the service:
+If you change environment values in `docker-compose.yml`, recreate the service. Examples:
 
 ```bash
+docker compose up -d corridorkey-cpu --force-recreate
 docker compose --profile gpu up -d corridorkey-gpu --force-recreate
 ```
 
-The startup script re-checks install/model env flags on every start and applies changes when needed.
+For **CPU/GPU**, `entrypoint.sh` re-checks install/model env flags on each start. For **`corridorkey-rocm`**, optional install env vars are **ignored** by the stock image; change Python deps by **rebuilding** the image (or extend `Dockerfile.rocm`).
 
 ## Logs
 
@@ -94,9 +116,15 @@ CPU service:
 docker compose logs -f corridorkey-cpu
 ```
 
+AMD (ROCm):
+
+```bash
+docker compose --profile rocm logs -f corridorkey-rocm
+```
+
 ## Volumes (persistent)
 
-- `corridorkey_install` → app source + `.venv`
+- `corridorkey_install` → app source + `.venv` (used by **CPU/GPU**; **not** mounted for **`corridorkey-rocm`**, which ships a baked `.venv`)
 - `corridorkey_projects` → project data
 - `corridorkey_models_*` → model checkpoints
 - `corridorkey_hf_cache` → Hugging Face cache
@@ -106,7 +134,8 @@ docker compose logs -f corridorkey-cpu
 
 ## Security note
 
-Password: 
-EZ-CorridorKey
+**VNC / noVNC:** x11vnc is configured with password **EZ-CorridorKey** (see `docker/supervisord.conf`). Use that when the viewer prompts for a password.
 
-The web and VNC endpoints are authenticated with password EZ-CorridorKey. Do not expose these ports directly to the public internet.
+**filebrowser (uploads):** listens on **127.0.0.1** inside the container; Compose publishes **6081** on **127.0.0.1** only. There is no shared VNC password for filebrowser—behavior depends on the installed **filebrowser** version (first-run setup is possible). The image build uses a **pinned** [filebrowser/get](https://github.com/filebrowser/get) `get.sh` commit (see `docker/Dockerfile`), not a floating **`master`** URL.
+
+Do not publish **6080**, **6081**, or **5900** beyond localhost unless you understand the exposure.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,46 @@ services:
     stdin_open: true
     tty: true
 
+  # AMD ROCm — baked .venv at build time (no 1-install.sh). Does not mount corridorkey_install
+  # over /opt/corridorkey (unlike CPU/GPU). CORRIDORKEY_INSTALL_* env vars do not re-provision
+  # deps; extend Dockerfile.rocm or run manual uv pip in a derived image for tracker/SAM2 extras.
+  corridorkey-rocm:
+    profiles: ["rocm"]
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.rocm
+      target: rocm-vnc
+    image: corridorkey:rocm
+    container_name: corridorkey-rocm
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+    environment:
+      DISPLAY: ":1"
+      QT_QPA_PLATFORM: "xcb"
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+      CORRIDORKEY_CONTAINER_MODE: "1"
+      CORRIDORKEY_RESOLUTION: "1920x1080x24"
+      HSA_OVERRIDE_GFX_VERSION: "10.3.0"
+    ports:
+      - "127.0.0.1:6080:6080"
+      - "127.0.0.1:6081:6081"
+      - "127.0.0.1:5900:5900"
+    volumes:
+      - corridorkey_projects:/opt/corridorkey/Projects
+      - corridorkey_models_corridorkey:/opt/corridorkey/CorridorKeyModule/checkpoints
+      - corridorkey_models_gvm:/opt/corridorkey/gvm_core/weights
+      - corridorkey_models_videomama:/opt/corridorkey/VideoMaMaInferenceModule/checkpoints
+      - corridorkey_hf_cache:/root/.cache/huggingface/hub
+      - corridorkey_config:/root/.config/corridorkey
+      - corridorkey_logs:/opt/corridorkey/logs
+      - corridorkey_uploads:/opt/corridorkey/ClipsForInference
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
 volumes:
   corridorkey_install:
     name: corridorkey_install

--- a/docker/entrypoint-rocm-vnc.sh
+++ b/docker/entrypoint-rocm-vnc.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# ROCm VNC image — starts noVNC + x11vnc + filebrowser + CorridorKey GUI (baked .venv).
+# Does not run 1-install.sh (Python 3.10 + deps are fixed at image build time).
+set -euo pipefail
+
+export HSA_OVERRIDE_GFX_VERSION="${HSA_OVERRIDE_GFX_VERSION:-10.3.0}"
+export CORRIDORKEY_RESOLUTION="${CORRIDORKEY_RESOLUTION:-1920x1080x24}"
+export CORRIDORKEY_CONTAINER_MODE="${CORRIDORKEY_CONTAINER_MODE:-1}"
+
+mkdir -p /opt/corridorkey/ClipsForInference
+
+echo "noVNC: http://localhost:6080"
+echo "Upload: http://localhost:6081"
+echo "VNC: localhost:5900 (password: EZ-CorridorKey — see docker/supervisord.conf)"
+echo ""
+
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/corridorkey-vnc.conf

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,7 @@ INSTALL_ENV_SIG_FILE="${APP_DIR}/.install_env_signature"
 mkdir -p "${APP_DIR}" "${APP_DIR}/ClipsForInference"
 
 export CORRIDORKEY_RESOLUTION="${CORRIDORKEY_RESOLUTION:-1920x1080x24}"
+export CORRIDORKEY_CONTAINER_MODE="${CORRIDORKEY_CONTAINER_MODE:-1}"
 
 compute_source_signature() {
   (
@@ -165,7 +166,7 @@ run_installer_if_needed() {
 
 echo "noVNC: http://localhost:6080"
 echo "Upload: http://localhost:6081"
-echo "VNC:   localhost:5900 (no password)"
+echo "VNC:   localhost:5900 (password: EZ-CorridorKey — see docker/supervisord.conf)"
 echo ""
 
 sync_app_source_if_needed

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -47,7 +47,7 @@ stderr_logfile_maxbytes=0
 [program:corridorkey]
 command=/opt/corridorkey/.venv/bin/python /opt/corridorkey/main.py --gui
 directory=/opt/corridorkey
-environment=DISPLAY=":1",QT_QPA_PLATFORM="xcb",HF_HUB_DISABLE_PROGRESS_BARS="1"
+environment=DISPLAY=":1",QT_QPA_PLATFORM="xcb",HF_HUB_DISABLE_PROGRESS_BARS="1",CORRIDORKEY_CONTAINER_MODE="%(ENV_CORRIDORKEY_CONTAINER_MODE)s"
 autorestart=true
 priority=40
 startsecs=5

--- a/docs/ROCm_PR_handoff.md
+++ b/docs/ROCm_PR_handoff.md
@@ -1,0 +1,137 @@
+# ROCm AMD support — implementation progress and PR package
+
+This document is for **you and the upstream maintainers**: it tracks delivery from **0% to 100%**, lists **exact verification commands**, and includes a **ready-to-paste GitHub PR description**.
+
+---
+
+## Implementation progress (0% → 100%)
+
+| Step | Weight | Status | Notes |
+|------|--------|--------|--------|
+| 1. `docker/Dockerfile.rocm` — `rocm-base`, **`rocm-runtime`** (default), **`rocm-vnc`** (noVNC parity), `pytorch-triton-rocm` | 25% | **Done** | Does not modify [`docker/Dockerfile`](../docker/Dockerfile). |
+| 2. `docker/entrypoint-rocm-vnc.sh` + Compose **`corridorkey-rocm`** (`profile: rocm`) | 5% | **Done** | Baked `.venv`; no `1-install.sh` in ROCm VNC path. |
+| 3. `device_utils.setup_rocm_env()` (HIP, stderr INFO before `setup_logging`, `HSA_*` `setdefault`) | 15% | **Done** | [`device_utils.py`](../device_utils.py). |
+| 4. `main.py` (`_try_setup_rocm_env`, stderr DEBUG on failure before root logging) | 10% | **Done** | Start of `main()`. |
+| 5. Tests + logging assertions + autouse logger reset | 15% | **Done** | [`tests/test_rocm_setup.py`](../tests/test_rocm_setup.py) (6 tests). |
+| 6. `pyproject.toml` — `[tool.uv.pip] torch-backend`, hatch **`force-include`** `device_utils.py` | 10% | **Done** | Fixes `uv` parse warning; ships `device_utils` in wheel/sdist. **No** ROCm optional extra. |
+| 7. CI `.github/workflows/rocm-ci.yml` (pytest + Docker build, `continue-on-error` on image) | 10% | **Done** | |
+| 8. Docs + `CHANGELOG.md` | 10% | **Done** | |
+
+**Overall: 100%** — ready for maintainer review.
+
+### Follow-on (post-review hardening)
+
+These landed after the core ROCm table but belong in the same PR / branch story:
+
+| Item | Notes |
+|------|--------|
+| **`.github/workflows/ruff.yml`** | Merge gate: **`uv run ruff check .`** + **`uv run ruff format --check .`** on **`**/*.py`** / **`pyproject.toml`** changes. |
+| **`[tool.ruff]` / `[tool.ruff.lint]`** in **`pyproject.toml`** | Default Ruff rules; **`ignore = ["E402", "E701"]`** (lazy imports + legacy one-liners). |
+| **`.gitignore`** | **`/test_*.py`** (repo root only). A bare **`test_*.py`** rule ignored **`tests/test_rocm_setup.py`** and broke CI checkout. |
+| **filebrowser** | Both Dockerfiles use a **pinned** [filebrowser/get](https://github.com/filebrowser/get) **`get.sh`** commit (not **`master`**). |
+| **[`docs/AI_full_pass_review_instructions.md`](AI_full_pass_review_instructions.md)** | Playbook for a full-file / line-by-line AI or human review. |
+
+Set **branch protection** on **`main`** to require the **`Ruff / Lint & format`** check name from Actions if merges should be blocked on lint.
+
+---
+
+## Verification evidence (run before submit)
+
+```bash
+uv sync --extra dev
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest tests/test_rocm_setup.py -m rocm -v --tb=short --noconftest
+```
+
+- Tests are marked **`@pytest.mark.rocm`** (see [`pyproject.toml`](../pyproject.toml)); the **file path** limits collection time.
+- **`--noconftest`** skips [`tests/conftest.py`](../tests/conftest.py) (imports `cv2`) for a fast, isolated run.
+- **`torch-backend`** now lives under **`[tool.uv.pip]`** — current `uv` should parse `pyproject.toml` without the old `unknown field` warning.
+- Confirm **`git ls-files tests/test_rocm_setup.py`** lists the file and **`git check-ignore -v tests/test_rocm_setup.py`** prints nothing.
+
+### Test coverage summary
+
+| Test | What it proves |
+|------|----------------|
+| `test_setup_rocm_env_no_hip_no_env_change` | HIP absent → no `HSA_OVERRIDE_GFX_VERSION` added. |
+| `test_setup_rocm_env_with_hip_sets_default` | HIP present → `setdefault` applies `10.3.0`. |
+| `test_setup_rocm_env_hip_preserves_existing_override` | Pre-set env wins. |
+| `test_try_setup_rocm_env_import_error_is_silent` | `ImportError` on `device_utils` → no crash. |
+| `test_try_setup_rocm_env_inner_failure_logged` | Inner failure → log record **"ROCm environment setup skipped"** (caplog). |
+| `test_setup_rocm_env_hip_writes_to_stderr` | HIP path → **stderr** contains `ROCm:` before `main.setup_logging()`. |
+
+---
+
+## Files changed (inventory)
+
+| Area | Files |
+|------|--------|
+| Docker | [`docker/Dockerfile.rocm`](../docker/Dockerfile.rocm), [`docker/entrypoint.sh`](../docker/entrypoint.sh), [`docker/entrypoint-rocm-vnc.sh`](../docker/entrypoint-rocm-vnc.sh), [`docker/docker-compose.yml`](../docker/docker-compose.yml), [`docker/supervisord.conf`](../docker/supervisord.conf) |
+| App | [`device_utils.py`](../device_utils.py), [`main.py`](../main.py) |
+| Packaging | [`pyproject.toml`](../pyproject.toml) — `[tool.uv.pip]`, hatch `force-include` |
+| Tests | [`tests/test_rocm_setup.py`](../tests/test_rocm_setup.py) |
+| CI | [`.github/workflows/rocm-ci.yml`](../.github/workflows/rocm-ci.yml), [`.github/workflows/ruff.yml`](../.github/workflows/ruff.yml) |
+| Docs | [`docs/ROCm_Setup.md`](ROCm_Setup.md), [`docs/AI_full_pass_review_instructions.md`](AI_full_pass_review_instructions.md), this file, [`README.md`](../README.md), [`docker/README.md`](../docker/README.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+| Changelog | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Repo hygiene | [`.gitignore`](../.gitignore) (`/test_*.py` for root scratch scripts only) |
+
+**Unchanged by design:** [`docker/Dockerfile`](../docker/Dockerfile) remains the default NVIDIA-oriented image (it shares **noVNC** / **filebrowser** patterns with ROCm); [`backend/service/core.py`](../backend/service/core.py) needs no ROCm branch. **No** `rocm` optional dependency group for `uv sync`.
+
+---
+
+## Suggested PR title
+
+```
+feat(docker): ROCm AMD image (runtime + noVNC), device_utils, CI
+```
+
+---
+
+## Copy-paste PR description (GitHub)
+
+```markdown
+## Summary
+
+Adds **optional AMD GPU (ROCm) support** via [`docker/Dockerfile.rocm`](docker/Dockerfile.rocm):
+
+- **`rocm-runtime`** (default build target): `uv run python main.py`.
+- **`rocm-vnc`**: same baked environment plus noVNC / x11vnc / filebrowser / supervisord (parity with the default `docker/Dockerfile` UX).
+
+ROCm PyTorch + **`pytorch-triton-rocm`** are applied **only inside the image** (`uv pip install … --reinstall` after `uv sync`). **No** `rocm` optional extra in `pyproject.toml`.
+
+Also adds **`device_utils.setup_rocm_env()`** (HIP detection, `HSA_OVERRIDE_GFX_VERSION`, stderr logging before `setup_logging`), **`main._try_setup_rocm_env()`**, **mocked tests**, **Compose profile `rocm`**, **ROCm CI workflow**, **`device_utils` in wheel/sdist** via hatch `force-include`, moves **`torch-backend = "auto"`** to **`[tool.uv.pip]`**, a **Ruff** merge gate (**`ruff.yml`**), **`[tool.ruff]`** lint config, **pinned filebrowser** `get.sh`, **`.gitignore`** fix so **`tests/test_rocm_setup.py`** is tracked, and **[`docs/AI_full_pass_review_instructions.md`](AI_full_pass_review_instructions.md)** for deep reviews.
+
+## How to test
+
+```bash
+uv sync --extra dev
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest tests/test_rocm_setup.py -m rocm -v --tb=short --noconftest
+```
+
+Docker (optional; large pull):
+
+```bash
+docker build -f docker/Dockerfile.rocm --target rocm-runtime -t ez-corridorkey-rocm .
+docker build -f docker/Dockerfile.rocm --target rocm-vnc -t ez-corridorkey-rocm-vnc .
+```
+
+## Docs
+
+- [`docs/ROCm_Setup.md`](docs/ROCm_Setup.md)
+- [`docs/ROCm_PR_handoff.md`](docs/ROCm_PR_handoff.md)
+- [`docs/AI_full_pass_review_instructions.md`](docs/AI_full_pass_review_instructions.md)
+```
+
+---
+
+## Cross-references
+
+- [ROCm_Setup.md](ROCm_Setup.md)
+- [docker/README.md](../docker/README.md)
+- [AI full-pass review instructions](AI_full_pass_review_instructions.md) — detailed playbook for line-by-line / full-file review of every changed path (for a larger AI or human reviewer)
+
+## Conclusion
+
+All previously identified gaps are addressed: **triton**, **verified `uv` binary path** (documented in Dockerfile), **VNC parity target + Compose**, **ROCm CI**, **Ruff CI + `[tool.ruff]`**, **CHANGELOG**, **wheel/sdist include**, **early logging**, **stronger tests**, **`[tool.uv.pip]`** fix, **pinned filebrowser installer**, **`.gitignore`** safe for **`tests/`**, and an **optional full-pass review playbook**.

--- a/docs/ROCm_Setup.md
+++ b/docs/ROCm_Setup.md
@@ -1,0 +1,140 @@
+# ROCm (AMD GPU) Docker setup
+
+## Overview
+
+This project’s default path targets **NVIDIA CUDA** (installer, manual venv, and [`docker/Dockerfile`](../docker/Dockerfile) / Compose). **AMD GPUs** are supported through a **separate** image, [`docker/Dockerfile.rocm`](../docker/Dockerfile.rocm). The default **`docker/Dockerfile`** is unchanged; [`docker/supervisord.conf`](../docker/supervisord.conf) is **shared** between the noVNC stacks (NVIDIA and ROCm).
+
+The **noVNC** targets in [`docker/Dockerfile`](../docker/Dockerfile) and [`docker/Dockerfile.rocm`](../docker/Dockerfile.rocm) install **filebrowser** via a **pinned** `get.sh` commit from [filebrowser/get](https://github.com/filebrowser/get) (not `master`), so the installer script is reproducible; bump the SHA in both Dockerfiles together when updating.
+
+[`docker/Dockerfile.rocm`](../docker/Dockerfile.rocm) defines **two build targets**:
+
+| Target | Purpose |
+|--------|---------|
+| **`rocm-runtime`** (default) | Single-process app: `uv run python main.py`. Use for direct runs, host X11 forwarding, or automation. |
+| **`rocm-vnc`** | Same baked app as above plus **noVNC**, **x11vnc**, **filebrowser**, and **supervisord** — aligned with the interactive stack in [`docker/Dockerfile`](../docker/Dockerfile). |
+
+## Critical configurations
+
+### Why not `pyproject.toml` / `uv sync --extra rocm`?
+
+To avoid shared lockfile churn and merge conflicts, **ROCm PyTorch wheels are not wired through optional extras**. Inside `Dockerfile.rocm` only:
+
+1. `uv sync --no-dev --python "$(command -v python3)"` installs the normal project dependency graph (conda `python3` on this base image; may briefly resolve the default Linux PyTorch build).
+2. `uv pip install --python /opt/corridorkey/.venv/bin/python torch==2.9.1 torchvision==0.24.1 pytorch-triton-rocm --index-url https://download.pytorch.org/whl/rocm6.1 --reinstall` **replaces** that stack with AMD-compatible wheels **inside the container** (Triton is included for `torch.compile` / inductor paths on ROCm). The **`--python …/.venv/bin/python`** pin matches [`docker/Dockerfile.rocm`](../docker/Dockerfile.rocm) so wheels land in the project venv, not another interpreter on the base image.
+
+### Runtime environment
+
+- **`HSA_OVERRIDE_GFX_VERSION`**: The image sets a default (`10.3.0`) suitable for many consumer RDNA2 cards. Override at run time if your GPU needs a different value, for example:
+
+  ```bash
+  docker run -e HSA_OVERRIDE_GFX_VERSION=11.0.0 ...
+  ```
+
+- **Application code**: [`main.py`](../main.py) calls **`device_utils.setup_rocm_env()`** at the start of **`main()`** (via **`_try_setup_rocm_env()`**) before argument parsing and logging setup. When HIP is present, **`device_utils`** attaches a **stderr** `StreamHandler` so INFO lines appear **before** `setup_logging()` runs, then uses `os.environ.setdefault` for `HSA_OVERRIDE_GFX_VERSION`. PyTorch on ROCm still uses the **CUDA API surface** (`torch.cuda.*`), so [`backend/service/core.py`](../backend/service/core.py) device detection does not need ROCm-specific branches.
+
+### Python version
+
+The **`rocm/pytorch:rocm6.1-py3.10-ubuntu22.04`** base uses **Python 3.10** (conda). The project allows `requires-python = ">=3.10,<3.14"`; the one-click installer and default Docker image typically use **3.11**. If you hit subtle version-only bugs, compare against a 3.11 environment.
+
+### Baked image vs NVIDIA Docker entrypoint
+
+| | Default [`docker/Dockerfile`](../docker/Dockerfile) + Compose | `Dockerfile.rocm` |
+|---|------------------|-------------------|
+| **Install** | `entrypoint.sh` runs `1-install.sh` into a volume when signatures change | Dependencies fixed at **`docker build`** (`uv sync` + ROCm `uv pip`) |
+| **`CORRIDORKEY_INSTALL_*`** | Drives optional SAM2 / GVM / VideoMaMa steps at container start | **Ignored** unless you add your own entrypoint or rebuild with a modified Dockerfile |
+| **`corridorkey_install` volume** | Mounts over `/opt/corridorkey` | **Not used** for ROCm (would overwrite the baked `.venv`) |
+
+### Optional: SAM2 / tracker extras
+
+To bake **SAM2** (`tracker` extra) into a ROCm image, extend `rocm-base` with an extra `RUN` (for example `uv sync --no-dev --extra tracker` before the ROCm `uv pip reinstall`, or `uv pip install -e ".[tracker]"` with the same Python), then rebuild. There is no runtime hook equivalent to `CORRIDORKEY_INSTALL_SAM2=y` on the stock ROCm images.
+
+### Host devices and groups
+
+Most AMD hosts need **`--device=/dev/kfd`** and **`--device=/dev/dri`** plus **`--group-add video`**. Some distributions also require the **`render`** group; if you get permission errors on `/dev/dri/*`, try `--group-add render` (numeric GID varies by distro).
+
+## Build
+
+From the **repository root**:
+
+**Default (minimal runtime image):**
+
+```bash
+docker build -t ez-corridorkey-rocm -f docker/Dockerfile.rocm .
+```
+
+**Browser / noVNC (parity with default Docker UX):**
+
+```bash
+docker build -t ez-corridorkey-rocm-vnc -f docker/Dockerfile.rocm --target rocm-vnc .
+```
+
+## Run (hardware passthrough)
+
+AMD access requires passing the render/KFD devices into the container (adjust group IDs if your distro differs).
+
+**`rocm-runtime`:**
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  ez-corridorkey-rocm
+```
+
+For GUI sessions that expect the same window sizing behavior as the default Docker stack, set **`CORRIDORKEY_CONTAINER_MODE=1`** (optional for headless or pure CLI use).
+
+**`rocm-vnc`** (same device flags; publish ports like the NVIDIA Compose services). The image defaults **`CORRIDORKEY_CONTAINER_MODE=1`**; [`docker/entrypoint-rocm-vnc.sh`](../docker/entrypoint-rocm-vnc.sh) and [`docker/supervisord.conf`](../docker/supervisord.conf) pass **`%(ENV_CORRIDORKEY_CONTAINER_MODE)s`** into the GUI process, so **`docker run -e CORRIDORKEY_CONTAINER_MODE=0`** disables container/fullscreen mode when you want desktop-style sizing.
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  -p 127.0.0.1:6080:6080 \
+  -p 127.0.0.1:6081:6081 \
+  -p 127.0.0.1:5900:5900 \
+  ez-corridorkey-rocm-vnc
+```
+
+### Docker Compose (profile `rocm`)
+
+From the `docker/` directory:
+
+```bash
+docker compose --profile rocm up -d corridorkey-rocm --build
+```
+
+This builds **`rocm-vnc`** and applies the same **127.0.0.1** port bindings as the CPU/GPU services. **Do not** mount a volume over all of `/opt/corridorkey` — the image ships a baked `.venv`; only data directories are mounted (projects, checkpoints, uploads, etc.).
+
+## CI
+
+Two workflows matter for this workstream:
+
+| Workflow | Role |
+|----------|------|
+| [`.github/workflows/ruff.yml`](../.github/workflows/ruff.yml) | **Merge gate** on **`pull_request`** / **`push`** to **`main`** when **`**/*.py`**, **`pyproject.toml`**, or the workflow file changes: **`uv run ruff check .`** and **`uv run ruff format --check .`**. Configure **branch protection** to require **`Ruff / Lint & format`** if merges must be blocked on lint. |
+| [`.github/workflows/rocm-ci.yml`](../.github/workflows/rocm-ci.yml) | **ROCm-focused**: mocked **`pytest tests/test_rocm_setup.py -m rocm --noconftest`**, optional **`docker build … --target rocm-runtime`** with **`continue-on-error: true`**. Runs only when paths in the YAML match (Dockerfiles, entrypoints, Compose, **`device_utils.py`**, **`main.py`**, tests, docs, **`CHANGELOG.md`**, etc.). |
+
+Lint rules live under **`[tool.ruff]`** / **`[tool.ruff.lint]`** in [`pyproject.toml`](../pyproject.toml) (defaults plus **`E402`** / **`E701`** ignored for legacy import layout). That config is **not** the ROCm wheel index; ROCm PyTorch stays **Docker-only** as above.
+
+## Troubleshooting
+
+- **`tests/test_rocm_setup.py` missing in CI / not in PR** — ensure [`.gitignore`](../.gitignore) uses **`/test_*.py`** (repo root only), not a bare **`test_*.py`** (that ignores every `tests/test_*.py`). Verify: **`git check-ignore -v tests/test_rocm_setup.py`** should print nothing; **`git ls-files tests/test_rocm_setup.py`** should list the file.
+- **`pytest` / `cv2` / `conftest` errors** — run ROCm tests with **`--noconftest`** (see [CONTRIBUTING.md](../CONTRIBUTING.md)) so the shared [`tests/conftest.py`](../tests/conftest.py) is not loaded.
+- **Port `6080` / `6081` already in use** — the **`rocm`** Compose profile uses the same localhost ports as **`corridorkey-cpu`** / **`corridorkey-gpu`**. Stop the other stack first, or change published ports in a local override file.
+- **`/dev/kfd` or `/dev/dri` missing inside WSL2 / VM** — ROCm needs a Linux host with AMD drivers and device nodes passed through; nested or Windows-only environments often cannot see these devices.
+- **VNC password** — same as the default Docker stack: **EZ-CorridorKey** in [`docker/supervisord.conf`](../docker/supervisord.conf) (`x11vnc -passwd`).
+
+## Cross-references
+
+- [docker/README.md](../docker/README.md) — default Docker / Compose (NVIDIA-oriented)
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — dev setup, **Ruff** / pytest commands, **ROCm** prerequisite note
+- [ROCm PR and handoff](ROCm_PR_handoff.md) — full change list, test commands, and copy-paste PR text for reviewers
+- [AI full-pass review instructions](AI_full_pass_review_instructions.md) — how to review every changed file and line (for a larger AI or maintainer audit)
+
+## Conclusion
+
+Use **`docker/Dockerfile.rocm`** for AMD (`rocm-runtime` or `rocm-vnc`). Keep using the existing installer and **`docker/Dockerfile`** for NVIDIA. ROCm torch resolution stays **inside the Docker build**; there is still **no** `rocm` optional extra for `uv sync`.
+
+Repo-wide **Python style** is enforced by **Ruff** in CI (see **`[tool.ruff]`** in [`pyproject.toml`](../pyproject.toml)); that is separate from ROCm packaging. Other **`pyproject.toml`** tweaks (**`[tool.uv.pip] torch-backend`**, hatch **`force-include`** for **`device_utils.py`**) fix **`uv`** parsing and ship the startup helper in wheels—they are **not** ROCm wheel indexes.

--- a/gvm_core/__init__.py
+++ b/gvm_core/__init__.py
@@ -1,1 +1,3 @@
 from .wrapper import GVMProcessor
+
+__all__ = ["GVMProcessor"]

--- a/gvm_core/gvm/models/unet_spatio_temporal_condition.py
+++ b/gvm_core/gvm/models/unet_spatio_temporal_condition.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Union
 
 import torch
@@ -6,7 +5,7 @@ import torch.nn as nn
 
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import UNet2DConditionLoadersMixin
-from diffusers.utils import BaseOutput, logging
+from diffusers.utils import logging
 from diffusers.models.attention_processor import (
     CROSS_ATTENTION_PROCESSORS,
     AttentionProcessor,
@@ -14,17 +13,22 @@ from diffusers.models.attention_processor import (
 )
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_utils import ModelMixin
-from diffusers.models.unets.unet_3d_blocks import UNetMidBlockSpatioTemporal, get_down_block, get_up_block
+from diffusers.models.unets.unet_3d_blocks import (
+    UNetMidBlockSpatioTemporal,
+    get_down_block,
+    get_up_block,
+)
 from diffusers.loaders import PeftAdapterMixin
 from diffusers.models.unets.unet_spatio_temporal_condition import (
     UNetSpatioTemporalConditionOutput,
 )
+
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class UNetSpatioTemporalConditionModel(
-    ModelMixin, 
-    ConfigMixin, 
+    ModelMixin,
+    ConfigMixin,
     UNet2DConditionLoadersMixin,
     PeftAdapterMixin,
     # LoraLoaderMixin,
@@ -91,8 +95,7 @@ class UNetSpatioTemporalConditionModel(
         transformer_layers_per_block: Union[int, Tuple[int], Tuple[Tuple]] = 1,
         num_attention_heads: Union[int, Tuple[int]] = (5, 10, 20, 20),
         num_frames: int = 25,
-
-        class_embed_type: Optional[str] = None, # 'projection',
+        class_embed_type: Optional[str] = None,  # 'projection',
         num_class_embeds: Optional[int] = None,
         act_fn: str = "silu",
     ):
@@ -125,9 +128,7 @@ class UNetSpatioTemporalConditionModel(
                 f"Must provide the same number of `cross_attention_dim` as `down_block_types`. `cross_attention_dim`: {cross_attention_dim}. `down_block_types`: {down_block_types}."
             )
 
-        if not isinstance(layers_per_block, int) and len(layers_per_block) != len(
-            down_block_types
-        ):
+        if not isinstance(layers_per_block, int) and len(layers_per_block) != len(down_block_types):
             raise ValueError(
                 f"Must provide the same number of `layers_per_block` as `down_block_types`. `layers_per_block`: {layers_per_block}. `down_block_types`: {down_block_types}."
             )
@@ -147,7 +148,7 @@ class UNetSpatioTemporalConditionModel(
         timestep_input_dim = block_out_channels[0]
 
         self.time_embedding = TimestepEmbedding(timestep_input_dim, time_embed_dim)
-        
+
         # self.add_time_proj = Timesteps(addition_time_embed_dim, True, downscale_freq_shift=0)
         # self.add_embedding = TimestepEmbedding(projection_class_embeddings_input_dim, time_embed_dim)
 
@@ -164,9 +165,7 @@ class UNetSpatioTemporalConditionModel(
             layers_per_block = [layers_per_block] * len(down_block_types)
 
         if isinstance(transformer_layers_per_block, int):
-            transformer_layers_per_block = [transformer_layers_per_block] * len(
-                down_block_types
-            )
+            transformer_layers_per_block = [transformer_layers_per_block] * len(down_block_types)
 
         blocks_time_embed_dim = time_embed_dim
 
@@ -209,9 +208,7 @@ class UNetSpatioTemporalConditionModel(
         reversed_num_attention_heads = list(reversed(num_attention_heads))
         reversed_layers_per_block = list(reversed(layers_per_block))
         reversed_cross_attention_dim = list(reversed(cross_attention_dim))
-        reversed_transformer_layers_per_block = list(
-            reversed(transformer_layers_per_block)
-        )
+        reversed_transformer_layers_per_block = list(reversed(transformer_layers_per_block))
 
         output_channel = reversed_block_out_channels[0]
         for i, up_block_type in enumerate(up_block_types):
@@ -219,9 +216,7 @@ class UNetSpatioTemporalConditionModel(
 
             prev_output_channel = output_channel
             output_channel = reversed_block_out_channels[i]
-            input_channel = reversed_block_out_channels[
-                min(i + 1, len(block_out_channels) - 1)
-            ]
+            input_channel = reversed_block_out_channels[min(i + 1, len(block_out_channels) - 1)]
 
             # add upsample block for all BUT final layer
             if not is_final_block:
@@ -283,7 +278,9 @@ class UNetSpatioTemporalConditionModel(
         if class_embed_type is None and num_class_embeds is not None:
             self.class_embedding = nn.Embedding(num_class_embeds, time_embed_dim)
         elif class_embed_type == "timestep":
-            self.class_embedding = TimestepEmbedding(timestep_input_dim, time_embed_dim, act_fn=act_fn)
+            self.class_embedding = TimestepEmbedding(
+                timestep_input_dim, time_embed_dim, act_fn=act_fn
+            )
         elif class_embed_type == "identity":
             self.class_embedding = nn.Identity(time_embed_dim, time_embed_dim)
         elif class_embed_type == "projection":
@@ -298,7 +295,9 @@ class UNetSpatioTemporalConditionModel(
             # Note that `TimestepEmbedding` is quite general, being mainly linear layers and activations.
             # When used for embedding actual timesteps, the timesteps are first converted to sinusoidal embeddings.
             # As a result, `TimestepEmbedding` can be passed arbitrary vectors.
-            self.class_embedding = TimestepEmbedding(projection_class_embeddings_input_dim, time_embed_dim)
+            self.class_embedding = TimestepEmbedding(
+                projection_class_embeddings_input_dim, time_embed_dim
+            )
         elif class_embed_type == "simple_projection":
             if projection_class_embeddings_input_dim is None:
                 raise ValueError(
@@ -308,7 +307,9 @@ class UNetSpatioTemporalConditionModel(
         else:
             self.class_embedding = None
 
-    def get_class_embed(self, sample: torch.Tensor, class_labels: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    def get_class_embed(
+        self, sample: torch.Tensor, class_labels: Optional[torch.Tensor]
+    ) -> Optional[torch.Tensor]:
         class_emb = None
         if self.class_embedding is not None:
             if class_labels is None:
@@ -323,7 +324,6 @@ class UNetSpatioTemporalConditionModel(
 
             class_emb = self.class_embedding(class_labels).to(dtype=sample.dtype)
         return class_emb
-
 
     @property
     def attn_processors(self) -> Dict[str, AttentionProcessor]:
@@ -396,8 +396,7 @@ class UNetSpatioTemporalConditionModel(
         Disables custom attention processors and sets the default attention implementation.
         """
         if all(
-            proc.__class__ in CROSS_ATTENTION_PROCESSORS
-            for proc in self.attn_processors.values()
+            proc.__class__ in CROSS_ATTENTION_PROCESSORS for proc in self.attn_processors.values()
         ):
             processor = AttnProcessor()
         else:
@@ -412,9 +411,7 @@ class UNetSpatioTemporalConditionModel(
             module.gradient_checkpointing = value
 
     # Copied from diffusers.models.unets.unet_3d_condition.UNet3DConditionModel.enable_forward_chunking
-    def enable_forward_chunking(
-        self, chunk_size: Optional[int] = None, dim: int = 0
-    ) -> None:
+    def enable_forward_chunking(self, chunk_size: Optional[int] = None, dim: int = 0) -> None:
         """
         Sets the attention processor to use [feed forward
         chunking](https://huggingface.co/blog/reformer#2-chunked-feed-forward-layers).
@@ -433,9 +430,7 @@ class UNetSpatioTemporalConditionModel(
         # By default chunk size is 1
         chunk_size = chunk_size or 1
 
-        def fn_recursive_feed_forward(
-            module: torch.nn.Module, chunk_size: int, dim: int
-        ):
+        def fn_recursive_feed_forward(module: torch.nn.Module, chunk_size: int, dim: int):
             if hasattr(module, "set_chunk_feed_forward"):
                 module.set_chunk_feed_forward(chunk_size=chunk_size, dim=dim)
 
@@ -513,7 +508,6 @@ class UNetSpatioTemporalConditionModel(
         t_emb = t_emb.to(dtype=sample.dtype)
         emb = self.time_embedding(t_emb)
 
-
         # time_embeds = self.add_time_proj(added_time_ids.flatten())
         # time_embeds = time_embeds.reshape((batch_size, -1))
         # time_embeds = time_embeds.to(emb.dtype)
@@ -537,9 +531,7 @@ class UNetSpatioTemporalConditionModel(
         # emb: [batch, channels] -> [batch * frames, channels]
         emb = emb.repeat_interleave(num_frames, dim=0)
         # encoder_hidden_states: [batch, 1, channels] -> [batch * frames, 1, channels]
-        encoder_hidden_states = encoder_hidden_states.repeat_interleave(
-            num_frames, dim=0
-        )
+        encoder_hidden_states = encoder_hidden_states.repeat_interleave(num_frames, dim=0)
 
         # 2. pre-process
         sample = self.conv_in(sample)
@@ -585,9 +577,7 @@ class UNetSpatioTemporalConditionModel(
             is_final_block = i == len(self.up_blocks) - 1
 
             res_samples = down_block_res_samples[-len(upsample_block.resnets) :]
-            down_block_res_samples = down_block_res_samples[
-                : -len(upsample_block.resnets)
-            ]
+            down_block_res_samples = down_block_res_samples[: -len(upsample_block.resnets)]
             if not is_final_block and forward_upsample_size:
                 upsample_size = down_block_res_samples[-1].shape[2:]
 

--- a/gvm_core/gvm/pipelines/pipeline_gvm.py
+++ b/gvm_core/gvm/pipelines/pipeline_gvm.py
@@ -2,40 +2,32 @@ import torch
 import tqdm
 import numpy as np
 from diffusers import DiffusionPipeline
-from diffusers.utils import (
-    BaseOutput, 
-    USE_PEFT_BACKEND,     
-    is_peft_available,
-    is_peft_version,
-    is_torch_version,
-    logging
-)
-from diffusers.loaders.lora_pipeline import (
-    _LOW_CPU_MEM_USAGE_DEFAULT_LORA,
-    StableDiffusionLoraLoaderMixin
-)
+from diffusers.utils import BaseOutput, logging
+from diffusers.loaders.lora_pipeline import StableDiffusionLoraLoaderMixin
 from peft import LoraConfig, LoraModel, set_peft_model_state_dict
 import os
 
 from typing import Union, Dict
+
 logger = logging.get_logger(__name__)
 
 
 class GVMLoraLoader(StableDiffusionLoraLoaderMixin):
     _lora_loadable_modules = ["unet"]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def load_lora_weights(
-        self, 
-        pretrained_model_name_or_path_or_dict: Union[str, Dict[str, torch.Tensor]], 
-        adapter_name=None, 
+        self,
+        pretrained_model_name_or_path_or_dict: Union[str, Dict[str, torch.Tensor]],
+        adapter_name=None,
         hotswap: bool = False,
-        **kwargs
+        **kwargs,
     ):
 
         unet_lora_config = LoraConfig.from_pretrained(pretrained_model_name_or_path_or_dict)
-        checkpoint = os.path.join(pretrained_model_name_or_path_or_dict, f"pytorch_lora_weights.pt")
+        checkpoint = os.path.join(pretrained_model_name_or_path_or_dict, "pytorch_lora_weights.pt")
         unet_lora_ckpt = torch.load(checkpoint, weights_only=True)
         self.unet = LoraModel(self.unet, unet_lora_config, "default")
         set_peft_model_state_dict(self.unet, unet_lora_ckpt)
@@ -50,15 +42,15 @@ class GVMOutput(BaseOutput):
             List of denoised PIL images of length `batch_size` or NumPy array of shape `(batch_size, height, width,
             num_channels)`.
     """
+
     alpha: np.ndarray
     image: np.ndarray
+
 
 class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
     def __init__(self, vae, unet, scheduler):
         super().__init__()
-        self.register_modules(
-            vae=vae, unet=unet, scheduler=scheduler
-        )
+        self.register_modules(vae=vae, unet=unet, scheduler=scheduler)
 
     def encode(self, input):
         num_frames = input.shape[1]
@@ -89,8 +81,14 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
         frames = frames.reshape(-1, num_frames, *frames.shape[1:])
         return frames.to(torch.float32)
 
-    
-    def single_infer(self, rgb, position_ids=None, num_inference_steps=None, class_labels=None, noise_type="gaussian"):
+    def single_infer(
+        self,
+        rgb,
+        position_ids=None,
+        num_inference_steps=None,
+        class_labels=None,
+        noise_type="gaussian",
+    ):
         rgb_latent = self.encode(rgb)
 
         self.scheduler.set_timesteps(num_inference_steps, device=rgb.device)
@@ -100,14 +98,14 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
             timesteps = self.scheduler.timesteps
         elif noise_type == "zeros":
             noise_latent = torch.zeros_like(rgb_latent)
-            timesteps = torch.ones_like(self.scheduler.timesteps) * (self.scheduler.config.num_train_timesteps - 1) # 999
+            timesteps = torch.ones_like(self.scheduler.timesteps) * (
+                self.scheduler.config.num_train_timesteps - 1
+            )  # 999
             timesteps = timesteps.long()
         else:
             raise NotImplementedError
-            
-        image_embeddings = torch.zeros((noise_latent.shape[0], 1, 1024)).to(
-            noise_latent
-        )
+
+        image_embeddings = torch.zeros((noise_latent.shape[0], 1, 1024)).to(noise_latent)
 
         for i, t in enumerate(timesteps):
             latent_model_input = noise_latent
@@ -121,17 +119,14 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
                 class_labels=class_labels,
             ).sample
 
-            if noise_type == 'zeros':
+            if noise_type == "zeros":
                 noise_latent = model_output
             else:
                 # compute the previous noisy sample x_t -> x_t-1
-                noise_latent = self.scheduler.step(
-                    model_output, t, noise_latent
-                ).prev_sample
+                noise_latent = self.scheduler.step(model_output, t, noise_latent).prev_sample
 
         return noise_latent
 
-    
     def __call__(
         self,
         image,
@@ -141,15 +136,15 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
         decode_chunk_size,
         num_inference_steps,
         use_clip_img_emb=False,
-        noise_type='zeros',
-        mode='matte',
+        noise_type="zeros",
+        mode="matte",
         ensemble_size: int = 3,
     ):
 
         assert ensemble_size >= 1
         self.vae.to(dtype=torch.float16)
         class_embedding = None
-        
+
         # (1, N, 3, H, W)
         image = image.unsqueeze(0)
         B, N = image.shape[:2]
@@ -166,7 +161,7 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
                 num_inference_steps=num_inference_steps,
                 class_labels=class_embedding,
                 position_ids=position_ids,
-                noise_type=noise_type
+                noise_type=noise_type,
             )
         else:
             # assert 2 <= num_overlap_frames <= (num_interp_frames + 2 + 1) // 2
@@ -174,11 +169,7 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
             # num_interp_frames = num_frames - 2
             key_frame_indices = []
             for i in range(0, N, num_frames - num_overlap_frames):
-                if (
-                    i + num_frames - 1 >= N
-                    or len(key_frame_indices) >= num_frames
-                ):
-
+                if i + num_frames - 1 >= N or len(key_frame_indices) >= num_frames:
                     # print(i)
                     pass
 
@@ -186,45 +177,45 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
                 key_frame_indices.append(min(N - 1, i + num_frames - 1))
 
             key_frame_indices = torch.tensor(key_frame_indices, device=rgb.device)
-            
+
             latent_all = None
             pre_latent = None
 
             for i in tqdm.tqdm(range(0, len(key_frame_indices), 2)):
-                position_ids = torch.arange(0, key_frame_indices[i + 1] - key_frame_indices[i] + 1).to(rgb.device)
+                position_ids = torch.arange(
+                    0, key_frame_indices[i + 1] - key_frame_indices[i] + 1
+                ).to(rgb.device)
                 position_ids = position_ids.unsqueeze(0).repeat(B, 1)
                 position_ids = None
                 latent = self.single_infer(
                     rgb[:, key_frame_indices[i] : key_frame_indices[i + 1] + 1],
                     position_ids=position_ids,
                     num_inference_steps=num_inference_steps,
-                    class_labels=class_embedding
+                    class_labels=class_embedding,
                 )
 
                 if pre_latent is not None:
-                    ratio = (
-                        torch.linspace(0, 1, num_overlap_frames)
-                        .to(latent)
-                        .view(1, -1, 1, 1, 1)
-                    )
+                    ratio = torch.linspace(0, 1, num_overlap_frames).to(latent).view(1, -1, 1, 1, 1)
                     try:
-                        latent_all[:, -num_overlap_frames:] = latent[:,:num_overlap_frames] * ratio + latent_all[:, -num_overlap_frames:] * (1 - ratio)
-                    except:
+                        latent_all[:, -num_overlap_frames:] = latent[
+                            :, :num_overlap_frames
+                        ] * ratio + latent_all[:, -num_overlap_frames:] * (1 - ratio)
+                    except Exception:
                         num_overlap_frames = min(num_overlap_frames, latent.shape[1])
                         ratio = (
-                                torch.linspace(0, 1, num_overlap_frames)
-                                .to(latent)
-                                .view(1, -1, 1, 1, 1)
+                            torch.linspace(0, 1, num_overlap_frames).to(latent).view(1, -1, 1, 1, 1)
                         )
-                        latent_all[:, -num_overlap_frames:] = latent[:,:num_overlap_frames] * ratio + latent_all[:, -num_overlap_frames:] * (1 - ratio)
-                    latent_all = torch.cat([latent_all, latent[:,num_overlap_frames:]], dim=1)
+                        latent_all[:, -num_overlap_frames:] = latent[
+                            :, :num_overlap_frames
+                        ] * ratio + latent_all[:, -num_overlap_frames:] * (1 - ratio)
+                    latent_all = torch.cat([latent_all, latent[:, num_overlap_frames:]], dim=1)
                 else:
                     latent_all = latent.clone()
 
                 pre_latent = latent
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
-                elif hasattr(torch, 'mps') and torch.backends.mps.is_available():
+                elif hasattr(torch, "mps") and torch.backends.mps.is_available():
                     torch.mps.empty_cache()
 
             assert latent_all.shape[1] == image.shape[1]
@@ -238,7 +229,7 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
 
         if alpha.dim() == 5:
             alpha = alpha.squeeze(0)
-        
+
         # (N, H, W, 3)
         image = image.squeeze(0)
 

--- a/gvm_core/gvm/utils/inference_utils.py
+++ b/gvm_core/gvm/utils/inference_utils.py
@@ -15,11 +15,11 @@ class VideoReader(Dataset):
         self.rate = self.video.frame_rate
         self.transform = transform
         self.max_frames = max_frames
-        
+
     @property
     def frame_rate(self):
         return self.rate
-    
+
     @property
     def origin_shape(self):
         return self.video[0].shape[:2]
@@ -29,7 +29,7 @@ class VideoReader(Dataset):
             return min(len(self.video), self.max_frames)
         else:
             return len(self.video)
-        
+
     def __getitem__(self, idx):
         frame = self.video[idx]
         frame = Image.fromarray(np.asarray(frame))
@@ -40,35 +40,37 @@ class VideoReader(Dataset):
 
 class VideoWriter:
     def __init__(self, path, frame_rate, bit_rate=1000000):
-        self.container = av.open(path, mode='w')
+        self.container = av.open(path, mode="w")
         # self.container.add_stream('h264', rate=30)
-        self.stream = self.container.add_stream('h264', rate=Fraction(frame_rate).limit_denominator())
-        self.stream.pix_fmt = 'yuv420p'
+        self.stream = self.container.add_stream(
+            "h264", rate=Fraction(frame_rate).limit_denominator()
+        )
+        self.stream.pix_fmt = "yuv420p"
         self.stream.bit_rate = bit_rate
-    
+
     def write(self, frames):
 
         # frames: [T, C, H, W]
         self.stream.width = frames.size(3)
         self.stream.height = frames.size(2)
         if frames.size(1) == 1:
-            frames = frames.repeat(1, 3, 1, 1) # convert grayscale to RGB
+            frames = frames.repeat(1, 3, 1, 1)  # convert grayscale to RGB
         frames = frames.mul(255).byte().cpu().permute(0, 2, 3, 1).numpy()
 
         for t in range(frames.shape[0]):
             frame = frames[t]
-            frame = av.VideoFrame.from_ndarray(frame, format='rgb24')
+            frame = av.VideoFrame.from_ndarray(frame, format="rgb24")
             self.container.mux(self.stream.encode(frame))
 
     def write_numpy(self, frames):
-        
+
         # frames: [T, H, W, C]
         self.stream.height = frames.shape[1]
         self.stream.width = frames.shape[2]
 
         for t in range(frames.shape[0]):
             frame = frames[t]
-            frame = av.VideoFrame.from_ndarray(frame, format='rgb24')
+            frame = av.VideoFrame.from_ndarray(frame, format="rgb24")
             self.container.mux(self.stream.encode(frame))
 
     def close(self):
@@ -76,17 +78,25 @@ class VideoWriter:
         self.container.close()
 
 
-_IMAGE_EXTS = frozenset({
-    '.png', '.jpg', '.jpeg', '.bmp', '.tiff', '.tif', '.exr', '.webp',
-})
+_IMAGE_EXTS = frozenset(
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".bmp",
+        ".tiff",
+        ".tif",
+        ".exr",
+        ".webp",
+    }
+)
 
 
 class ImageSequenceReader(Dataset):
     def __init__(self, path, transform=None):
         self.path = path
         self.files = sorted(
-            f for f in os.listdir(path)
-            if os.path.splitext(f)[1].lower() in _IMAGE_EXTS
+            f for f in os.listdir(path) if os.path.splitext(f)[1].lower() in _IMAGE_EXTS
         )
         self.transform = transform
 
@@ -94,50 +104,52 @@ class ImageSequenceReader(Dataset):
     def origin_shape(self):
         # Use cv2 for robustness
         import cv2
+
         img = cv2.imread(os.path.join(self.path, self.files[0]), cv2.IMREAD_UNCHANGED)
         return img.shape[:2]
 
     def __len__(self):
         return len(self.files)
-    
+
     def __getitem__(self, idx):
         import cv2
+
         fpath = os.path.join(self.path, self.files[idx])
-        is_exr = fpath.lower().endswith('.exr')
-        
+        is_exr = fpath.lower().endswith(".exr")
+
         if is_exr:
             img = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
             # Convert to RGB (OpenCV is BGR)
             if img is None:
-                 raise ValueError(f"Failed to read {fpath}")
+                raise ValueError(f"Failed to read {fpath}")
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            
+
             # Convert to PIL Image for Transforms (expected by torchvision)
             # EXR is float32 (Linear). PIL usually handles 0-255 uint8 better for standard transforms?
-            # BUT: The pipeline might expect standard range. 
+            # BUT: The pipeline might expect standard range.
             # If I convert to float 0-1 range and then ToTensor() handles it?
-            # ToTensor handles np.ndarray. 
+            # ToTensor handles np.ndarray.
             # If float32, ToTensor() keeps it float32.
             # If uint8, ToTensor() scales to 0-1 float32.
-            
-            # Simple tone map for passing to GVM if needed? 
-            # GVM expects an RGB image. 
+
+            # Simple tone map for passing to GVM if needed?
+            # GVM expects an RGB image.
             # Let's assume simplest path: Clip linear to 0-1, sRGB gamma, then uint8 PIL?
             # Or pass float tensor?
-            
+
             # The transforms are: ToTensor(), Resize(). ToTensor accepts array.
             # Resize accepts PIL or Tensor.
-            
+
             # Let's normalize consistent with main.py: linear -> sRGB gamma
-            img = np.power(np.clip(img, 0.0, None), 1.0/2.2)
+            img = np.power(np.clip(img, 0.0, None), 1.0 / 2.2)
             img = (np.clip(img, 0.0, 1.0) * 255).astype(np.uint8)
             img = Image.fromarray(img)
-            
+
         else:
             # Fallback to PIL for non-exr for safety/compatibility
             with Image.open(fpath) as img:
                 img.load()
-        
+
         origin_shape = torch.from_numpy(np.asarray(np.array(img).shape[:2]))
 
         if self.transform is not None:
@@ -149,24 +161,22 @@ class ImageSequenceReader(Dataset):
 
 
 class ImageSequenceWriter:
-    def __init__(self, path, extension='jpg'):
+    def __init__(self, path, extension="jpg"):
         self.path = path
         self.extension = extension
         self.counter = 0
         os.makedirs(path, exist_ok=True)
-    
+
     def write(self, frames, filenames=None):
         # frames: [T, C, H, W]
         for t in range(frames.shape[0]):
             if filenames is None:
-                filename = str(self.counter).zfill(4) + '.' + self.extension
+                filename = str(self.counter).zfill(4) + "." + self.extension
             else:
-                filename = filenames[t].split('.')[0] + '.' + self.extension
+                filename = filenames[t].split(".")[0] + "." + self.extension
 
-            to_pil_image(frames[t]).save(os.path.join(
-                self.path, filename))
+            to_pil_image(frames[t]).save(os.path.join(self.path, filename))
             self.counter += 1
-            
+
     def close(self):
         pass
-        

--- a/gvm_core/wrapper.py
+++ b/gvm_core/wrapper.py
@@ -19,7 +19,12 @@ from tqdm import tqdm
 # Relative imports from the internal gvm package
 # Assuming this file is inside gvm_core/
 from .gvm.pipelines.pipeline_gvm import GVMPipeline
-from .gvm.utils.inference_utils import VideoReader, VideoWriter, ImageSequenceReader, ImageSequenceWriter
+from .gvm.utils.inference_utils import (
+    VideoReader,
+    VideoWriter,
+    ImageSequenceReader,
+    ImageSequenceWriter,
+)
 from .gvm.models.unet_spatio_temporal_condition import UNetSpatioTemporalConditionModel
 
 
@@ -30,10 +35,11 @@ def seed_all(seed: int = 0):
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
 
+
 def impad_multi(img, multiple=32):
     # img: (N, C, H, W)
     h, w = img.shape[2], img.shape[3]
-    
+
     target_h = int(np.ceil(h / multiple) * multiple)
     target_w = int(np.ceil(w / multiple) * multiple)
 
@@ -43,25 +49,22 @@ def impad_multi(img, multiple=32):
     pad_right = target_w - w - pad_left
 
     # F.pad expects (padding_left, padding_right, padding_top, padding_bottom)
-    padded = F.pad(img, (pad_left, pad_right, pad_top, pad_bottom), mode='reflect')
+    padded = F.pad(img, (pad_left, pad_right, pad_top, pad_bottom), mode="reflect")
 
     return padded, (pad_top, pad_left, pad_bottom, pad_right)
+
 
 def sequence_collate_fn(examples):
     rgb_values = torch.stack([example["image"] for example in examples])
     rgb_values = rgb_values.to(memory_format=torch.contiguous_format).float()
     rgb_names = [example["filename"] for example in examples]
-    return {'rgb_values': rgb_values, 'rgb_names': rgb_names}
+    return {"rgb_values": rgb_values, "rgb_names": rgb_names}
+
 
 class GVMProcessor:
-    def __init__(self, 
-                 model_base=None,
-                 unet_base=None,
-                 lora_base=None,
-                 device="cuda",
-                 seed=None):
+    def __init__(self, model_base=None, unet_base=None, lora_base=None, device="cuda", seed=None):
         self.device = torch.device(device)
-        
+
         # Resolve default weights path relative to this file,
         # falling back to the HuggingFace repo ID if local weights aren't present.
         if model_base is None:
@@ -70,36 +73,37 @@ class GVMProcessor:
                 model_base = local_weights
             else:
                 model_base = "geyongtao/gvm"
-            
+
         self.model_base = model_base
         self.unet_base = unet_base
         self.lora_base = lora_base
-        
+
         if seed is None:
             seed = int(time.time())
         seed_all(seed)
-        
+
         logger.info(f"Loading GVM models from {model_base}...")
-        self.vae = AutoencoderKLTemporalDecoder.from_pretrained(model_base, subfolder="vae", torch_dtype=torch.float16)
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(model_base, subfolder="scheduler")
-        
+        self.vae = AutoencoderKLTemporalDecoder.from_pretrained(
+            model_base, subfolder="vae", torch_dtype=torch.float16
+        )
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model_base, subfolder="scheduler"
+        )
+
         unet_folder = unet_base if unet_base is not None else model_base
         self.unet = UNetSpatioTemporalConditionModel.from_pretrained(
-            unet_folder, 
-            subfolder="unet", 
-            class_embed_type=None,
-            torch_dtype=torch.float16
+            unet_folder, subfolder="unet", class_embed_type=None, torch_dtype=torch.float16
         )
 
         self.pipe = GVMPipeline(vae=self.vae, unet=self.unet, scheduler=self.scheduler)
         if lora_base:
             # Check if lora_base is None or points to valid path, otherwise try default
             if lora_base is None and osp.exists(osp.join(model_base, "unet")):
-                 # Often lora weights are just the unet weights in this codebase based on demo.py usage
-                 pass 
+                # Often lora weights are just the unet weights in this codebase based on demo.py usage
+                pass
             elif lora_base:
                 self.pipe.load_lora_weights(lora_base)
-                
+
         self.pipe = self.pipe.to(self.device, dtype=torch.float16)
         logger.info("Models loaded.")
 
@@ -116,26 +120,30 @@ class GVMProcessor:
             self.unet = self.unet.to(device)
         return self
 
-    def process_sequence(self, input_path, output_dir,
-                         num_frames_per_batch=8,
-                         denoise_steps=1,
-                         max_frames=None,
-                         decode_chunk_size=8,
-                         num_interp_frames=1,
-                         num_overlap_frames=1,
-                         use_clip_img_emb=False,
-                         noise_type='zeros',
-                         mode='matte',
-                         write_video=True,
-                         direct_output_dir=None,
-                         progress_callback=None):
+    def process_sequence(
+        self,
+        input_path,
+        output_dir,
+        num_frames_per_batch=8,
+        denoise_steps=1,
+        max_frames=None,
+        decode_chunk_size=8,
+        num_interp_frames=1,
+        num_overlap_frames=1,
+        use_clip_img_emb=False,
+        noise_type="zeros",
+        mode="matte",
+        write_video=True,
+        direct_output_dir=None,
+        progress_callback=None,
+    ):
         """
         Process a single video or directory of images.
         """
         input_path = Path(input_path)
         file_name = input_path.stem
-        is_video = input_path.suffix.lower() in ['.mp4', '.mkv', '.gif', '.mov', '.avi']
-        
+        is_video = input_path.suffix.lower() in [".mp4", ".mkv", ".gif", ".mov", ".avi"]
+
         # --- Determine Resolution & Upscaling ---
         if is_video:
             cap = cv2.VideoCapture(str(input_path))
@@ -143,38 +151,43 @@ class GVMProcessor:
             orig_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
             cap.release()
         else:
-            image_files = sorted([f for f in input_path.iterdir() if f.is_file() and f.suffix.lower() in ['.jpg', '.png', '.jpeg', '.exr']])
+            image_files = sorted(
+                [
+                    f
+                    for f in input_path.iterdir()
+                    if f.is_file() and f.suffix.lower() in [".jpg", ".png", ".jpeg", ".exr"]
+                ]
+            )
             if not image_files:
                 logger.warning(f"No images found in {input_path}")
                 return
             # Use cv2 for EXR support if needed
             first_img_path = str(image_files[0])
-            if first_img_path.lower().endswith('.exr'):
-                 # import cv2 # Global import used
-                 if "OPENCV_IO_ENABLE_OPENEXR" not in os.environ:
-                     os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
-                 img = cv2.imread(first_img_path, cv2.IMREAD_UNCHANGED)
+            if first_img_path.lower().endswith(".exr"):
+                # import cv2 # Global import used
+                if "OPENCV_IO_ENABLE_OPENEXR" not in os.environ:
+                    os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
+                img = cv2.imread(first_img_path, cv2.IMREAD_UNCHANGED)
             else:
-                 img = cv2.imread(first_img_path)
-                 
+                img = cv2.imread(first_img_path)
+
             if img is not None:
                 orig_h, orig_w = img.shape[:2]
             else:
-                orig_h, orig_w = 1080, 1920 # Fallback
+                orig_h, orig_w = 1080, 1920  # Fallback
 
         # MPS (Apple Silicon): reduce resolution to fit in unified memory.
         # SDPA on MPS has no FlashAttention, so O(N^2) memory scales fast.
-        is_mps = self.device.type == 'mps'
+        is_mps = self.device.type == "mps"
         _base_res = 512 if is_mps else 1024
         _scale_cap = 960 if is_mps else 1920
 
         target_h = orig_h
         if target_h < _base_res:
-            scale_ratio = _base_res / target_h
             target_h = _base_res
 
         # Calculate max resolution / long edge
-        if orig_h < orig_w: # Landscape
+        if orig_h < orig_w:  # Landscape
             ratio = orig_w / orig_h
             new_long = int(_base_res * ratio)
         else:
@@ -186,62 +199,66 @@ class GVMProcessor:
 
         max_res_param = new_long
 
-        transform = Compose([
-            ToTensor(),
-            Resize(size=_base_res, max_size=max_res_param, antialias=True)
-        ])
+        transform = Compose(
+            [ToTensor(), Resize(size=_base_res, max_size=max_res_param, antialias=True)]
+        )
 
         if is_video:
-            reader = VideoReader(
-                str(input_path), 
-                max_frames=max_frames,
-                transform=transform
-            )
+            reader = VideoReader(str(input_path), max_frames=max_frames, transform=transform)
         else:
-            reader = ImageSequenceReader(
-                str(input_path), 
-                transform=transform
-            )
+            reader = ImageSequenceReader(str(input_path), transform=transform)
 
         # Get upscaled shape from first frame
         first_frame = reader[0]
         if isinstance(first_frame, dict):
-             first_frame = first_frame['image']
-        
-        current_upscaled_shape = list(first_frame.shape[1:]) # H, W
-        if current_upscaled_shape[0] % 2 != 0: current_upscaled_shape[0] -= 1
-        if current_upscaled_shape[1] % 2 != 0: current_upscaled_shape[1] -= 1
+            first_frame = first_frame["image"]
+
+        current_upscaled_shape = list(first_frame.shape[1:])  # H, W
+        if current_upscaled_shape[0] % 2 != 0:
+            current_upscaled_shape[0] -= 1
+        if current_upscaled_shape[1] % 2 != 0:
+            current_upscaled_shape[1] -= 1
         current_upscaled_shape = tuple(current_upscaled_shape)
 
         # Output preparation
-        fps = reader.frame_rate if hasattr(reader, 'frame_rate') else 24.0
-        
+        fps = reader.frame_rate if hasattr(reader, "frame_rate") else 24.0
+
         if direct_output_dir:
             # Write directly to this folder
             os.makedirs(direct_output_dir, exist_ok=True)
-            writer_alpha_seq = ImageSequenceWriter(direct_output_dir, extension='png')
+            writer_alpha_seq = ImageSequenceWriter(direct_output_dir, extension="png")
             writer_alpha = None
             if write_video:
-                 # Warning: direct mode might not support video naming nicely without logic
-                 # Let's write video into the directory with fixed name
-                 writer_alpha = VideoWriter(osp.join(direct_output_dir, f"{file_name}_alpha.mp4"), frame_rate=fps)
+                # Warning: direct mode might not support video naming nicely without logic
+                # Let's write video into the directory with fixed name
+                writer_alpha = VideoWriter(
+                    osp.join(direct_output_dir, f"{file_name}_alpha.mp4"), frame_rate=fps
+                )
         else:
             # Create output directory for this specific file
             file_output_dir = osp.join(output_dir, file_name)
             os.makedirs(file_output_dir, exist_ok=True)
             logger.info(f"Processing {input_path} -> {file_output_dir}")
-            
-            writer_alpha = VideoWriter(osp.join(file_output_dir, f"{file_name}_alpha.mp4"), frame_rate=fps) if write_video else None
-            writer_alpha_seq = ImageSequenceWriter(osp.join(file_output_dir, "alpha_seq"), extension='png')
-        
+
+            writer_alpha = (
+                VideoWriter(osp.join(file_output_dir, f"{file_name}_alpha.mp4"), frame_rate=fps)
+                if write_video
+                else None
+            )
+            writer_alpha_seq = ImageSequenceWriter(
+                osp.join(file_output_dir, "alpha_seq"), extension="png"
+            )
+
         # Dataloader
         if is_video:
             dataloader = DataLoader(reader, batch_size=num_frames_per_batch)
         else:
-            dataloader = DataLoader(reader, batch_size=num_frames_per_batch, collate_fn=sequence_collate_fn)
+            dataloader = DataLoader(
+                reader, batch_size=num_frames_per_batch, collate_fn=sequence_collate_fn
+            )
 
-        upper_bound = 240./255.
-        lower_bound = 25./ 255.
+        upper_bound = 240.0 / 255.0
+        lower_bound = 25.0 / 255.0
 
         # Determine output directory for checkpoint detection
         _checkpoint_dir = direct_output_dir or osp.join(output_dir, file_name, "alpha_seq")
@@ -249,7 +266,9 @@ class GVMProcessor:
         skipped = 0
 
         total_batches = len(dataloader)
-        for batch_id, batch in tqdm(enumerate(dataloader), total=total_batches, desc=f"Inferencing {file_name}"):
+        for batch_id, batch in tqdm(
+            enumerate(dataloader), total=total_batches, desc=f"Inferencing {file_name}"
+        ):
             if progress_callback is not None:
                 progress_callback(batch_id, total_batches)
 
@@ -261,16 +280,15 @@ class GVMProcessor:
                     file_id = batch_id * b + i
                     filenames.append(f"{file_id:05d}.jpg")
             else:
-                filenames = batch['rgb_names']
-                batch = batch['rgb_values']
+                filenames = batch["rgb_names"]
+                batch = batch["rgb_values"]
 
             # Checkpoint: skip batch if ALL output frames already exist.
             # Always reprocess last 3 batches as safety margin against
             # partially-written files from an interrupted run.
-            out_names = [fn.split('.')[0] + '.' + _out_ext for fn in filenames]
+            out_names = [fn.split(".")[0] + "." + _out_ext for fn in filenames]
             is_tail = batch_id >= total_batches - 3
-            if (not is_tail
-                    and all(osp.exists(osp.join(_checkpoint_dir, n)) for n in out_names)):
+            if not is_tail and all(osp.exists(osp.join(_checkpoint_dir, n)) for n in out_names):
                 # Advance writer counter to stay in sync
                 writer_alpha_seq.counter += len(out_names)
                 skipped += 1
@@ -307,18 +325,22 @@ class GVMProcessor:
             alpha = alpha[:, :, pad_t:end_h, pad_l:end_w]
 
             # Resize to ensure exact match if there's any discrepancy
-            alpha = F.interpolate(alpha, current_upscaled_shape, mode='bilinear')
+            alpha = F.interpolate(alpha, current_upscaled_shape, mode="bilinear")
 
             # Threshold
-            alpha[alpha>=upper_bound] = 1.0
-            alpha[alpha<=lower_bound] = 0.0
+            alpha[alpha >= upper_bound] = 1.0
+            alpha[alpha <= lower_bound] = 0.0
 
-            if writer_alpha: writer_alpha.write(alpha)
+            if writer_alpha:
+                writer_alpha.write(alpha)
             writer_alpha_seq.write(alpha, filenames=filenames)
 
         if skipped:
-            logger.info(f"Checkpoint: skipped {skipped}/{total_batches} batches (frames already on disk)")
-        
-        if writer_alpha: writer_alpha.close()
+            logger.info(
+                f"Checkpoint: skipped {skipped}/{total_batches} batches (frames already on disk)"
+            )
+
+        if writer_alpha:
+            writer_alpha.close()
         writer_alpha_seq.close()
         logger.info(f"Finished {file_name}")

--- a/main.py
+++ b/main.py
@@ -5,9 +5,11 @@ Usage:
     python main.py --gui        # Launch GUI explicitly
     python main.py --cli        # Run CLI wizard (original clip_manager.py)
 """
+
 from __future__ import annotations
 
 import os
+
 # Enable OpenEXR support in OpenCV — must be set before cv2 is imported anywhere
 os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
 
@@ -56,7 +58,7 @@ def get_base_dir() -> str:
     In frozen build: returns sys._MEIPASS (PyInstaller temp dir) for bundled
     resources, or the executable's directory for user files.
     """
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         # Running as PyInstaller bundle
         return sys._MEIPASS
     return os.path.dirname(os.path.abspath(__file__))
@@ -64,8 +66,8 @@ def get_base_dir() -> str:
 
 def is_portable() -> bool:
     """True when a 'portable.txt' marker exists next to the executable."""
-    if getattr(sys, 'frozen', False):
-        return os.path.isfile(os.path.join(os.path.dirname(sys.executable), 'portable.txt'))
+    if getattr(sys, "frozen", False):
+        return os.path.isfile(os.path.join(os.path.dirname(sys.executable), "portable.txt"))
     return False
 
 
@@ -77,12 +79,12 @@ def get_app_dir() -> str:
     Windows frozen: returns the .exe directory (user-writable).
     Use get_base_dir() for bundled resources (checkpoints, QSS, fonts).
     """
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         if is_portable():
             return os.path.dirname(sys.executable)
-        if sys.platform == 'darwin':
+        if sys.platform == "darwin":
             support = os.path.join(
-                os.path.expanduser('~'), 'Library', 'Application Support', 'EZ-CorridorKey'
+                os.path.expanduser("~"), "Library", "Application Support", "EZ-CorridorKey"
             )
             os.makedirs(support, exist_ok=True)
             return support
@@ -92,6 +94,26 @@ def get_app_dir() -> str:
 
 # Ensure project root is on path
 sys.path.insert(0, get_base_dir())
+
+
+def _try_setup_rocm_env() -> None:
+    """Best-effort ROCm env before torch-heavy work; never raises."""
+    log = logging.getLogger(__name__)
+    try:
+        from device_utils import setup_rocm_env
+
+        setup_rocm_env()
+    except ImportError:
+        pass
+    except Exception:
+        if not log.handlers and not logging.root.handlers:
+            _early = logging.StreamHandler(sys.stderr)
+            _early.setLevel(logging.DEBUG)
+            _early.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+            log.addHandler(_early)
+            log.setLevel(logging.DEBUG)
+            log.propagate = False
+        log.debug("ROCm environment setup skipped", exc_info=True)
 
 
 def setup_logging(level: str = "INFO") -> None:
@@ -117,7 +139,9 @@ def setup_logging(level: str = "INFO") -> None:
     log_path = os.path.join(log_dir, f"{session_ts}_corridorkey.log")
 
     file_handler = logging.handlers.RotatingFileHandler(
-        log_path, maxBytes=50 * 1024 * 1024, backupCount=3,
+        log_path,
+        maxBytes=50 * 1024 * 1024,
+        backupCount=3,
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(logging.Formatter(fmt, datefmt="%Y-%m-%d %H:%M:%S"))
@@ -144,6 +168,7 @@ def run_gui() -> int:
 
     # First-launch setup: download model checkpoints if missing
     from ui.widgets.setup_wizard import needs_setup, SetupWizard
+
     if needs_setup():
         wizard = SetupWizard()
         if wizard.exec() == SetupWizard.Rejected:
@@ -151,8 +176,9 @@ def run_gui() -> int:
 
     # Frozen builds: point projects at the user-chosen install directory
     # (same location as model checkpoints) instead of the exe directory.
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         from backend.project import get_data_dir, set_app_dir
+
         set_app_dir(get_data_dir())
 
     service = CorridorKeyService()
@@ -205,6 +231,7 @@ def run_cli() -> int:
 
 def main() -> int:
     ensure_standard_streams()
+    _try_setup_rocm_env()
     parser = argparse.ArgumentParser(
         description="CorridorKey — AI Green Screen Keyer",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -231,7 +258,7 @@ def main() -> int:
         default=None,
         choices=["auto", "speed", "lowvram"],
         help="GPU optimization mode: auto (detect VRAM), speed (torch.compile), "
-             "lowvram (tiled refiner for 8GB cards). Overrides CORRIDORKEY_OPT_MODE env var.",
+        "lowvram (tiled refiner for 8GB cards). Overrides CORRIDORKEY_OPT_MODE env var.",
     )
 
     # parse_known_args so CLI-mode flags (--action, --win_path, etc.)
@@ -241,10 +268,11 @@ def main() -> int:
 
     # CLI flag takes priority over env var for optimization mode
     if args.opt_mode:
-        os.environ['CORRIDORKEY_OPT_MODE'] = args.opt_mode
+        os.environ["CORRIDORKEY_OPT_MODE"] = args.opt_mode
 
     # Configure backend with the application directory
     from backend.project import set_app_dir
+
     set_app_dir(get_app_dir())
 
     if args.cli:
@@ -254,5 +282,6 @@ def main() -> int:
 
 if __name__ == "__main__":
     import multiprocessing
+
     multiprocessing.freeze_support()
     sys.exit(main())

--- a/modules/BiRefNetModule/wrapper.py
+++ b/modules/BiRefNetModule/wrapper.py
@@ -14,6 +14,7 @@ Usage:
         cancel_check=fn,
     )
 """
+
 from __future__ import annotations
 
 import logging
@@ -69,11 +70,13 @@ class _ImagePreprocessor:
     """Resize and normalize for BiRefNet inference."""
 
     def __init__(self, resolution: Tuple[int, int] = (1024, 1024)) -> None:
-        self.transform = transforms.Compose([
-            transforms.Resize(resolution),
-            transforms.ToTensor(),
-            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-        ])
+        self.transform = transforms.Compose(
+            [
+                transforms.Resize(resolution),
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+            ]
+        )
 
     def __call__(self, image: Image.Image) -> torch.Tensor:
         return self.transform(image)
@@ -108,8 +111,7 @@ class BiRefNetProcessor:
         repo_name = BIREFNET_MODELS.get(self._usage)
         if repo_name is None:
             raise ValueError(
-                f"Unknown BiRefNet model '{self._usage}'. "
-                f"Available: {list(BIREFNET_MODELS.keys())}"
+                f"Unknown BiRefNet model '{self._usage}'. Available: {list(BIREFNET_MODELS.keys())}"
             )
 
         repo_id = f"ZhengPeng7/{repo_name}"
@@ -118,13 +120,15 @@ class BiRefNetProcessor:
 
         # Download if needed (idempotent — skips existing files)
         if not os.path.isdir(model_local_dir) or not any(
-            f.endswith(('.safetensors', '.bin')) for f in os.listdir(model_local_dir)
+            f.endswith((".safetensors", ".bin"))
+            for f in os.listdir(model_local_dir)
             if os.path.isfile(os.path.join(model_local_dir, f))
         ):
             if on_status:
                 on_status(f"Downloading {repo_name}...")
             logger.info(f"Downloading BiRefNet model: {repo_id}")
             from huggingface_hub import snapshot_download
+
             snapshot_download(
                 repo_id=repo_id,
                 local_dir=model_local_dir,
@@ -139,9 +143,10 @@ class BiRefNetProcessor:
         t0 = time.monotonic()
 
         # Enable TF32 for Ampere+ GPUs
-        torch.set_float32_matmul_precision('high')
+        torch.set_float32_matmul_precision("high")
 
         from transformers import AutoModelForImageSegmentation
+
         self._model = AutoModelForImageSegmentation.from_pretrained(
             model_local_dir, trust_remote_code=True
         )
@@ -266,7 +271,8 @@ class BiRefNetProcessor:
                     elapsed = time.monotonic() - _t_start
                     logger.info(
                         "BiRefNet: frame %d/%d, %.2fs/frame",
-                        frames_written, num_frames,
+                        frames_written,
+                        num_frames,
                         elapsed / frames_written,
                     )
 
@@ -286,15 +292,18 @@ class BiRefNetProcessor:
 
         except _CancelledError:
             import shutil
+
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
         except Exception:
             import shutil
+
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
         finally:
             if os.path.isdir(tmp_dir):
                 import shutil
+
                 shutil.rmtree(tmp_dir, ignore_errors=True)
 
         elapsed = time.monotonic() - _t_start
@@ -307,4 +316,5 @@ class BiRefNetProcessor:
 
 class _CancelledError(Exception):
     """Internal: raised when cancel_check returns True."""
+
     pass

--- a/modules/MatAnyone2Module/download_util/download_util.py
+++ b/modules/MatAnyone2Module/download_util/download_util.py
@@ -5,7 +5,8 @@ from torch.hub import download_url_to_file, get_dir
 from tqdm import tqdm
 from urllib.parse import urlparse
 
-def sizeof_fmt(size, suffix='B'):
+
+def sizeof_fmt(size, suffix="B"):
     """Get human readable file size.
 
     Args:
@@ -15,11 +16,11 @@ def sizeof_fmt(size, suffix='B'):
     Return:
         str: Formated file siz.
     """
-    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+    for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
         if abs(size) < 1024.0:
-            return f'{size:3.1f} {unit}{suffix}'
+            return f"{size:3.1f} {unit}{suffix}"
         size /= 1024.0
-    return f'{size:3.1f} Y{suffix}'
+    return f"{size:3.1f} Y{suffix}"
 
 
 def download_file_from_google_drive(file_id, save_path):
@@ -32,20 +33,22 @@ def download_file_from_google_drive(file_id, save_path):
     """
 
     session = requests.Session()
-    URL = 'https://docs.google.com/uc?export=download'
-    params = {'id': file_id}
+    URL = "https://docs.google.com/uc?export=download"
+    params = {"id": file_id}
 
     response = session.get(URL, params=params, stream=True)
     token = get_confirm_token(response)
     if token:
-        params['confirm'] = token
+        params["confirm"] = token
         response = session.get(URL, params=params, stream=True)
 
     # get file size
-    response_file_size = session.get(URL, params=params, stream=True, headers={'Range': 'bytes=0-2'})
+    response_file_size = session.get(
+        URL, params=params, stream=True, headers={"Range": "bytes=0-2"}
+    )
     print(response_file_size)
-    if 'Content-Range' in response_file_size.headers:
-        file_size = int(response_file_size.headers['Content-Range'].split('/')[1])
+    if "Content-Range" in response_file_size.headers:
+        file_size = int(response_file_size.headers["Content-Range"].split("/")[1])
     else:
         file_size = None
 
@@ -54,26 +57,28 @@ def download_file_from_google_drive(file_id, save_path):
 
 def get_confirm_token(response):
     for key, value in response.cookies.items():
-        if key.startswith('download_warning'):
+        if key.startswith("download_warning"):
             return value
     return None
 
 
 def save_response_content(response, destination, file_size=None, chunk_size=32768):
     if file_size is not None:
-        pbar = tqdm(total=math.ceil(file_size / chunk_size), unit='chunk')
+        pbar = tqdm(total=math.ceil(file_size / chunk_size), unit="chunk")
 
         readable_file_size = sizeof_fmt(file_size)
     else:
         pbar = None
 
-    with open(destination, 'wb') as f:
+    with open(destination, "wb") as f:
         downloaded_size = 0
         for chunk in response.iter_content(chunk_size):
             downloaded_size += chunk_size
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_description(f'Download {sizeof_fmt(downloaded_size)} / {readable_file_size}')
+                pbar.set_description(
+                    f"Download {sizeof_fmt(downloaded_size)} / {readable_file_size}"
+                )
             if chunk:  # filter out keep-alive new chunks
                 f.write(chunk)
         if pbar is not None:
@@ -94,7 +99,7 @@ def load_file_from_url(url, model_dir=None, progress=True, file_name=None):
     """
     if model_dir is None:  # use the pytorch hub_dir
         hub_dir = get_dir()
-        model_dir = os.path.join(hub_dir, 'checkpoints')
+        model_dir = os.path.join(hub_dir, "checkpoints")
 
     os.makedirs(model_dir, exist_ok=True)
 

--- a/modules/MatAnyone2Module/matanyone2/__init__.py
+++ b/modules/MatAnyone2Module/matanyone2/__init__.py
@@ -1,2 +1,4 @@
 from matanyone2.inference.inference_core import InferenceCore
 from matanyone2.model.matanyone2 import MatAnyone2
+
+__all__ = ["InferenceCore", "MatAnyone2"]

--- a/modules/MatAnyone2Module/matanyone2/inference/image_feature_store.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/image_feature_store.py
@@ -13,6 +13,7 @@ class ImageFeatureStore:
 
     Feature of a frame should be associated with a unique index -- typically the frame id.
     """
+
     def __init__(self, network: MatAnyone2, no_warning: bool = False):
         self.network = network
         self._store = {}
@@ -22,23 +23,31 @@ class ImageFeatureStore:
         ms_features, pix_feat = self.network.encode_image(image, last_feats=last_feats)
         key, shrinkage, selection = self.network.transform_key(ms_features[0])
         self._store[index] = (ms_features, pix_feat, key, shrinkage, selection)
-   
+
     def get_all_features(self, images: torch.Tensor) -> (Iterable[torch.Tensor], torch.Tensor):
         seq_length = images.shape[0]
         ms_features, pix_feat = self.network.encode_image(images, seq_length)
         key, shrinkage, selection = self.network.transform_key(ms_features[0])
         for index in range(seq_length):
-            self._store[index] = ([f[index].unsqueeze(0) for f in ms_features], pix_feat[index].unsqueeze(0), key[index].unsqueeze(0), shrinkage[index].unsqueeze(0), selection[index].unsqueeze(0))
+            self._store[index] = (
+                [f[index].unsqueeze(0) for f in ms_features],
+                pix_feat[index].unsqueeze(0),
+                key[index].unsqueeze(0),
+                shrinkage[index].unsqueeze(0),
+                selection[index].unsqueeze(0),
+            )
 
-    def get_features(self, index: int,
-                     image: torch.Tensor, last_feats=None) -> (Iterable[torch.Tensor], torch.Tensor):
+    def get_features(
+        self, index: int, image: torch.Tensor, last_feats=None
+    ) -> (Iterable[torch.Tensor], torch.Tensor):
         if index not in self._store:
             self._encode_feature(index, image, last_feats)
 
         return self._store[index][:2]
 
-    def get_key(self, index: int,
-                image: torch.Tensor, last_feats=None) -> (torch.Tensor, torch.Tensor, torch.Tensor):
+    def get_key(
+        self, index: int, image: torch.Tensor, last_feats=None
+    ) -> (torch.Tensor, torch.Tensor, torch.Tensor):
         if index not in self._store:
             self._encode_feature(index, image, last_feats)
 
@@ -53,4 +62,4 @@ class ImageFeatureStore:
 
     def __del__(self):
         if len(self._store) > 0 and not self.no_warning:
-            warnings.warn(f'Leaking {self._store.keys()} in the image feature store')
+            warnings.warn(f"Leaking {self._store.keys()} in the image feature store")

--- a/modules/MatAnyone2Module/matanyone2/inference/inference_core.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/inference_core.py
@@ -1,6 +1,6 @@
 import logging
 from omegaconf import DictConfig
-from typing import List, Optional, Iterable, Union,Tuple
+from typing import List, Optional, Iterable, Union, Tuple
 
 import os
 import cv2
@@ -25,14 +25,14 @@ log = logging.getLogger()
 
 
 class InferenceCore:
-
-    def __init__(self,
-                 network: Union[MatAnyone2,str],
-                 cfg: DictConfig = None,
-                 *,
-                 image_feature_store: ImageFeatureStore = None,
-                 device: Optional[Union[str, torch.device]] = None
-                 ):
+    def __init__(
+        self,
+        network: Union[MatAnyone2, str],
+        cfg: DictConfig = None,
+        *,
+        image_feature_store: ImageFeatureStore = None,
+        device: Optional[Union[str, torch.device]] = None,
+    ):
         if device is None:
             device = get_default_device()
         self.device = device
@@ -40,7 +40,7 @@ class InferenceCore:
             network = MatAnyone2.from_pretrained(network)
         network.to(device)
         network.eval()
-        self.network = network  
+        self.network = network
         cfg = cfg if cfg is not None else network.cfg
         self.cfg = cfg
         self.mem_every = cfg.mem_every
@@ -57,7 +57,8 @@ class InferenceCore:
             self.stagger_ti = set(range(1, self.mem_every + 1))
         else:
             self.stagger_ti = set(
-                np.round(np.linspace(1, self.mem_every, stagger_updates)).astype(int))
+                np.round(np.linspace(1, self.mem_every, stagger_updates)).astype(int)
+            )
         self.object_manager = ObjectManager()
         self.memory = MemoryManager(cfg=cfg, object_manager=self.object_manager)
 
@@ -86,25 +87,27 @@ class InferenceCore:
         self.memory.clear_sensory_memory()
 
     def update_config(self, cfg):
-        self.mem_every = cfg['mem_every']
+        self.mem_every = cfg["mem_every"]
         self.memory.update_config(cfg)
-    
+
     def clear_temp_mem(self):
         self.memory.clear_work_mem()
         # self.object_manager = ObjectManager()
         self.memory.clear_obj_mem()
         # self.memory.clear_sensory_memory()
 
-    def _add_memory(self,
-                    image: torch.Tensor,
-                    pix_feat: torch.Tensor,
-                    prob: torch.Tensor,
-                    key: torch.Tensor,
-                    shrinkage: torch.Tensor,
-                    selection: torch.Tensor,
-                    *,
-                    is_deep_update: bool = True,
-                    force_permanent: bool = False) -> None:
+    def _add_memory(
+        self,
+        image: torch.Tensor,
+        pix_feat: torch.Tensor,
+        prob: torch.Tensor,
+        key: torch.Tensor,
+        shrinkage: torch.Tensor,
+        selection: torch.Tensor,
+        *,
+        is_deep_update: bool = True,
+        force_permanent: bool = False,
+    ) -> None:
         """
         Memorize the given segmentation in all memory stores.
 
@@ -119,13 +122,13 @@ class InferenceCore:
         """
         if prob.shape[1] == 0:
             # nothing to add
-            log.warn('Trying to add an empty object mask to memory!')
+            log.warn("Trying to add an empty object mask to memory!")
             return
 
         if force_permanent:
-            as_permanent = 'all'
+            as_permanent = "all"
         else:
-            as_permanent = 'first'
+            as_permanent = "first"
 
         self.memory.initialize_sensory_if_needed(key, self.object_manager.all_obj_ids)
         msk_value, sensory, obj_value, _ = self.network.encode_mask(
@@ -135,25 +138,30 @@ class InferenceCore:
             prob,
             deep_update=is_deep_update,
             chunk_size=self.chunk_size,
-            need_weights=self.save_aux)
-        self.memory.add_memory(key,
-                               shrinkage,
-                               msk_value,
-                               obj_value,
-                               self.object_manager.all_obj_ids,
-                               selection=selection,
-                               as_permanent=as_permanent)
+            need_weights=self.save_aux,
+        )
+        self.memory.add_memory(
+            key,
+            shrinkage,
+            msk_value,
+            obj_value,
+            self.object_manager.all_obj_ids,
+            selection=selection,
+            as_permanent=as_permanent,
+        )
         self.last_mem_ti = self.curr_ti
         if is_deep_update:
             self.memory.update_sensory(sensory, self.object_manager.all_obj_ids)
         self.last_msk_value = msk_value
 
-    def _segment(self,
-                 key: torch.Tensor,
-                 selection: torch.Tensor,
-                 pix_feat: torch.Tensor,
-                 ms_features: Iterable[torch.Tensor],
-                 update_sensory: bool = True) -> torch.Tensor:
+    def _segment(
+        self,
+        key: torch.Tensor,
+        selection: torch.Tensor,
+        pix_feat: torch.Tensor,
+        ms_features: Iterable[torch.Tensor],
+        update_sensory: bool = True,
+    ) -> torch.Tensor:
         """
         Produce a segmentation using the given features and the memory
 
@@ -173,60 +181,80 @@ class InferenceCore:
             assert bs == 1
 
         if not self.memory.engaged:
-            log.warn('Trying to segment without any memory!')
-            return torch.zeros((1, key.shape[-2] * 16, key.shape[-1] * 16),
-                               device=key.device,
-                               dtype=key.dtype)
-        
+            log.warn("Trying to segment without any memory!")
+            return torch.zeros(
+                (1, key.shape[-2] * 16, key.shape[-1] * 16), device=key.device, dtype=key.dtype
+            )
+
         uncert_output = None
 
-        if self.curr_ti == 0: # ONLY for the first frame for prediction
-            memory_readout = self.memory.read_first_frame(self.last_msk_value, pix_feat, self.last_mask, self.network, uncert_output=uncert_output)
+        if self.curr_ti == 0:  # ONLY for the first frame for prediction
+            memory_readout = self.memory.read_first_frame(
+                self.last_msk_value,
+                pix_feat,
+                self.last_mask,
+                self.network,
+                uncert_output=uncert_output,
+            )
         else:
-            memory_readout = self.memory.read(pix_feat, key, selection, self.last_mask, self.network, uncert_output=uncert_output, last_msk_value=self.last_msk_value, ti=self.curr_ti, 
-                                              last_pix_feat=self.last_pix_feat, last_pred_mask=self.last_mask)
+            memory_readout = self.memory.read(
+                pix_feat,
+                key,
+                selection,
+                self.last_mask,
+                self.network,
+                uncert_output=uncert_output,
+                last_msk_value=self.last_msk_value,
+                ti=self.curr_ti,
+                last_pix_feat=self.last_pix_feat,
+                last_pred_mask=self.last_mask,
+            )
         memory_readout = self.object_manager.realize_dict(memory_readout)
 
-        sensory, _, pred_prob_with_bg = self.network.segment(ms_features,
-                                                        memory_readout,
-                                                        self.memory.get_sensory(
-                                                            self.object_manager.all_obj_ids),
-                                                        chunk_size=self.chunk_size,
-                                                        update_sensory=update_sensory)
+        sensory, _, pred_prob_with_bg = self.network.segment(
+            ms_features,
+            memory_readout,
+            self.memory.get_sensory(self.object_manager.all_obj_ids),
+            chunk_size=self.chunk_size,
+            update_sensory=update_sensory,
+        )
         # remove batch dim
         if self.flip_aug:
             # average predictions of the non-flipped and flipped version
-            pred_prob_with_bg = (pred_prob_with_bg[0] +
-                                 torch.flip(pred_prob_with_bg[1], dims=[-1])) / 2
+            pred_prob_with_bg = (
+                pred_prob_with_bg[0] + torch.flip(pred_prob_with_bg[1], dims=[-1])
+            ) / 2
         else:
             pred_prob_with_bg = pred_prob_with_bg[0]
         if update_sensory:
             self.memory.update_sensory(sensory, self.object_manager.all_obj_ids)
         return pred_prob_with_bg
-    
+
     def pred_all_flow(self, images):
         self.total_len = images.shape[0]
         images, self.pad = pad_divide_by(images, 16)
         images = images.unsqueeze(0)  # add the batch dimension: (1,t,c,h,w)
-        
+
         self.flows_forward, self.flows_backward = self.network.pred_forward_backward_flow(images)
 
     def encode_all_images(self, images):
         images, self.pad = pad_divide_by(images, 16)
-        self.image_feature_store.get_all_features(images) # t c h w
+        self.image_feature_store.get_all_features(images)  # t c h w
         return images
 
-    def step(self,
-             image: torch.Tensor,
-             mask: Optional[torch.Tensor] = None,
-             objects: Optional[List[int]] = None,
-             *,
-             idx_mask: bool = False,
-             end: bool = False,
-             delete_buffer: bool = True,
-             force_permanent: bool = False,
-             matting: bool = True,
-             first_frame_pred: bool = False) -> torch.Tensor:
+    def step(
+        self,
+        image: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        objects: Optional[List[int]] = None,
+        *,
+        idx_mask: bool = False,
+        end: bool = False,
+        delete_buffer: bool = True,
+        force_permanent: bool = False,
+        matting: bool = True,
+        first_frame_pred: bool = False,
+    ) -> torch.Tensor:
         """
         Take a step with a new incoming image.
         If there is an incoming mask with new objects, we will memorize them.
@@ -236,15 +264,15 @@ class InferenceCore:
         image: 3*H*W
         mask: H*W (if idx mask) or len(objects)*H*W or None
         objects: list of object ids that are valid in the mask Tensor.
-                The ids themselves do not need to be consecutive/in order, but they need to be 
+                The ids themselves do not need to be consecutive/in order, but they need to be
                 in the same position in the list as the corresponding mask
                 in the tensor in non-idx-mask mode.
-                objects is ignored if the mask is None. 
+                objects is ignored if the mask is None.
                 If idx_mask is False and objects is None, we sequentially infer the object ids.
         idx_mask: if True, mask is expected to contain an object id at every pixel.
                   If False, mask should have multiple channels with each channel representing one object.
         end: if we are at the end of the sequence, we do not need to update memory
-            if unsure just set it to False 
+            if unsure just set it to False
         delete_buffer: whether to delete the image feature buffer after this step
         force_permanent: the memory recorded this frame will be added to the permanent memory
         """
@@ -261,42 +289,51 @@ class InferenceCore:
                 resize_needed = True
                 new_h = int(h / min_side * self.max_internal_size)
                 new_w = int(w / min_side * self.max_internal_size)
-                image = F.interpolate(image.unsqueeze(0),
-                                      size=(new_h, new_w),
-                                      mode='bilinear',
-                                      align_corners=False)[0]
+                image = F.interpolate(
+                    image.unsqueeze(0), size=(new_h, new_w), mode="bilinear", align_corners=False
+                )[0]
                 if mask is not None:
                     if idx_mask:
-                        mask = F.interpolate(mask.unsqueeze(0).unsqueeze(0).float(),
-                                             size=(new_h, new_w),
-                                             mode='nearest-exact',
-                                             align_corners=False)[0, 0].round().long()
+                        mask = (
+                            F.interpolate(
+                                mask.unsqueeze(0).unsqueeze(0).float(),
+                                size=(new_h, new_w),
+                                mode="nearest-exact",
+                                align_corners=False,
+                            )[0, 0]
+                            .round()
+                            .long()
+                        )
                     else:
                         # Ensure mask is at least 3D for F.interpolate (N, C, H, W)
                         _squeeze_back = False
                         if mask.ndim == 2:
                             mask = mask.unsqueeze(0)  # (H, W) → (1, H, W)
                             _squeeze_back = True
-                        mask = F.interpolate(mask.unsqueeze(0),
-                                             size=(new_h, new_w),
-                                             mode='bilinear',
-                                             align_corners=False)[0]
+                        mask = F.interpolate(
+                            mask.unsqueeze(0),
+                            size=(new_h, new_w),
+                            mode="bilinear",
+                            align_corners=False,
+                        )[0]
                         if _squeeze_back:
                             mask = mask.squeeze(0)  # restore (H, W)
 
         self.curr_ti += 1
 
-        image, self.pad = pad_divide_by(image, 16) # DONE alreay for 3DCNN!!
+        image, self.pad = pad_divide_by(image, 16)  # DONE alreay for 3DCNN!!
         image = image.unsqueeze(0)  # add the batch dimension
         if self.flip_aug:
             image = torch.cat([image, torch.flip(image, dims=[-1])], dim=0)
 
         # whether to update the working memory
-        is_mem_frame = ((self.curr_ti - self.last_mem_ti >= self.mem_every) or
-                        (mask is not None)) and (not end)
+        is_mem_frame = (
+            (self.curr_ti - self.last_mem_ti >= self.mem_every) or (mask is not None)
+        ) and (not end)
         # segment when there is no input mask or when the input mask is incomplete
-        need_segment = (mask is None) or (self.object_manager.num_obj > 0
-                                          and not self.object_manager.has_all(objects))
+        need_segment = (mask is None) or (
+            self.object_manager.num_obj > 0 and not self.object_manager.has_all(objects)
+        )
         update_sensory = ((self.curr_ti - self.last_mem_ti) in self.stagger_ti) and (not end)
 
         # reinit if it is the first frame for prediction
@@ -313,11 +350,9 @@ class InferenceCore:
 
         # segmentation from memory if needed
         if need_segment:
-            pred_prob_with_bg = self._segment(key,
-                                              selection,
-                                              pix_feat,
-                                              ms_feat,
-                                              update_sensory=update_sensory)
+            pred_prob_with_bg = self._segment(
+                key, selection, pix_feat, ms_feat, update_sensory=update_sensory
+            )
 
         # use the input mask if provided
         if mask is not None:
@@ -354,16 +389,19 @@ class InferenceCore:
                 if len(objects) == 0:
                     if delete_buffer:
                         self.image_feature_store.delete(self.curr_ti)
-                    log.warn('Trying to insert an empty mask as memory!')
-                    return torch.zeros((1, key.shape[-2] * 16, key.shape[-1] * 16),
-                                       device=key.device,
-                                       dtype=key.dtype)
+                    log.warn("Trying to insert an empty mask as memory!")
+                    return torch.zeros(
+                        (1, key.shape[-2] * 16, key.shape[-1] * 16),
+                        device=key.device,
+                        dtype=key.dtype,
+                    )
                 mask = torch.stack(
                     [mask == objects[mask_id] for mask_id, _ in enumerate(corresponding_tmp_ids)],
-                    dim=0)
+                    dim=0,
+                )
             if matting:
-                mask = mask.unsqueeze(0).float() / 255.
-                pred_prob_with_bg = torch.cat([1-mask, mask], 0)
+                mask = mask.unsqueeze(0).float() / 255.0
+                pred_prob_with_bg = torch.cat([1 - mask, mask], 0)
             else:
                 pred_prob_with_bg = aggregate(mask, dim=0)
                 pred_prob_with_bg = torch.softmax(pred_prob_with_bg, dim=0)
@@ -371,7 +409,8 @@ class InferenceCore:
         self.last_mask = pred_prob_with_bg[1:].unsqueeze(0)
         if self.flip_aug:
             self.last_mask = torch.cat(
-                [self.last_mask, torch.flip(self.last_mask, dims=[-1])], dim=0)
+                [self.last_mask, torch.flip(self.last_mask, dims=[-1])], dim=0
+            )
         self.last_pix_feat = pix_feat
 
         # save as memory if needed
@@ -379,23 +418,26 @@ class InferenceCore:
             # clear the memory for given mask and add the first predicted mask
             if first_frame_pred:
                 self.clear_temp_mem()
-            self._add_memory(image,
-                             pix_feat,
-                             self.last_mask,
-                             key,
-                             shrinkage,
-                             selection,
-                             force_permanent=force_permanent,
-                             is_deep_update=True)
-        else: # compute self.last_msk_value for non-memory frame 
+            self._add_memory(
+                image,
+                pix_feat,
+                self.last_mask,
+                key,
+                shrinkage,
+                selection,
+                force_permanent=force_permanent,
+                is_deep_update=True,
+            )
+        else:  # compute self.last_msk_value for non-memory frame
             msk_value, _, _, _ = self.network.encode_mask(
-                            image,
-                            pix_feat,
-                            self.memory.get_sensory(self.object_manager.all_obj_ids),
-                            self.last_mask,
-                            deep_update=False,
-                            chunk_size=self.chunk_size,
-                            need_weights=self.save_aux)
+                image,
+                pix_feat,
+                self.memory.get_sensory(self.object_manager.all_obj_ids),
+                self.last_mask,
+                deep_update=False,
+                chunk_size=self.chunk_size,
+                need_weights=self.save_aux,
+            )
             self.last_msk_value = msk_value
 
         if delete_buffer:
@@ -404,10 +446,9 @@ class InferenceCore:
         output_prob = unpad(pred_prob_with_bg, self.pad)
         if resize_needed:
             # restore output to the original size
-            output_prob = F.interpolate(output_prob.unsqueeze(0),
-                                        size=(h, w),
-                                        mode='bilinear',
-                                        align_corners=False)[0]
+            output_prob = F.interpolate(
+                output_prob.unsqueeze(0), size=(h, w), mode="bilinear", align_corners=False
+            )[0]
 
         return output_prob
 
@@ -500,7 +541,7 @@ class InferenceCore:
             mask = gen_dilate(mask, r_dilate, r_dilate)
         if r_erode > 0:
             mask = gen_erosion(mask, r_erode, r_erode)
-        
+
         mask = torch.from_numpy(mask).float().to(self.device)
         if max_size > 0:
             mask = F.interpolate(
@@ -547,11 +588,11 @@ class InferenceCore:
 
         fgrs = np.array(fgrs)
         phas = np.array(phas)
-        
+
         fgr_filename = f"{output_path}/{video_name}_fgr.mp4"
         alpha_filename = f"{output_path}/{video_name}_pha.mp4"
-        
+
         imageio.mimwrite(fgr_filename, fgrs, fps=fps, quality=7)
         imageio.mimwrite(alpha_filename, phas, fps=fps, quality=7)
-        
-        return (fgr_filename,alpha_filename)
+
+        return (fgr_filename, alpha_filename)

--- a/modules/MatAnyone2Module/matanyone2/inference/kv_memory_store.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/kv_memory_store.py
@@ -18,6 +18,7 @@ class KeyValueMemoryStore:
     Works for key/value pairs type storage
     e.g., working and long-term memory
     """
+
     def __init__(self, save_selection: bool = False, save_usage: bool = False):
         """
         We store keys and values of objects that first appear in the same frame in a bucket.
@@ -48,13 +49,15 @@ class KeyValueMemoryStore:
             self.use_cnt = {}  # indexed by bucket id, does not contain the permanent memory part
             self.life_cnt = {}  # indexed by bucket id, does not contain the permanent memory part
 
-    def add(self,
-            key: torch.Tensor,
-            values: Dict[int, torch.Tensor],
-            shrinkage: torch.Tensor,
-            selection: torch.Tensor,
-            supposed_bucket_id: int = -1,
-            as_permanent: Literal['no', 'first', 'all'] = 'no') -> None:
+    def add(
+        self,
+        key: torch.Tensor,
+        values: Dict[int, torch.Tensor],
+        shrinkage: torch.Tensor,
+        selection: torch.Tensor,
+        supposed_bucket_id: int = -1,
+        as_permanent: Literal["no", "first", "all"] = "no",
+    ) -> None:
         """
         key: (1/2)*C*N
         values: dict of values ((1/2)*C*N), object ids are used as keys
@@ -73,7 +76,7 @@ class KeyValueMemoryStore:
         assert len(key.shape) == 3
         assert len(shrinkage.shape) == 3
         assert not self.save_selection or len(selection.shape) == 3
-        assert as_permanent in ['no', 'first', 'all']
+        assert as_permanent in ["no", "first", "all"]
 
         # add the value and create new buckets if necessary
         if supposed_bucket_id >= 0:
@@ -83,7 +86,7 @@ class KeyValueMemoryStore:
                 if bucket_exist:
                     assert obj in self.v
                     assert obj in self.buckets[supposed_bucket_id]
-                    _add_last_dim(self.v, obj, value, prepend=(as_permanent == 'all'))
+                    _add_last_dim(self.v, obj, value, prepend=(as_permanent == "all"))
                 else:
                     assert obj not in self.v
                     self.v[obj] = value
@@ -94,9 +97,10 @@ class KeyValueMemoryStore:
             for obj, value in values.items():
                 assert len(value.shape) == 3
                 if obj in self.v:
-                    _add_last_dim(self.v, obj, value, prepend=(as_permanent == 'all'))
+                    _add_last_dim(self.v, obj, value, prepend=(as_permanent == "all"))
                     bucket_used = [
-                        bucket_id for bucket_id, object_ids in self.buckets.items()
+                        bucket_id
+                        for bucket_id, object_ids in self.buckets.items()
                         if obj in object_ids
                     ]
                     assert len(bucket_used) == 1  # each object should only be in one bucket
@@ -116,16 +120,16 @@ class KeyValueMemoryStore:
         add_as_permanent = {}  # indexed by bucket id
         for bucket_id in enabled_buckets:
             add_as_permanent[bucket_id] = False
-            if as_permanent == 'all':
+            if as_permanent == "all":
                 self.perm_end_pt[bucket_id] += ne
                 add_as_permanent[bucket_id] = True
-            elif as_permanent == 'first':
+            elif as_permanent == "first":
                 if self.perm_end_pt[bucket_id] == 0:
                     self.perm_end_pt[bucket_id] = ne
                     add_as_permanent[bucket_id] = True
 
         # create new counters for usage if necessary
-        if self.save_usage and as_permanent != 'all':
+        if self.save_usage and as_permanent != "all":
             new_count = torch.zeros((bs, ne), device=key.device, dtype=torch.float32)
             new_life = torch.zeros((bs, ne), device=key.device, dtype=torch.float32) + 1e-7
 
@@ -150,7 +154,7 @@ class KeyValueMemoryStore:
         if not self.save_usage:
             return
 
-        usage = usage[:, self.perm_end_pt[bucket_id]:]
+        usage = usage[:, self.perm_end_pt[bucket_id] :]
         if usage.shape[-1] == 0:
             # if there is no temporary memory, we don't need to update
             return
@@ -190,11 +194,14 @@ class KeyValueMemoryStore:
         self.k[bucket_id] = torch.cat([k[:, :, :start], k[:, :, end:]], -1)
         self.s[bucket_id] = torch.cat([s[:, :, :start], s[:, :, end:]], -1)
         if self.save_selection:
-            self.e[bucket_id] = torch.cat([e[:, :, :start - p_size], e[:, :, end:]], -1)
+            self.e[bucket_id] = torch.cat([e[:, :, : start - p_size], e[:, :, end:]], -1)
         if self.save_usage:
-            self.use_cnt[bucket_id] = torch.cat([use_cnt[:, :start - p_size], use_cnt[:, end:]], -1)
-            self.life_cnt[bucket_id] = torch.cat([life_cnt[:, :start - p_size], life_cnt[:, end:]],
-                                                 -1)
+            self.use_cnt[bucket_id] = torch.cat(
+                [use_cnt[:, : start - p_size], use_cnt[:, end:]], -1
+            )
+            self.life_cnt[bucket_id] = torch.cat(
+                [life_cnt[:, : start - p_size], life_cnt[:, end:]], -1
+            )
         for obj_id in object_ids:
             v = self.v[obj_id]
             self.v[obj_id] = torch.cat([v[:, :, :start], v[:, :, end:]], -1)
@@ -220,27 +227,33 @@ class KeyValueMemoryStore:
             assert survived.shape[-1] == survivals[0].shape[-1]
 
         self.k[bucket_id] = torch.stack(
-            [self.k[bucket_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0)
+            [self.k[bucket_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0
+        )
         self.s[bucket_id] = torch.stack(
-            [self.s[bucket_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0)
+            [self.s[bucket_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0
+        )
 
         if self.save_selection:
             # Long-term memory does not store selection so this should not be needed
             self.e[bucket_id] = torch.stack(
-                [self.e[bucket_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0)
+                [self.e[bucket_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0
+            )
         for obj_id in object_ids:
             self.v[obj_id] = torch.stack(
-                [self.v[obj_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0)
+                [self.v[obj_id][bi, :, survived] for bi, survived in enumerate(survivals)], 0
+            )
 
         self.use_cnt[bucket_id] = torch.stack(
-            [self.use_cnt[bucket_id][bi, survived] for bi, survived in enumerate(survivals)], 0)
+            [self.use_cnt[bucket_id][bi, survived] for bi, survived in enumerate(survivals)], 0
+        )
         self.life_cnt[bucket_id] = torch.stack(
-            [self.life_cnt[bucket_id][bi, survived] for bi, survived in enumerate(survivals)], 0)
+            [self.life_cnt[bucket_id][bi, survived] for bi, survived in enumerate(survivals)], 0
+        )
 
     def get_usage(self, bucket_id: int) -> torch.Tensor:
         # return normalized usage
         if not self.save_usage:
-            raise RuntimeError('I did not count usage!')
+            raise RuntimeError("I did not count usage!")
         else:
             usage = self.use_cnt[bucket_id] / self.life_cnt[bucket_id]
             return usage
@@ -261,15 +274,15 @@ class KeyValueMemoryStore:
             # negative 0 would not work as the end index!
             k = self.k[bucket_id][:, :, start:]
             sk = self.s[bucket_id][:, :, start:]
-            ek = self.e[bucket_id][:, :, start - p_size:] if self.save_selection else None
+            ek = self.e[bucket_id][:, :, start - p_size :] if self.save_selection else None
             value = {obj_id: self.v[obj_id][:, :, start:] for obj_id in self.buckets[bucket_id]}
-            usage = self.get_usage(bucket_id)[:, start - p_size:] if self.save_usage else None
+            usage = self.get_usage(bucket_id)[:, start - p_size :] if self.save_usage else None
         else:
             k = self.k[bucket_id][:, :, start:end]
             sk = self.s[bucket_id][:, :, start:end]
-            ek = self.e[bucket_id][:, :, start - p_size:end] if self.save_selection else None
+            ek = self.e[bucket_id][:, :, start - p_size : end] if self.save_selection else None
             value = {obj_id: self.v[obj_id][:, :, start:end] for obj_id in self.buckets[bucket_id]}
-            usage = self.get_usage(bucket_id)[:, start - p_size:end] if self.save_usage else None
+            usage = self.get_usage(bucket_id)[:, start - p_size : end] if self.save_usage else None
 
         return k, sk, ek, value, usage
 

--- a/modules/MatAnyone2Module/matanyone2/inference/memory_manager.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/memory_manager.py
@@ -15,6 +15,7 @@ class MemoryManager:
     """
     Manages all three memory stores and the transition between working/long-term memory
     """
+
     def __init__(self, cfg: DictConfig, object_manager: ObjectManager):
         self.object_manager = object_manager
         self.sensory_dim = cfg.model.sensory_dim
@@ -48,8 +49,9 @@ class MemoryManager:
         # a dictionary indexed by object ids, each of shape bs * T * Q * C
         self.obj_v = {}
 
-        self.work_mem = KeyValueMemoryStore(save_selection=self.use_long_term,
-                                            save_usage=self.use_long_term)
+        self.work_mem = KeyValueMemoryStore(
+            save_selection=self.use_long_term, save_usage=self.use_long_term
+        )
         if self.use_long_term:
             self.long_mem = KeyValueMemoryStore(save_usage=self.count_long_term_usage)
 
@@ -58,10 +60,10 @@ class MemoryManager:
 
     def update_config(self, cfg: DictConfig) -> None:
         self.config_stale = True
-        self.top_k = cfg['top_k']
+        self.top_k = cfg["top_k"]
 
-        assert self.use_long_term == cfg.use_long_term, 'cannot update this'
-        assert self.count_long_term_usage == cfg.long_term.count_usage, 'cannot update this'
+        assert self.use_long_term == cfg.use_long_term, "cannot update this"
+        assert self.count_long_term_usage == cfg.long_term.count_usage, "cannot update this"
 
         self.use_long_term = cfg.use_long_term
         self.count_long_term_usage = cfg.long_term.count_usage
@@ -111,9 +113,15 @@ class MemoryManager:
             value = torch.cat([lt_value, value], dim=-1)
 
         return value
-    
-    def read_first_frame(self, last_msk_value, pix_feat: torch.Tensor, 
-             last_mask: torch.Tensor, network: MatAnyone2, uncert_output=None) -> Dict[int, torch.Tensor]:
+
+    def read_first_frame(
+        self,
+        last_msk_value,
+        pix_feat: torch.Tensor,
+        last_mask: torch.Tensor,
+        network: MatAnyone2,
+        uncert_output=None,
+    ) -> Dict[int, torch.Tensor]:
         """
         Read from all memory stores and returns a single memory readout tensor for each object
 
@@ -133,20 +141,20 @@ class MemoryManager:
         all_readout_mem = {}
         buckets = self.work_mem.buckets
         for bucket_id, bucket in buckets.items():
-
             if self.chunk_size < 1:
                 object_chunks = [bucket]
             else:
                 object_chunks = [
-                    bucket[i:i + self.chunk_size] for i in range(0, len(bucket), self.chunk_size)
+                    bucket[i : i + self.chunk_size] for i in range(0, len(bucket), self.chunk_size)
                 ]
 
             for objects in object_chunks:
                 this_sensory = self._get_sensory_by_ids(objects)
                 this_last_mask = self._get_mask_by_ids(last_mask, objects)
-                this_msk_value = self._get_visual_values_by_ids(objects)  # (1/2)*num_objects*C*N
-                pixel_readout = network.pixel_fusion(pix_feat, last_msk_value, this_sensory,
-                                                     this_last_mask)
+                _this_msk_value = self._get_visual_values_by_ids(objects)  # (1/2)*num_objects*C*N
+                pixel_readout = network.pixel_fusion(
+                    pix_feat, last_msk_value, this_sensory, this_last_mask
+                )
                 this_obj_mem = self._get_object_mem_by_ids(objects).unsqueeze(2)
                 readout_memory, aux_features = network.readout_query(pixel_readout, this_obj_mem)
                 for i, obj in enumerate(objects):
@@ -156,7 +164,7 @@ class MemoryManager:
                     aux_output = {
                         # 'sensory': this_sensory,
                         # 'pixel_readout': pixel_readout,
-                        'q_logits': aux_features['logits'] if aux_features else None,
+                        "q_logits": aux_features["logits"] if aux_features else None,
                         # 'q_weights': aux_features['q_weights'] if aux_features else None,
                         # 'p_weights': aux_features['p_weights'] if aux_features else None,
                         # 'attn_mask': aux_features['attn_mask'].float() if aux_features else None,
@@ -165,9 +173,19 @@ class MemoryManager:
 
         return all_readout_mem
 
-    def read(self, pix_feat: torch.Tensor, query_key: torch.Tensor, selection: torch.Tensor,
-             last_mask: torch.Tensor, network: MatAnyone2, uncert_output=None, last_msk_value=None, ti=None,
-             last_pix_feat=None, last_pred_mask=None) -> Dict[int, torch.Tensor]:
+    def read(
+        self,
+        pix_feat: torch.Tensor,
+        query_key: torch.Tensor,
+        selection: torch.Tensor,
+        last_mask: torch.Tensor,
+        network: MatAnyone2,
+        uncert_output=None,
+        last_msk_value=None,
+        ti=None,
+        last_pix_feat=None,
+        last_pred_mask=None,
+    ) -> Dict[int, torch.Tensor]:
         """
         Read from all memory stores and returns a single memory readout tensor for each object
 
@@ -196,16 +214,17 @@ class MemoryManager:
             if self.use_long_term and self.long_mem.engaged(bucket_id):
                 # Use long-term memory
                 long_mem_size = self.long_mem.size(bucket_id)
-                memory_key = torch.cat([self.long_mem.key[bucket_id], self.work_mem.key[bucket_id]],
-                                       -1)
+                memory_key = torch.cat(
+                    [self.long_mem.key[bucket_id], self.work_mem.key[bucket_id]], -1
+                )
                 shrinkage = torch.cat(
-                    [self.long_mem.shrinkage[bucket_id], self.work_mem.shrinkage[bucket_id]], -1)
+                    [self.long_mem.shrinkage[bucket_id], self.work_mem.shrinkage[bucket_id]], -1
+                )
 
                 similarity = get_similarity(memory_key, shrinkage, query_key, selection)
-                affinity, usage = do_softmax(similarity,
-                                             top_k=self.top_k,
-                                             inplace=True,
-                                             return_usage=True)
+                affinity, usage = do_softmax(
+                    similarity, top_k=self.top_k, inplace=True, return_usage=True
+                )
                 """
                 Record memory usage for working and long-term memory
                 """
@@ -221,13 +240,14 @@ class MemoryManager:
                 # no long-term memory
                 memory_key = self.work_mem.key[bucket_id]
                 shrinkage = self.work_mem.shrinkage[bucket_id]
-                similarity = get_similarity(memory_key, shrinkage, query_key, selection, uncert_mask=uncert_mask)
+                similarity = get_similarity(
+                    memory_key, shrinkage, query_key, selection, uncert_mask=uncert_mask
+                )
 
                 if self.use_long_term:
-                    affinity, usage = do_softmax(similarity,
-                                                 top_k=self.top_k,
-                                                 inplace=True,
-                                                 return_usage=True)
+                    affinity, usage = do_softmax(
+                        similarity, top_k=self.top_k, inplace=True, return_usage=True
+                    )
                     self.work_mem.update_bucket_usage(bucket_id, usage)
                 else:
                     affinity = do_softmax(similarity, top_k=self.top_k, inplace=True)
@@ -236,24 +256,33 @@ class MemoryManager:
                 object_chunks = [bucket]
             else:
                 object_chunks = [
-                    bucket[i:i + self.chunk_size] for i in range(0, len(bucket), self.chunk_size)
+                    bucket[i : i + self.chunk_size] for i in range(0, len(bucket), self.chunk_size)
                 ]
 
             for objects in object_chunks:
                 this_sensory = self._get_sensory_by_ids(objects)
                 this_last_mask = self._get_mask_by_ids(last_mask, objects)
                 this_msk_value = self._get_visual_values_by_ids(objects)  # (1/2)*num_objects*C*N
-                visual_readout = self._readout(affinity,
-                                               this_msk_value, uncert_mask).view(bs, len(objects), self.CV, h, w)
-                
-                uncert_output = network.pred_uncertainty(last_pix_feat, pix_feat, last_pred_mask, visual_readout[:,0]-last_msk_value[:,0])
+                visual_readout = self._readout(affinity, this_msk_value, uncert_mask).view(
+                    bs, len(objects), self.CV, h, w
+                )
+
+                uncert_output = network.pred_uncertainty(
+                    last_pix_feat,
+                    pix_feat,
+                    last_pred_mask,
+                    visual_readout[:, 0] - last_msk_value[:, 0],
+                )
 
                 if uncert_output is not None:
-                    uncert_prob = uncert_output["prob"].unsqueeze(1) # b n 1 h w
-                    visual_readout = visual_readout*uncert_prob + last_msk_value*(1-uncert_prob)
+                    uncert_prob = uncert_output["prob"].unsqueeze(1)  # b n 1 h w
+                    visual_readout = visual_readout * uncert_prob + last_msk_value * (
+                        1 - uncert_prob
+                    )
 
-                pixel_readout = network.pixel_fusion(pix_feat, visual_readout, this_sensory,
-                                                     this_last_mask)
+                pixel_readout = network.pixel_fusion(
+                    pix_feat, visual_readout, this_sensory, this_last_mask
+                )
                 this_obj_mem = self._get_object_mem_by_ids(objects).unsqueeze(2)
                 readout_memory, aux_features = network.readout_query(pixel_readout, this_obj_mem)
                 for i, obj in enumerate(objects):
@@ -263,7 +292,7 @@ class MemoryManager:
                     aux_output = {
                         # 'sensory': this_sensory,
                         # 'pixel_readout': pixel_readout,
-                        'q_logits': aux_features['logits'] if aux_features else None,
+                        "q_logits": aux_features["logits"] if aux_features else None,
                         # 'q_weights': aux_features['q_weights'] if aux_features else None,
                         # 'p_weights': aux_features['p_weights'] if aux_features else None,
                         # 'attn_mask': aux_features['attn_mask'].float() if aux_features else None,
@@ -272,15 +301,17 @@ class MemoryManager:
 
         return all_readout_mem
 
-    def add_memory(self,
-                   key: torch.Tensor,
-                   shrinkage: torch.Tensor,
-                   msk_value: torch.Tensor,
-                   obj_value: torch.Tensor,
-                   objects: List[int],
-                   selection: torch.Tensor = None,
-                   *,
-                   as_permanent: bool = False) -> None:
+    def add_memory(
+        self,
+        key: torch.Tensor,
+        shrinkage: torch.Tensor,
+        msk_value: torch.Tensor,
+        obj_value: torch.Tensor,
+        objects: List[int],
+        selection: torch.Tensor = None,
+        *,
+        as_permanent: bool = False,
+    ) -> None:
         # key: (1/2)*C*H*W
         # msk_value: (1/2)*num_objects*C*H*W
         # obj_value: (1/2)*num_objects*Q*C
@@ -328,19 +359,18 @@ class MemoryManager:
                 last_acc = self.obj_v[obj][:, :, -1]
                 new_acc = last_acc + obj_value[:, obj_id, :, -1]
 
-                self.obj_v[obj][:, :, :-1] = (self.obj_v[obj][:, :, :-1] +
-                                              obj_value[:, obj_id, :, :-1])
+                self.obj_v[obj][:, :, :-1] = (
+                    self.obj_v[obj][:, :, :-1] + obj_value[:, obj_id, :, :-1]
+                )
                 self.obj_v[obj][:, :, -1] = new_acc
             else:
                 self.obj_v[obj] = obj_value[:, obj_id]
 
         # convert mask value tensor into a dict for insertion
         msk_values = {obj: msk_value[:, obj_id] for obj_id, obj in enumerate(objects)}
-        self.work_mem.add(key,
-                          msk_values,
-                          shrinkage,
-                          selection=selection,
-                          as_permanent=as_permanent)
+        self.work_mem.add(
+            key, msk_values, shrinkage, selection=selection, as_permanent=as_permanent
+        )
 
         for bucket_id in self.work_mem.buckets.keys():
             # long-term memory cleanup
@@ -348,11 +378,13 @@ class MemoryManager:
                 # Do memory compressed if needed
                 if self.work_mem.non_perm_size(bucket_id) >= self.max_work_tokens:
                     # Remove obsolete features if needed
-                    if self.long_mem.non_perm_size(bucket_id) >= (self.max_long_tokens -
-                                                         self.num_prototypes):
+                    if self.long_mem.non_perm_size(bucket_id) >= (
+                        self.max_long_tokens - self.num_prototypes
+                    ):
                         self.long_mem.remove_obsolete_features(
                             bucket_id,
-                            self.max_long_tokens - self.num_prototypes - self.buffer_tokens)
+                            self.max_long_tokens - self.num_prototypes - self.buffer_tokens,
+                        )
 
                     self.compress_features(bucket_id)
             else:
@@ -374,24 +406,31 @@ class MemoryManager:
 
         # perform memory consolidation
         prototype_key, prototype_value, prototype_shrinkage = self.consolidation(
-            *self.work_mem.get_all_sliced(bucket_id, 0, -self.min_work_tokens))
+            *self.work_mem.get_all_sliced(bucket_id, 0, -self.min_work_tokens)
+        )
 
         # remove consolidated working memory
-        self.work_mem.sieve_by_range(bucket_id,
-                                     0,
-                                     -self.min_work_tokens,
-                                     min_size=self.min_work_tokens)
+        self.work_mem.sieve_by_range(
+            bucket_id, 0, -self.min_work_tokens, min_size=self.min_work_tokens
+        )
 
         # add to long-term memory
-        self.long_mem.add(prototype_key,
-                          prototype_value,
-                          prototype_shrinkage,
-                          selection=None,
-                          supposed_bucket_id=bucket_id)
+        self.long_mem.add(
+            prototype_key,
+            prototype_value,
+            prototype_shrinkage,
+            selection=None,
+            supposed_bucket_id=bucket_id,
+        )
 
-    def consolidation(self, candidate_key: torch.Tensor, candidate_shrinkage: torch.Tensor,
-                      candidate_selection: torch.Tensor, candidate_value: Dict[int, torch.Tensor],
-                      usage: torch.Tensor) -> (torch.Tensor, Dict[int, torch.Tensor], torch.Tensor):
+    def consolidation(
+        self,
+        candidate_key: torch.Tensor,
+        candidate_shrinkage: torch.Tensor,
+        candidate_selection: torch.Tensor,
+        candidate_value: Dict[int, torch.Tensor],
+        usage: torch.Tensor,
+    ) -> (torch.Tensor, Dict[int, torch.Tensor], torch.Tensor):
         # find the indices with max usage
         bs = candidate_key.shape[0]
         assert bs in [1, 2]
@@ -408,8 +447,9 @@ class MemoryManager:
         """
         Potentiation step
         """
-        similarity = get_similarity(candidate_key, candidate_shrinkage, prototype_key,
-                                    prototype_selection)
+        similarity = get_similarity(
+            candidate_key, candidate_shrinkage, prototype_key, prototype_selection
+        )
         affinity = do_softmax(similarity)
 
         # readout the values
@@ -425,8 +465,9 @@ class MemoryManager:
             if obj not in self.sensory:
                 # also initializes the sensory memory
                 bs, _, h, w = sample_key.shape
-                self.sensory[obj] = torch.zeros((bs, self.sensory_dim, h, w),
-                                                device=sample_key.device)
+                self.sensory[obj] = torch.zeros(
+                    (bs, self.sensory_dim, h, w), device=sample_key.device
+                )
 
     def update_sensory(self, sensory: torch.Tensor, ids: List[int]):
         # sensory: 1*num_objects*C*H*W
@@ -436,7 +477,7 @@ class MemoryManager:
     def get_sensory(self, ids: List[int]):
         # returns (1/2)*num_objects*C*H*W
         return self._get_sensory_by_ids(ids)
-    
+
     def clear_non_permanent_memory(self):
         self.work_mem.clear_non_permanent_memory()
         if self.use_long_term:
@@ -444,10 +485,11 @@ class MemoryManager:
 
     def clear_sensory_memory(self):
         self.sensory = {}
-    
+
     def clear_work_mem(self):
-        self.work_mem = KeyValueMemoryStore(save_selection=self.use_long_term,
-                                            save_usage=self.use_long_term)
-    
+        self.work_mem = KeyValueMemoryStore(
+            save_selection=self.use_long_term, save_usage=self.use_long_term
+        )
+
     def clear_obj_mem(self):
         self.obj_v = {}

--- a/modules/MatAnyone2Module/matanyone2/inference/object_info.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/object_info.py
@@ -2,6 +2,7 @@ class ObjectInfo:
     """
     Store meta information for an object
     """
+
     def __init__(self, id: int):
         self.id = id
         self.poke_count = 0  # count number of detections missed
@@ -16,9 +17,9 @@ class ObjectInfo:
         return hash(self.id)
 
     def __eq__(self, other):
-        if type(other) == int:
+        if isinstance(other, int):
             return self.id == other
         return self.id == other.id
 
     def __repr__(self):
-        return f'(ID: {self.id})'
+        return f"(ID: {self.id})"

--- a/modules/MatAnyone2Module/matanyone2/inference/object_manager.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/object_manager.py
@@ -22,8 +22,8 @@ class ObjectManager:
         self.obj_id_to_obj = {obj.id: obj for obj in self.obj_to_tmp_id}
 
     def add_new_objects(
-            self, objects: Union[List[ObjectInfo], ObjectInfo,
-                                 List[int]]) -> (List[int], List[int]):
+        self, objects: Union[List[ObjectInfo], ObjectInfo, List[int]]
+    ) -> (List[int], List[int]):
         if not isinstance(objects, list):
             objects = [objects]
 
@@ -76,8 +76,9 @@ class ObjectManager:
         self.tmp_id_to_obj = local_tmp_to_obj_id
         self._recompute_obj_id_to_obj_mapping()
 
-    def purge_inactive_objects(self,
-                               max_missed_detection_count: int) -> (bool, List[int], List[int]):
+    def purge_inactive_objects(
+        self, max_missed_detection_count: int
+    ) -> (bool, List[int], List[int]):
         # remove tmp ids of objects that are removed
         obj_id_to_be_deleted = []
         tmp_id_to_be_deleted = []

--- a/modules/MatAnyone2Module/matanyone2/inference/utils/args_utils.py
+++ b/modules/MatAnyone2Module/matanyone2/inference/utils/args_utils.py
@@ -9,19 +9,19 @@ def get_dataset_cfg(cfg: DictConfig):
     data_cfg = cfg.datasets[dataset_name]
 
     potential_overrides = [
-        'image_directory',
-        'mask_directory',
-        'json_directory',
-        'size',
-        'save_all',
-        'use_all_masks',
-        'use_long_term',
-        'mem_every',
+        "image_directory",
+        "mask_directory",
+        "json_directory",
+        "size",
+        "save_all",
+        "use_all_masks",
+        "use_long_term",
+        "mem_every",
     ]
 
     for override in potential_overrides:
         if cfg[override] is not None:
-            log.info(f'Overriding config {override} from {data_cfg[override]} to {cfg[override]}')
+            log.info(f"Overriding config {override} from {data_cfg[override]} to {cfg[override]}")
             data_cfg[override] = cfg[override]
         # escalte all potential overrides to the top-level config
         if override in data_cfg:

--- a/modules/MatAnyone2Module/matanyone2/model/aux_modules.py
+++ b/modules/MatAnyone2Module/matanyone2/model/aux_modules.py
@@ -1,6 +1,7 @@
 """
 For computing auxiliary outputs for auxiliary losses
 """
+
 from typing import Dict
 from omegaconf import DictConfig
 import torch
@@ -48,46 +49,55 @@ class AuxComputer(nn.Module):
         sensory_dim = cfg.model.sensory_dim
         embed_dim = cfg.model.embed_dim
 
-        if use_sensory_aux:  
+        if use_sensory_aux:
             self.sensory_aux = LinearPredictor(sensory_dim, embed_dim)
 
-    def _aggregate_with_selector(self, logits: torch.Tensor, selector: torch.Tensor) -> torch.Tensor:
+    def _aggregate_with_selector(
+        self, logits: torch.Tensor, selector: torch.Tensor
+    ) -> torch.Tensor:
         prob = torch.sigmoid(logits)
         if selector is not None:
             prob = prob * selector
         logits = aggregate(prob, dim=1)
         return logits
 
-    def forward(self, pix_feat: torch.Tensor, aux_input: Dict[str, torch.Tensor],
-                selector: torch.Tensor, seg_pass=False) -> Dict[str, torch.Tensor]:
-        sensory = aux_input['sensory']
-        q_logits = aux_input['q_logits']
+    def forward(
+        self,
+        pix_feat: torch.Tensor,
+        aux_input: Dict[str, torch.Tensor],
+        selector: torch.Tensor,
+        seg_pass=False,
+    ) -> Dict[str, torch.Tensor]:
+        sensory = aux_input["sensory"]
+        q_logits = aux_input["q_logits"]
 
         aux_output = {}
-        aux_output['attn_mask'] = aux_input['attn_mask']
+        aux_output["attn_mask"] = aux_input["attn_mask"]
 
         if self.use_sensory_aux:
             # B*num_objects*H*W
             logits = self.sensory_aux(pix_feat, sensory)
-            aux_output['sensory_logits'] = self._aggregate_with_selector(logits, selector)
+            aux_output["sensory_logits"] = self._aggregate_with_selector(logits, selector)
         if self.use_query_aux:
             # B*num_objects*num_levels*H*W
-            aux_output['q_logits'] = self._aggregate_with_selector(
+            aux_output["q_logits"] = self._aggregate_with_selector(
                 torch.stack(q_logits, dim=2),
-                selector.unsqueeze(2) if selector is not None else None)
+                selector.unsqueeze(2) if selector is not None else None,
+            )
 
         return aux_output
-    
-    def compute_mask(self, aux_input: Dict[str, torch.Tensor],
-                selector: torch.Tensor) -> Dict[str, torch.Tensor]:
+
+    def compute_mask(
+        self, aux_input: Dict[str, torch.Tensor], selector: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
         # sensory = aux_input['sensory']
-        q_logits = aux_input['q_logits']
+        q_logits = aux_input["q_logits"]
 
         aux_output = {}
 
         # B*num_objects*num_levels*H*W
-        aux_output['q_logits'] = self._aggregate_with_selector(
-            torch.stack(q_logits, dim=2),
-            selector.unsqueeze(2) if selector is not None else None)
+        aux_output["q_logits"] = self._aggregate_with_selector(
+            torch.stack(q_logits, dim=2), selector.unsqueeze(2) if selector is not None else None
+        )
 
         return aux_output

--- a/modules/MatAnyone2Module/matanyone2/model/big_modules.py
+++ b/modules/MatAnyone2Module/matanyone2/model/big_modules.py
@@ -2,7 +2,7 @@
 big_modules.py - This file stores higher-level network blocks.
 
 x - usually denotes features that are shared between objects.
-g - usually denotes features that are not shared between objects 
+g - usually denotes features that are not shared between objects
     with an extra "num_objects" dimension (batch_size * num_objects * num_channels * H * W).
 
 The trailing number of a variable usually denotes the stride
@@ -16,21 +16,43 @@ import torch.nn.functional as F
 
 from matanyone2.model.group_modules import MainToGroupDistributor, GroupFeatureFusionBlock, GConv2d
 from matanyone2.model.utils import resnet
-from matanyone2.model.modules import SensoryDeepUpdater, SensoryUpdater_fullscale, DecoderFeatureProcessor, MaskUpsampleBlock
+from matanyone2.model.modules import (
+    SensoryDeepUpdater,
+    SensoryUpdater_fullscale,
+    DecoderFeatureProcessor,
+    MaskUpsampleBlock,
+)
 from matanyone2.utils.device import safe_autocast
+
 
 class UncertPred(nn.Module):
     def __init__(self, model_cfg: DictConfig):
         super().__init__()
-        self.conv1x1_v2 = nn.Conv2d(model_cfg.pixel_dim*2 + 1 + model_cfg.value_dim, 64, kernel_size=1, stride=1, bias=False)
+        self.conv1x1_v2 = nn.Conv2d(
+            model_cfg.pixel_dim * 2 + 1 + model_cfg.value_dim,
+            64,
+            kernel_size=1,
+            stride=1,
+            bias=False,
+        )
         self.bn1 = nn.BatchNorm2d(64)
         self.relu = nn.ReLU(inplace=True)
-        self.conv3x3 = nn.Conv2d(64, 32, kernel_size=3, stride=1, padding=1, groups=1, bias=False, dilation=1)
+        self.conv3x3 = nn.Conv2d(
+            64, 32, kernel_size=3, stride=1, padding=1, groups=1, bias=False, dilation=1
+        )
         self.bn2 = nn.BatchNorm2d(32)
-        self.conv3x3_out = nn.Conv2d(32, 1, kernel_size=3, stride=1, padding=1, groups=1, bias=False, dilation=1)
-    
-    def forward(self, last_frame_feat: torch.Tensor, cur_frame_feat: torch.Tensor, last_mask: torch.Tensor, mem_val_diff:torch.Tensor):
-        last_mask = F.interpolate(last_mask, size=last_frame_feat.shape[-2:], mode='area')
+        self.conv3x3_out = nn.Conv2d(
+            32, 1, kernel_size=3, stride=1, padding=1, groups=1, bias=False, dilation=1
+        )
+
+    def forward(
+        self,
+        last_frame_feat: torch.Tensor,
+        cur_frame_feat: torch.Tensor,
+        last_mask: torch.Tensor,
+        mem_val_diff: torch.Tensor,
+    ):
+        last_mask = F.interpolate(last_mask, size=last_frame_feat.shape[-2:], mode="area")
         x = torch.cat([last_frame_feat, cur_frame_feat, last_mask, mem_val_diff], dim=1)
         x = self.conv1x1_v2(x)
         x = self.bn1(x)
@@ -40,7 +62,7 @@ class UncertPred(nn.Module):
         x = self.relu(x)
         x = self.conv3x3_out(x)
         return x
-    
+
     # override the default train() to freeze BN statistics
     def train(self, mode=True):
         self.training = False
@@ -48,18 +70,19 @@ class UncertPred(nn.Module):
             module.train(False)
         return self
 
+
 class PixelEncoder(nn.Module):
     def __init__(self, model_cfg: DictConfig):
         super().__init__()
 
-        self.is_resnet = 'resnet' in model_cfg.pixel_encoder.type
+        self.is_resnet = "resnet" in model_cfg.pixel_encoder.type
         # if model_cfg.pretrained_resnet is set in the model_cfg we get the value
         # else default to True
-        is_pretrained_resnet = getattr(model_cfg,"pretrained_resnet",True)
+        is_pretrained_resnet = getattr(model_cfg, "pretrained_resnet", True)
         if self.is_resnet:
-            if model_cfg.pixel_encoder.type == 'resnet18':
+            if model_cfg.pixel_encoder.type == "resnet18":
                 network = resnet.resnet18(pretrained=is_pretrained_resnet)
-            elif model_cfg.pixel_encoder.type == 'resnet50':
+            elif model_cfg.pixel_encoder.type == "resnet50":
                 network = resnet.resnet50(pretrained=is_pretrained_resnet)
             else:
                 raise NotImplementedError
@@ -74,7 +97,9 @@ class PixelEncoder(nn.Module):
         else:
             raise NotImplementedError
 
-    def forward(self, x: torch.Tensor, seq_length=None) -> (torch.Tensor, torch.Tensor, torch.Tensor):
+    def forward(
+        self, x: torch.Tensor, seq_length=None
+    ) -> (torch.Tensor, torch.Tensor, torch.Tensor):
         f1 = x
         x = self.conv1(x)
         x = self.bn1(x)
@@ -112,10 +137,11 @@ class KeyProjection(nn.Module):
         nn.init.orthogonal_(self.key_proj.weight.data)
         nn.init.zeros_(self.key_proj.bias.data)
 
-    def forward(self, x: torch.Tensor, *, need_s: bool,
-                need_e: bool) -> (torch.Tensor, torch.Tensor, torch.Tensor):
+    def forward(
+        self, x: torch.Tensor, *, need_s: bool, need_e: bool
+    ) -> (torch.Tensor, torch.Tensor, torch.Tensor):
         x = self.pix_feat_proj(x)
-        shrinkage = self.d_proj(x)**2 + 1 if (need_s) else None
+        shrinkage = self.d_proj(x) ** 2 + 1 if (need_s) else None
         selection = torch.sigmoid(self.e_proj(x)) if (need_e) else None
 
         return self.key_proj(x), shrinkage, selection
@@ -134,10 +160,10 @@ class MaskEncoder(nn.Module):
 
         # if model_cfg.pretrained_resnet is set in the model_cfg we get the value
         # else default to True
-        is_pretrained_resnet = getattr(model_cfg,"pretrained_resnet",True)
-        if model_cfg.mask_encoder.type == 'resnet18':
+        is_pretrained_resnet = getattr(model_cfg, "pretrained_resnet", True)
+        if model_cfg.mask_encoder.type == "resnet18":
             network = resnet.resnet18(pretrained=is_pretrained_resnet, extra_dim=extra_dim)
-        elif model_cfg.mask_encoder.type == 'resnet50':
+        elif model_cfg.mask_encoder.type == "resnet50":
             network = resnet.resnet50(pretrained=is_pretrained_resnet, extra_dim=extra_dim)
         else:
             raise NotImplementedError
@@ -155,15 +181,17 @@ class MaskEncoder(nn.Module):
 
         self.sensory_update = SensoryDeepUpdater(value_dim, sensory_dim)
 
-    def forward(self,
-                image: torch.Tensor,
-                pix_feat: torch.Tensor,
-                sensory: torch.Tensor,
-                masks: torch.Tensor,
-                others: torch.Tensor,
-                *,
-                deep_update: bool = True,
-                chunk_size: int = -1) -> (torch.Tensor, torch.Tensor):
+    def forward(
+        self,
+        image: torch.Tensor,
+        pix_feat: torch.Tensor,
+        sensory: torch.Tensor,
+        masks: torch.Tensor,
+        others: torch.Tensor,
+        *,
+        deep_update: bool = True,
+        chunk_size: int = -1,
+    ) -> (torch.Tensor, torch.Tensor):
         # ms_features are from the key encoder
         # we only use the first one (lowest resolution), following XMem
         if self.single_object:
@@ -191,18 +219,18 @@ class MaskEncoder(nn.Module):
             if fast_path:
                 g_chunk = g
             else:
-                g_chunk = g[:, i:i + chunk_size]
+                g_chunk = g[:, i : i + chunk_size]
             actual_chunk_size = g_chunk.shape[1]
             g_chunk = g_chunk.flatten(start_dim=0, end_dim=1)
 
             g_chunk = self.conv1(g_chunk)
-            g_chunk = self.bn1(g_chunk)      # 1/2, 64
+            g_chunk = self.bn1(g_chunk)  # 1/2, 64
             g_chunk = self.maxpool(g_chunk)  # 1/4, 64
             g_chunk = self.relu(g_chunk)
 
-            g_chunk = self.layer1(g_chunk)   # 1/4
-            g_chunk = self.layer2(g_chunk)   # 1/8
-            g_chunk = self.layer3(g_chunk)   # 1/16
+            g_chunk = self.layer1(g_chunk)  # 1/4
+            g_chunk = self.layer2(g_chunk)  # 1/8
+            g_chunk = self.layer3(g_chunk)  # 1/16
 
             g_chunk = g_chunk.view(batch_size, actual_chunk_size, *g_chunk.shape[1:])
             g_chunk = self.fuser(pix_feat, g_chunk)
@@ -211,8 +239,9 @@ class MaskEncoder(nn.Module):
                 if fast_path:
                     new_sensory = self.sensory_update(g_chunk, sensory)
                 else:
-                    new_sensory[:, i:i + chunk_size] = self.sensory_update(
-                        g_chunk, sensory[:, i:i + chunk_size])
+                    new_sensory[:, i : i + chunk_size] = self.sensory_update(
+                        g_chunk, sensory[:, i : i + chunk_size]
+                    )
         g = torch.cat(all_g, dim=1)
 
         return g, new_sensory
@@ -240,14 +269,16 @@ class PixelFeatureFuser(nn.Module):
         else:
             self.sensory_compress = GConv2d(sensory_dim + 2, value_dim, kernel_size=1)
 
-    def forward(self,
-                pix_feat: torch.Tensor,
-                pixel_memory: torch.Tensor,
-                sensory_memory: torch.Tensor,
-                last_mask: torch.Tensor,
-                last_others: torch.Tensor,
-                *,
-                chunk_size: int = -1) -> torch.Tensor:
+    def forward(
+        self,
+        pix_feat: torch.Tensor,
+        pixel_memory: torch.Tensor,
+        sensory_memory: torch.Tensor,
+        last_mask: torch.Tensor,
+        last_others: torch.Tensor,
+        *,
+        chunk_size: int = -1,
+    ) -> torch.Tensor:
         batch_size, num_objects = pixel_memory.shape[:2]
 
         if self.single_object:
@@ -262,8 +293,11 @@ class PixelFeatureFuser(nn.Module):
         all_p16 = []
         for i in range(0, num_objects, chunk_size):
             sensory_readout = self.sensory_compress(
-                torch.cat([sensory_memory[:, i:i + chunk_size], last_mask[:, i:i + chunk_size]], 2))
-            p16 = pixel_memory[:, i:i + chunk_size] + sensory_readout
+                torch.cat(
+                    [sensory_memory[:, i : i + chunk_size], last_mask[:, i : i + chunk_size]], 2
+                )
+            )
+            p16 = pixel_memory[:, i : i + chunk_size] + sensory_readout
             p16 = self.fuser(pix_feat, p16)
             all_p16.append(p16)
         p16 = torch.cat(all_p16, dim=1)
@@ -281,8 +315,11 @@ class MaskDecoder(nn.Module):
 
         assert embed_dim == up_dims[0]
 
-        self.sensory_update = SensoryUpdater_fullscale([up_dims[0], up_dims[1], up_dims[2], up_dims[3], up_dims[4] + 1], sensory_dim,
-                                             sensory_dim)
+        self.sensory_update = SensoryUpdater_fullscale(
+            [up_dims[0], up_dims[1], up_dims[2], up_dims[3], up_dims[4] + 1],
+            sensory_dim,
+            sensory_dim,
+        )
 
         self.decoder_feat_proc = DecoderFeatureProcessor(ms_image_dims[1:], up_dims[:-1])
         self.up_16_8 = MaskUpsampleBlock(up_dims[0], up_dims[1])
@@ -294,16 +331,18 @@ class MaskDecoder(nn.Module):
         self.pred_seg = nn.Conv2d(up_dims[-1], 1, kernel_size=3, padding=1)
         self.pred_mat = nn.Conv2d(up_dims[-1], 1, kernel_size=3, padding=1)
 
-    def forward(self,
-                ms_image_feat: Iterable[torch.Tensor],
-                memory_readout: torch.Tensor,
-                sensory: torch.Tensor,
-                *,
-                chunk_size: int = -1,
-                update_sensory: bool = True,
-                seg_pass: bool = False,
-                last_mask=None,
-                sigmoid_residual=False) -> (torch.Tensor, torch.Tensor):
+    def forward(
+        self,
+        ms_image_feat: Iterable[torch.Tensor],
+        memory_readout: torch.Tensor,
+        sensory: torch.Tensor,
+        *,
+        chunk_size: int = -1,
+        update_sensory: bool = True,
+        seg_pass: bool = False,
+        last_mask=None,
+        sigmoid_residual=False,
+    ) -> (torch.Tensor, torch.Tensor):
 
         batch_size, num_objects = memory_readout.shape[:2]
         f8, f4, f2, f1 = self.decoder_feat_proc(ms_image_feat[1:])
@@ -324,7 +363,7 @@ class MaskDecoder(nn.Module):
             if fast_path:
                 p16 = memory_readout
             else:
-                p16 = memory_readout[:, i:i + chunk_size]
+                p16 = memory_readout[:, i : i + chunk_size]
             actual_chunk_size = p16.shape[1]
 
             p8 = self.up_16_8(p16, f8)
@@ -336,7 +375,9 @@ class MaskDecoder(nn.Module):
                     if last_mask is not None:
                         res = self.pred_seg(F.relu(p1.flatten(start_dim=0, end_dim=1).float()))
                         if sigmoid_residual:
-                            res = (torch.sigmoid(res) - 0.5) * 2  # regularization: (-1, 1) change on last mask
+                            res = (
+                                torch.sigmoid(res) - 0.5
+                            ) * 2  # regularization: (-1, 1) change on last mask
                         logits = last_mask + res
                     else:
                         logits = self.pred_seg(F.relu(p1.flatten(start_dim=0, end_dim=1).float()))
@@ -344,21 +385,23 @@ class MaskDecoder(nn.Module):
                     if last_mask is not None:
                         res = self.pred_mat(F.relu(p1.flatten(start_dim=0, end_dim=1).float()))
                         if sigmoid_residual:
-                            res = (torch.sigmoid(res) - 0.5) * 2  # regularization: (-1, 1) change on last mask
+                            res = (
+                                torch.sigmoid(res) - 0.5
+                            ) * 2  # regularization: (-1, 1) change on last mask
                         logits = last_mask + res
                     else:
                         logits = self.pred_mat(F.relu(p1.flatten(start_dim=0, end_dim=1).float()))
             ## SensoryUpdater_fullscale
             if update_sensory:
                 p1 = torch.cat(
-                    [p1, logits.view(batch_size, actual_chunk_size, 1, *logits.shape[-2:])], 2)
+                    [p1, logits.view(batch_size, actual_chunk_size, 1, *logits.shape[-2:])], 2
+                )
                 if fast_path:
                     new_sensory = self.sensory_update([p16, p8, p4, p2, p1], sensory)
                 else:
-                    new_sensory[:,
-                                i:i + chunk_size] = self.sensory_update([p16, p8, p4, p2, p1],
-                                                                        sensory[:,
-                                                                                i:i + chunk_size])
+                    new_sensory[:, i : i + chunk_size] = self.sensory_update(
+                        [p16, p8, p4, p2, p1], sensory[:, i : i + chunk_size]
+                    )
             all_logits.append(logits)
         logits = torch.cat(all_logits, dim=0)
         logits = logits.view(batch_size, num_objects, *logits.shape[-2:])

--- a/modules/MatAnyone2Module/matanyone2/model/group_modules.py
+++ b/modules/MatAnyone2Module/matanyone2/model/group_modules.py
@@ -4,28 +4,30 @@ import torch.nn as nn
 import torch.nn.functional as F
 from matanyone2.model.channel_attn import CAResBlock
 
-def interpolate_groups(g: torch.Tensor, ratio: float, mode: str,
-                       align_corners: bool) -> torch.Tensor:
+
+def interpolate_groups(
+    g: torch.Tensor, ratio: float, mode: str, align_corners: bool
+) -> torch.Tensor:
     batch_size, num_objects = g.shape[:2]
-    g = F.interpolate(g.flatten(start_dim=0, end_dim=1),
-                      scale_factor=ratio,
-                      mode=mode,
-                      align_corners=align_corners)
+    g = F.interpolate(
+        g.flatten(start_dim=0, end_dim=1),
+        scale_factor=ratio,
+        mode=mode,
+        align_corners=align_corners,
+    )
     g = g.view(batch_size, num_objects, *g.shape[1:])
     return g
 
 
-def upsample_groups(g: torch.Tensor,
-                    ratio: float = 2,
-                    mode: str = 'bilinear',
-                    align_corners: bool = False) -> torch.Tensor:
+def upsample_groups(
+    g: torch.Tensor, ratio: float = 2, mode: str = "bilinear", align_corners: bool = False
+) -> torch.Tensor:
     return interpolate_groups(g, ratio, mode, align_corners)
 
 
-def downsample_groups(g: torch.Tensor,
-                      ratio: float = 1 / 2,
-                      mode: str = 'area',
-                      align_corners: bool = None) -> torch.Tensor:
+def downsample_groups(
+    g: torch.Tensor, ratio: float = 1 / 2, mode: str = "area", align_corners: bool = None
+) -> torch.Tensor:
     return interpolate_groups(g, ratio, mode, align_corners)
 
 
@@ -58,11 +60,13 @@ class GroupResBlock(nn.Module):
 
 
 class MainToGroupDistributor(nn.Module):
-    def __init__(self,
-                 x_transform: Optional[nn.Module] = None,
-                 g_transform: Optional[nn.Module] = None,
-                 method: str = 'cat',
-                 reverse_order: bool = False):
+    def __init__(
+        self,
+        x_transform: Optional[nn.Module] = None,
+        g_transform: Optional[nn.Module] = None,
+        method: str = "cat",
+        reverse_order: bool = False,
+    ):
         super().__init__()
 
         self.x_transform = x_transform
@@ -81,16 +85,16 @@ class MainToGroupDistributor(nn.Module):
 
         if not skip_expand:
             x = x.unsqueeze(1).expand(-1, num_objects, -1, -1, -1)
-        if self.method == 'cat':
+        if self.method == "cat":
             if self.reverse_order:
                 g = torch.cat([g, x], 2)
             else:
                 g = torch.cat([x, g], 2)
-        elif self.method == 'add':
+        elif self.method == "add":
             g = x + g
-        elif self.method == 'mulcat':
+        elif self.method == "mulcat":
             g = torch.cat([x * g, g], dim=2)
-        elif self.method == 'muladd':
+        elif self.method == "muladd":
             g = x * g + g
         else:
             raise NotImplementedError
@@ -105,9 +109,9 @@ class GroupFeatureFusionBlock(nn.Module):
         x_transform = nn.Conv2d(x_in_dim, out_dim, kernel_size=1)
         g_transform = GConv2d(g_in_dim, out_dim, kernel_size=1)
 
-        self.distributor = MainToGroupDistributor(x_transform=x_transform,
-                                                  g_transform=g_transform,
-                                                  method='add')
+        self.distributor = MainToGroupDistributor(
+            x_transform=x_transform, g_transform=g_transform, method="add"
+        )
         self.block1 = CAResBlock(out_dim, out_dim)
         self.block2 = CAResBlock(out_dim, out_dim)
 

--- a/modules/MatAnyone2Module/matanyone2/model/matanyone2.py
+++ b/modules/MatAnyone2Module/matanyone2/model/matanyone2.py
@@ -7,7 +7,14 @@ import torch.nn.functional as F
 from omegaconf import OmegaConf
 from huggingface_hub import PyTorchModelHubMixin
 
-from matanyone2.model.big_modules import PixelEncoder, UncertPred, KeyProjection, MaskEncoder, PixelFeatureFuser, MaskDecoder
+from matanyone2.model.big_modules import (
+    PixelEncoder,
+    UncertPred,
+    KeyProjection,
+    MaskEncoder,
+    PixelFeatureFuser,
+    MaskDecoder,
+)
 from matanyone2.model.aux_modules import AuxComputer
 from matanyone2.model.utils.memory_utils import get_affinity, readout
 from matanyone2.model.transformer.object_transformer import QueryTransformer
@@ -18,18 +25,20 @@ from matanyone2.utils.device import get_default_device, safe_autocast
 device = get_default_device()
 
 log = logging.getLogger()
-class MatAnyone2(nn.Module,
-                PyTorchModelHubMixin,
-                library_name="matanyone2",
-                repo_url="https://github.com/pq-yang/MatAnyone2",
-                coders={
-                    DictConfig: (
-                        lambda x: OmegaConf.to_container(x),
-                        lambda data: OmegaConf.create(data),
-                    )
-                },
-        ):
 
+
+class MatAnyone2(
+    nn.Module,
+    PyTorchModelHubMixin,
+    library_name="matanyone2",
+    repo_url="https://github.com/pq-yang/MatAnyone2",
+    coders={
+        DictConfig: (
+            lambda x: OmegaConf.to_container(x),
+            lambda data: OmegaConf.create(data),
+        )
+    },
+):
     def __init__(self, cfg: DictConfig, *, single_object=False):
         super().__init__()
         self.cfg = cfg
@@ -42,7 +51,7 @@ class MatAnyone2(nn.Module,
         self.embed_dim = model_cfg.embed_dim
         self.single_object = single_object
 
-        log.info(f'Single object: {self.single_object}')
+        log.info(f"Single object: {self.single_object}")
 
         self.pixel_encoder = PixelEncoder(model_cfg)
         self.pix_feat_proj = nn.Conv2d(self.ms_dims[0], self.pixel_dim, kernel_size=1)
@@ -70,66 +79,86 @@ class MatAnyone2(nn.Module,
             others = torch.zeros_like(masks)
         return others
 
-    def pred_uncertainty(self, last_pix_feat: torch.Tensor, cur_pix_feat: torch.Tensor, last_mask: torch.Tensor, mem_val_diff:torch.Tensor):
-        logits = self.temp_sparity(last_frame_feat=last_pix_feat,
-                                cur_frame_feat=cur_pix_feat,
-                                last_mask=last_mask,
-                                mem_val_diff=mem_val_diff)
+    def pred_uncertainty(
+        self,
+        last_pix_feat: torch.Tensor,
+        cur_pix_feat: torch.Tensor,
+        last_mask: torch.Tensor,
+        mem_val_diff: torch.Tensor,
+    ):
+        logits = self.temp_sparity(
+            last_frame_feat=last_pix_feat,
+            cur_frame_feat=cur_pix_feat,
+            last_mask=last_mask,
+            mem_val_diff=mem_val_diff,
+        )
 
         prob = torch.sigmoid(logits)
         mask = (prob > 0) + 0
 
-        uncert_output = {"logits": logits,
-                     "prob": prob,
-                     "mask": mask}
+        uncert_output = {"logits": logits, "prob": prob, "mask": mask}
 
         return uncert_output
 
-    def encode_image(self, image: torch.Tensor, seq_length=None, last_feats=None) -> (Iterable[torch.Tensor], torch.Tensor): # type: ignore
+    def encode_image(
+        self, image: torch.Tensor, seq_length=None, last_feats=None
+    ) -> (Iterable[torch.Tensor], torch.Tensor):  # type: ignore
         self.pixel_mean = self.pixel_mean.to(device)
         self.pixel_std = self.pixel_std.to(device)
         image = (image - self.pixel_mean) / self.pixel_std
-        ms_image_feat = self.pixel_encoder(image, seq_length) # f16, f8, f4, f2, f1
+        ms_image_feat = self.pixel_encoder(image, seq_length)  # f16, f8, f4, f2, f1
         return ms_image_feat, self.pix_feat_proj(ms_image_feat[0])
 
     def encode_mask(
-            self,
-            image: torch.Tensor,
-            ms_features: List[torch.Tensor],
-            sensory: torch.Tensor,
-            masks: torch.Tensor,
-            *,
-            deep_update: bool = True,
-            chunk_size: int = -1,
-            need_weights: bool = False) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        self,
+        image: torch.Tensor,
+        ms_features: List[torch.Tensor],
+        sensory: torch.Tensor,
+        masks: torch.Tensor,
+        *,
+        deep_update: bool = True,
+        chunk_size: int = -1,
+        need_weights: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         image = (image - self.pixel_mean) / self.pixel_std
         others = self._get_others(masks)
-        mask_value, new_sensory = self.mask_encoder(image,
-                                                    ms_features,
-                                                    sensory,
-                                                    masks,
-                                                    others,
-                                                    deep_update=deep_update,
-                                                    chunk_size=chunk_size)
+        mask_value, new_sensory = self.mask_encoder(
+            image,
+            ms_features,
+            sensory,
+            masks,
+            others,
+            deep_update=deep_update,
+            chunk_size=chunk_size,
+        )
         object_summaries, object_logits = self.object_summarizer(masks, mask_value, need_weights)
         return mask_value, new_sensory, object_summaries, object_logits
 
-    def transform_key(self,
-                      final_pix_feat: torch.Tensor,
-                      *,
-                      need_sk: bool = True,
-                      need_ek: bool = True) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def transform_key(
+        self, final_pix_feat: torch.Tensor, *, need_sk: bool = True, need_ek: bool = True
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         key, shrinkage, selection = self.key_proj(final_pix_feat, need_s=need_sk, need_e=need_ek)
         return key, shrinkage, selection
 
     # Used in training only.
     # This step is replaced by MemoryManager in test time
-    def read_memory(self, query_key: torch.Tensor, query_selection: torch.Tensor,
-                    memory_key: torch.Tensor, memory_shrinkage: torch.Tensor,
-                    msk_value: torch.Tensor, obj_memory: torch.Tensor, pix_feat: torch.Tensor,
-                    sensory: torch.Tensor, last_mask: torch.Tensor,
-                    selector: torch.Tensor, uncert_output=None, seg_pass=False,
-                    last_pix_feat=None, last_pred_mask=None) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+    def read_memory(
+        self,
+        query_key: torch.Tensor,
+        query_selection: torch.Tensor,
+        memory_key: torch.Tensor,
+        memory_shrinkage: torch.Tensor,
+        msk_value: torch.Tensor,
+        obj_memory: torch.Tensor,
+        pix_feat: torch.Tensor,
+        sensory: torch.Tensor,
+        last_mask: torch.Tensor,
+        selector: torch.Tensor,
+        uncert_output=None,
+        seg_pass=False,
+        last_pix_feat=None,
+        last_pred_mask=None,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
         """
         query_key       : B * CK * H * W
         query_selection : B * CK * H * W
@@ -145,38 +174,55 @@ class MatAnyone2(nn.Module,
 
         # read using visual attention
         with safe_autocast(enabled=False):
-            affinity = get_affinity(memory_key.float(), memory_shrinkage.float(), query_key.float(),
-                                    query_selection.float(), uncert_mask=uncert_mask)
+            affinity = get_affinity(
+                memory_key.float(),
+                memory_shrinkage.float(),
+                query_key.float(),
+                query_selection.float(),
+                uncert_mask=uncert_mask,
+            )
 
             msk_value = msk_value.flatten(start_dim=1, end_dim=2).float()
 
             # B * (num_objects*CV) * H * W
             pixel_readout = readout(affinity, msk_value, uncert_mask)
-            pixel_readout = pixel_readout.view(batch_size, num_objects, self.value_dim,
-                                            *pixel_readout.shape[-2:])
-            
-            uncert_output = self.pred_uncertainty(last_pix_feat, pix_feat, last_pred_mask, pixel_readout[:,0]-msk_value[:,:,-1])
-            uncert_prob = uncert_output["prob"].unsqueeze(1) # b n 1 h w
-            pixel_readout = pixel_readout*uncert_prob + msk_value[:,:,-1].unsqueeze(1)*(1-uncert_prob)
-                
+            pixel_readout = pixel_readout.view(
+                batch_size, num_objects, self.value_dim, *pixel_readout.shape[-2:]
+            )
+
+            uncert_output = self.pred_uncertainty(
+                last_pix_feat, pix_feat, last_pred_mask, pixel_readout[:, 0] - msk_value[:, :, -1]
+            )
+            uncert_prob = uncert_output["prob"].unsqueeze(1)  # b n 1 h w
+            pixel_readout = pixel_readout * uncert_prob + msk_value[:, :, -1].unsqueeze(1) * (
+                1 - uncert_prob
+            )
+
         pixel_readout = self.pixel_fusion(pix_feat, pixel_readout, sensory, last_mask)
 
-
         # read from query transformer
-        mem_readout, aux_features = self.readout_query(pixel_readout, obj_memory, selector=selector, seg_pass=seg_pass)
+        mem_readout, aux_features = self.readout_query(
+            pixel_readout, obj_memory, selector=selector, seg_pass=seg_pass
+        )
 
         aux_output = {
-            'sensory': sensory,
-            'q_logits': aux_features['logits'] if aux_features else None,
-            'attn_mask': aux_features['attn_mask'] if aux_features else None,
+            "sensory": sensory,
+            "q_logits": aux_features["logits"] if aux_features else None,
+            "attn_mask": aux_features["attn_mask"] if aux_features else None,
         }
 
         return mem_readout, aux_output, uncert_output
-    
-    def read_first_frame_memory(self, pixel_readout,
-                    obj_memory: torch.Tensor, pix_feat: torch.Tensor,
-                    sensory: torch.Tensor, last_mask: torch.Tensor,
-                    selector: torch.Tensor, seg_pass=False) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+
+    def read_first_frame_memory(
+        self,
+        pixel_readout,
+        obj_memory: torch.Tensor,
+        pix_feat: torch.Tensor,
+        sensory: torch.Tensor,
+        last_mask: torch.Tensor,
+        selector: torch.Tensor,
+        seg_pass=False,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
         """
         query_key       : B * CK * H * W
         query_selection : B * CK * H * W
@@ -186,63 +232,64 @@ class MatAnyone2(nn.Module,
         obj_memory      : B * num_objects * T * num_summaries * C
         pixel_feature   : B * C * H * W
         """
-                
+
         pixel_readout = self.pixel_fusion(pix_feat, pixel_readout, sensory, last_mask)
 
         # read from query transformer
-        mem_readout, aux_features = self.readout_query(pixel_readout, obj_memory, selector=selector, seg_pass=seg_pass)
+        mem_readout, aux_features = self.readout_query(
+            pixel_readout, obj_memory, selector=selector, seg_pass=seg_pass
+        )
 
         aux_output = {
-            'sensory': sensory,
-            'q_logits': aux_features['logits'] if aux_features else None,
-            'attn_mask': aux_features['attn_mask'] if aux_features else None,
+            "sensory": sensory,
+            "q_logits": aux_features["logits"] if aux_features else None,
+            "attn_mask": aux_features["attn_mask"] if aux_features else None,
         }
 
         return mem_readout, aux_output
 
-    def pixel_fusion(self,
-                     pix_feat: torch.Tensor,
-                     pixel: torch.Tensor,
-                     sensory: torch.Tensor,
-                     last_mask: torch.Tensor,
-                     *,
-                     chunk_size: int = -1) -> torch.Tensor:
-        last_mask = F.interpolate(last_mask, size=sensory.shape[-2:], mode='area')
+    def pixel_fusion(
+        self,
+        pix_feat: torch.Tensor,
+        pixel: torch.Tensor,
+        sensory: torch.Tensor,
+        last_mask: torch.Tensor,
+        *,
+        chunk_size: int = -1,
+    ) -> torch.Tensor:
+        last_mask = F.interpolate(last_mask, size=sensory.shape[-2:], mode="area")
         last_others = self._get_others(last_mask)
-        fused = self.pixel_fuser(pix_feat,
-                                 pixel,
-                                 sensory,
-                                 last_mask,
-                                 last_others,
-                                 chunk_size=chunk_size)
+        fused = self.pixel_fuser(
+            pix_feat, pixel, sensory, last_mask, last_others, chunk_size=chunk_size
+        )
         return fused
 
-    def readout_query(self,
-                      pixel_readout,
-                      obj_memory,
-                      *,
-                      selector=None,
-                      need_weights=False,
-                      seg_pass=False) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
-        return self.object_transformer(pixel_readout,
-                                       obj_memory,
-                                       selector=selector,
-                                       need_weights=need_weights,
-                                       seg_pass=seg_pass)
+    def readout_query(
+        self, pixel_readout, obj_memory, *, selector=None, need_weights=False, seg_pass=False
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        return self.object_transformer(
+            pixel_readout,
+            obj_memory,
+            selector=selector,
+            need_weights=need_weights,
+            seg_pass=seg_pass,
+        )
 
-    def segment(self,
-                ms_image_feat: List[torch.Tensor],
-                memory_readout: torch.Tensor,
-                sensory: torch.Tensor,
-                *,
-                selector: bool = None,
-                chunk_size: int = -1,
-                update_sensory: bool = True,
-                seg_pass: bool = False,
-                clamp_mat: bool = True,
-                last_mask=None,
-                sigmoid_residual=False,
-                seg_mat=False) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def segment(
+        self,
+        ms_image_feat: List[torch.Tensor],
+        memory_readout: torch.Tensor,
+        sensory: torch.Tensor,
+        *,
+        selector: bool = None,
+        chunk_size: int = -1,
+        update_sensory: bool = True,
+        seg_pass: bool = False,
+        clamp_mat: bool = True,
+        last_mask=None,
+        sigmoid_residual=False,
+        seg_mat=False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         multi_scale_features is from the key encoder for skip-connection
         memory_readout is from working/long-term memory
@@ -256,14 +303,16 @@ class MatAnyone2(nn.Module,
             assert seg_pass
             seg_pass = False
         ####
-        sensory, logits = self.mask_decoder(ms_image_feat,
-                                        memory_readout,
-                                        sensory,
-                                        chunk_size=chunk_size,
-                                        update_sensory=update_sensory,
-                                        seg_pass = seg_pass,
-                                        last_mask=last_mask,
-                                        sigmoid_residual=sigmoid_residual)
+        sensory, logits = self.mask_decoder(
+            ms_image_feat,
+            memory_readout,
+            sensory,
+            chunk_size=chunk_size,
+            update_sensory=update_sensory,
+            seg_pass=seg_pass,
+            last_mask=last_mask,
+            sigmoid_residual=sigmoid_residual,
+        )
         if seg_pass:
             prob = torch.sigmoid(logits)
             if selector is not None:
@@ -277,11 +326,16 @@ class MatAnyone2(nn.Module,
                 logits = logits.clamp(0.0, 1.0)
             logits = torch.cat([torch.prod(1 - logits, dim=1, keepdim=True), logits], 1)
             prob = logits
-        
+
         return sensory, logits, prob
 
-    def compute_aux(self, pix_feat: torch.Tensor, aux_inputs: Dict[str, torch.Tensor],
-                    selector: torch.Tensor, seg_pass=False) -> Dict[str, torch.Tensor]:
+    def compute_aux(
+        self,
+        pix_feat: torch.Tensor,
+        aux_inputs: Dict[str, torch.Tensor],
+        selector: torch.Tensor,
+        seg_pass=False,
+    ) -> Dict[str, torch.Tensor]:
         return self.aux_computer(pix_feat, aux_inputs, selector, seg_pass=seg_pass)
 
     def forward(self, *args, **kwargs):
@@ -291,25 +345,25 @@ class MatAnyone2(nn.Module,
         if not self.single_object:
             # Map single-object weight to multi-object weight (4->5 out channels in conv1)
             for k in list(src_dict.keys()):
-                if k == 'mask_encoder.conv1.weight':
+                if k == "mask_encoder.conv1.weight":
                     if src_dict[k].shape[1] == 4:
-                        log.info(f'Converting {k} from single object to multiple objects.')
+                        log.info(f"Converting {k} from single object to multiple objects.")
                         pads = torch.zeros((64, 1, 7, 7), device=src_dict[k].device)
                         if not init_as_zero_if_needed:
                             nn.init.orthogonal_(pads)
-                            log.info(f'Randomly initialized padding for {k}.')
+                            log.info(f"Randomly initialized padding for {k}.")
                         else:
-                            log.info(f'Zero-initialized padding for {k}.')
+                            log.info(f"Zero-initialized padding for {k}.")
                         src_dict[k] = torch.cat([src_dict[k], pads], 1)
-                elif k == 'pixel_fuser.sensory_compress.weight':
+                elif k == "pixel_fuser.sensory_compress.weight":
                     if src_dict[k].shape[1] == self.sensory_dim + 1:
-                        log.info(f'Converting {k} from single object to multiple objects.')
+                        log.info(f"Converting {k} from single object to multiple objects.")
                         pads = torch.zeros((self.value_dim, 1, 1, 1), device=src_dict[k].device)
                         if not init_as_zero_if_needed:
                             nn.init.orthogonal_(pads)
-                            log.info(f'Randomly initialized padding for {k}.')
+                            log.info(f"Randomly initialized padding for {k}.")
                         else:
-                            log.info(f'Zero-initialized padding for {k}.')
+                            log.info(f"Zero-initialized padding for {k}.")
                         src_dict[k] = torch.cat([src_dict[k], pads], 1)
         elif self.single_object:
             """
@@ -318,19 +372,25 @@ class MatAnyone2(nn.Module,
             This is not supposed to happen in standard training except when users are trying to
             finetune a trained model with single object datasets.
             """
-            if src_dict['mask_encoder.conv1.weight'].shape[1] == 5:
-                log.warning('Converting mask_encoder.conv1.weight from multiple objects to single object.'
-                            'This is not supposed to happen in standard training.')
-                src_dict['mask_encoder.conv1.weight'] = src_dict['mask_encoder.conv1.weight'][:, :-1]
-                src_dict['pixel_fuser.sensory_compress.weight'] = src_dict['pixel_fuser.sensory_compress.weight'][:, :-1]
+            if src_dict["mask_encoder.conv1.weight"].shape[1] == 5:
+                log.warning(
+                    "Converting mask_encoder.conv1.weight from multiple objects to single object."
+                    "This is not supposed to happen in standard training."
+                )
+                src_dict["mask_encoder.conv1.weight"] = src_dict["mask_encoder.conv1.weight"][
+                    :, :-1
+                ]
+                src_dict["pixel_fuser.sensory_compress.weight"] = src_dict[
+                    "pixel_fuser.sensory_compress.weight"
+                ][:, :-1]
 
         for k in src_dict:
             if k not in self.state_dict():
-                log.info(f'Key {k} found in src_dict but not in self.state_dict()!!!')
+                log.info(f"Key {k} found in src_dict but not in self.state_dict()!!!")
         for k in self.state_dict():
             if k not in src_dict:
-                log.info(f'Key {k} found in self.state_dict() but not in src_dict!!!')
-                
+                log.info(f"Key {k} found in self.state_dict() but not in src_dict!!!")
+
         self.load_state_dict(src_dict, strict=False)
 
     @property

--- a/modules/MatAnyone2Module/matanyone2/model/modules.py
+++ b/modules/MatAnyone2Module/matanyone2/model/modules.py
@@ -3,7 +3,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from matanyone2.model.group_modules import MainToGroupDistributor, GroupResBlock, upsample_groups, GConv2d, downsample_groups
+from matanyone2.model.group_modules import (
+    MainToGroupDistributor,
+    GroupResBlock,
+    upsample_groups,
+    GConv2d,
+    downsample_groups,
+)
 from matanyone2.utils.device import safe_autocast
 
 
@@ -14,17 +20,16 @@ class UpsampleBlock(nn.Module):
         self.scale_factor = scale_factor
 
     def forward(self, in_g: torch.Tensor, skip_f: torch.Tensor) -> torch.Tensor:
-        g = F.interpolate(in_g,
-                      scale_factor=self.scale_factor,
-                      mode='bilinear')
+        g = F.interpolate(in_g, scale_factor=self.scale_factor, mode="bilinear")
         g = self.out_conv(g)
         g = g + skip_f
         return g
 
+
 class MaskUpsampleBlock(nn.Module):
     def __init__(self, in_dim: int, out_dim: int, scale_factor: int = 2):
         super().__init__()
-        self.distributor = MainToGroupDistributor(method='add')
+        self.distributor = MainToGroupDistributor(method="add")
         self.out_conv = GroupResBlock(in_dim, out_dim)
         self.scale_factor = scale_factor
 
@@ -33,14 +38,14 @@ class MaskUpsampleBlock(nn.Module):
         g = self.distributor(skip_f, g)
         g = self.out_conv(g)
         return g
-    
+
 
 class DecoderFeatureProcessor(nn.Module):
     def __init__(self, decoder_dims: List[int], out_dims: List[int]):
         super().__init__()
-        self.transforms = nn.ModuleList([
-            nn.Conv2d(d_dim, p_dim, kernel_size=1) for d_dim, p_dim in zip(decoder_dims, out_dims)
-        ])
+        self.transforms = nn.ModuleList(
+            [nn.Conv2d(d_dim, p_dim, kernel_size=1) for d_dim, p_dim in zip(decoder_dims, out_dims)]
+        )
 
     def forward(self, multi_scale_features: Iterable[torch.Tensor]) -> List[torch.Tensor]:
         outputs = [func(x) for x, func in zip(multi_scale_features, self.transforms)]
@@ -53,8 +58,8 @@ def _recurrent_update(h: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
     # values: batch_size * num_objects * (hidden_dim*3) * h * w
     dim = values.shape[2] // 3
     forget_gate = torch.sigmoid(values[:, :, :dim])
-    update_gate = torch.sigmoid(values[:, :, dim:dim * 2])
-    new_value = torch.tanh(values[:, :, dim * 2:])
+    update_gate = torch.sigmoid(values[:, :, dim : dim * 2])
+    new_value = torch.tanh(values[:, :, dim * 2 :])
     new_h = forget_gate * h * (1 - update_gate) + update_gate * new_value
     return new_h
 
@@ -74,10 +79,13 @@ class SensoryUpdater_fullscale(nn.Module):
         nn.init.xavier_normal_(self.transform.weight)
 
     def forward(self, g: torch.Tensor, h: torch.Tensor) -> torch.Tensor:
-        g = self.g16_conv(g[0]) + self.g8_conv(downsample_groups(g[1], ratio=1/2)) + \
-            self.g4_conv(downsample_groups(g[2], ratio=1/4)) + \
-            self.g2_conv(downsample_groups(g[3], ratio=1/8)) + \
-            self.g1_conv(downsample_groups(g[4], ratio=1/16))
+        g = (
+            self.g16_conv(g[0])
+            + self.g8_conv(downsample_groups(g[1], ratio=1 / 2))
+            + self.g4_conv(downsample_groups(g[2], ratio=1 / 4))
+            + self.g2_conv(downsample_groups(g[3], ratio=1 / 8))
+            + self.g1_conv(downsample_groups(g[4], ratio=1 / 16))
+        )
 
         with safe_autocast(enabled=False):
             g = g.float()
@@ -86,6 +94,7 @@ class SensoryUpdater_fullscale(nn.Module):
             new_h = _recurrent_update(h, values)
 
         return new_h
+
 
 class SensoryUpdater(nn.Module):
     # Used in the decoder, multi-scale feature + GRU
@@ -100,8 +109,11 @@ class SensoryUpdater(nn.Module):
         nn.init.xavier_normal_(self.transform.weight)
 
     def forward(self, g: torch.Tensor, h: torch.Tensor) -> torch.Tensor:
-        g = self.g16_conv(g[0]) + self.g8_conv(downsample_groups(g[1], ratio=1/2)) + \
-            self.g4_conv(downsample_groups(g[2], ratio=1/4))
+        g = (
+            self.g16_conv(g[0])
+            + self.g8_conv(downsample_groups(g[1], ratio=1 / 2))
+            + self.g4_conv(downsample_groups(g[2], ratio=1 / 4))
+        )
 
         with safe_autocast(enabled=False):
             g = g.float()
@@ -128,7 +140,7 @@ class SensoryDeepUpdater(nn.Module):
 
         return new_h
 
-  
+
 class ResBlock(nn.Module):
     def __init__(self, in_dim: int, out_dim: int):
         super().__init__()

--- a/modules/MatAnyone2Module/matanyone2/model/transformer/object_summarizer.py
+++ b/modules/MatAnyone2Module/matanyone2/model/transformer/object_summarizer.py
@@ -9,14 +9,15 @@ from matanyone2.utils.device import safe_autocast
 
 
 # @torch.jit.script
-def _weighted_pooling(masks: torch.Tensor, value: torch.Tensor,
-                      logits: torch.Tensor) -> (torch.Tensor, torch.Tensor):
+def _weighted_pooling(
+    masks: torch.Tensor, value: torch.Tensor, logits: torch.Tensor
+) -> (torch.Tensor, torch.Tensor):
     # value: B*num_objects*H*W*value_dim
     # logits: B*num_objects*H*W*num_summaries
     # masks: B*num_objects*H*W*num_summaries: 1 if allowed
     weights = logits.sigmoid() * masks
     # B*num_objects*num_summaries*value_dim
-    sums = torch.einsum('bkhwq,bkhwc->bkqc', weights, value)
+    sums = torch.einsum("bkhwq,bkhwc->bkqc", weights, value)
     # B*num_objects*H*W*num_summaries -> B*num_objects*num_summaries*1
     area = weights.flatten(start_dim=2, end_dim=3).sum(2).unsqueeze(-1)
 
@@ -37,9 +38,9 @@ class ObjectSummarizer(nn.Module):
         self.pixel_pe_temperature = model_cfg.pixel_pe_temperature
 
         if self.add_pe:
-            self.pos_enc = PositionalEncoding(self.embed_dim,
-                                              scale=self.pixel_pe_scale,
-                                              temperature=self.pixel_pe_temperature)
+            self.pos_enc = PositionalEncoding(
+                self.embed_dim, scale=self.pixel_pe_scale, temperature=self.pixel_pe_temperature
+            )
 
         self.input_proj = nn.Linear(self.value_dim, self.embed_dim)
         self.feature_pred = nn.Sequential(
@@ -53,22 +54,23 @@ class ObjectSummarizer(nn.Module):
             nn.Linear(self.embed_dim, self.num_summaries),
         )
 
-    def forward(self,
-                masks: torch.Tensor,
-                value: torch.Tensor,
-                need_weights: bool = False) -> (torch.Tensor, Optional[torch.Tensor]):
+    def forward(
+        self, masks: torch.Tensor, value: torch.Tensor, need_weights: bool = False
+    ) -> (torch.Tensor, Optional[torch.Tensor]):
         # masks: B*num_objects*(H0)*(W0)
         # value: B*num_objects*value_dim*H*W
         # -> B*num_objects*H*W*value_dim
         h, w = value.shape[-2:]
-        masks = F.interpolate(masks, size=(h, w), mode='area')
+        masks = F.interpolate(masks, size=(h, w), mode="area")
         masks = masks.unsqueeze(-1)
         inv_masks = 1 - masks
-        repeated_masks = torch.cat([
-            masks.expand(-1, -1, -1, -1, self.num_summaries // 2),
-            inv_masks.expand(-1, -1, -1, -1, self.num_summaries // 2),
-        ],
-                                   dim=-1)
+        repeated_masks = torch.cat(
+            [
+                masks.expand(-1, -1, -1, -1, self.num_summaries // 2),
+                inv_masks.expand(-1, -1, -1, -1, self.num_summaries // 2),
+            ],
+            dim=-1,
+        )
 
         value = value.permute(0, 1, 3, 4, 2)
         value = self.input_proj(value)

--- a/modules/MatAnyone2Module/matanyone2/model/transformer/object_transformer.py
+++ b/modules/MatAnyone2Module/matanyone2/model/transformer/object_transformer.py
@@ -6,7 +6,12 @@ import torch.nn as nn
 from matanyone2.model.group_modules import GConv2d
 from matanyone2.utils.tensor_utils import aggregate
 from matanyone2.model.transformer.positional_encoding import PositionalEncoding
-from matanyone2.model.transformer.transformer_layers import CrossAttention, SelfAttention, FFN, PixelFFN
+from matanyone2.model.transformer.transformer_layers import (
+    CrossAttention,
+    SelfAttention,
+    FFN,
+    PixelFFN,
+)
 
 
 class QueryTransformerBlock(nn.Module):
@@ -19,27 +24,32 @@ class QueryTransformerBlock(nn.Module):
         self.num_queries = this_cfg.num_queries
         self.ff_dim = this_cfg.ff_dim
 
-        self.read_from_pixel = CrossAttention(self.embed_dim,
-                                              self.num_heads,
-                                              add_pe_to_qkv=this_cfg.read_from_pixel.add_pe_to_qkv)
-        self.self_attn = SelfAttention(self.embed_dim,
-                                       self.num_heads,
-                                       add_pe_to_qkv=this_cfg.query_self_attention.add_pe_to_qkv)
+        self.read_from_pixel = CrossAttention(
+            self.embed_dim, self.num_heads, add_pe_to_qkv=this_cfg.read_from_pixel.add_pe_to_qkv
+        )
+        self.self_attn = SelfAttention(
+            self.embed_dim,
+            self.num_heads,
+            add_pe_to_qkv=this_cfg.query_self_attention.add_pe_to_qkv,
+        )
         self.ffn = FFN(self.embed_dim, self.ff_dim)
-        self.read_from_query = CrossAttention(self.embed_dim,
-                                              self.num_heads,
-                                              add_pe_to_qkv=this_cfg.read_from_query.add_pe_to_qkv,
-                                              norm=this_cfg.read_from_query.output_norm)
+        self.read_from_query = CrossAttention(
+            self.embed_dim,
+            self.num_heads,
+            add_pe_to_qkv=this_cfg.read_from_query.add_pe_to_qkv,
+            norm=this_cfg.read_from_query.output_norm,
+        )
         self.pixel_ffn = PixelFFN(self.embed_dim)
 
     def forward(
-            self,
-            x: torch.Tensor,
-            pixel: torch.Tensor,
-            query_pe: torch.Tensor,
-            pixel_pe: torch.Tensor,
-            attn_mask: torch.Tensor,
-            need_weights: bool = False) -> (torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor):
+        self,
+        x: torch.Tensor,
+        pixel: torch.Tensor,
+        query_pe: torch.Tensor,
+        pixel_pe: torch.Tensor,
+        attn_mask: torch.Tensor,
+        need_weights: bool = False,
+    ) -> (torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor):
         # x: (bs*num_objects)*num_queries*embed_dim
         # pixel: bs*num_objects*C*H*W
         # query_pe: (bs*num_objects)*num_queries*embed_dim
@@ -48,27 +58,23 @@ class QueryTransformerBlock(nn.Module):
 
         # bs*num_objects*C*H*W -> (bs*num_objects)*(H*W)*C
         pixel_flat = pixel.flatten(3, 4).flatten(0, 1).transpose(1, 2).contiguous()
-        x, q_weights = self.read_from_pixel(x,
-                                            pixel_flat,
-                                            query_pe,
-                                            pixel_pe,
-                                            attn_mask=attn_mask,
-                                            need_weights=need_weights)
+        x, q_weights = self.read_from_pixel(
+            x, pixel_flat, query_pe, pixel_pe, attn_mask=attn_mask, need_weights=need_weights
+        )
         x = self.self_attn(x, query_pe)
         x = self.ffn(x)
 
-        pixel_flat, p_weights = self.read_from_query(pixel_flat,
-                                                     x,
-                                                     pixel_pe,
-                                                     query_pe,
-                                                     need_weights=need_weights)
+        pixel_flat, p_weights = self.read_from_query(
+            pixel_flat, x, pixel_pe, query_pe, need_weights=need_weights
+        )
         pixel = self.pixel_ffn(pixel, pixel_flat)
 
         if need_weights:
             bs, num_objects, _, h, w = pixel.shape
             q_weights = q_weights.view(bs, num_objects, self.num_heads, self.num_queries, h, w)
-            p_weights = p_weights.transpose(2, 3).view(bs, num_objects, self.num_heads,
-                                                       self.num_queries, h, w)
+            p_weights = p_weights.transpose(2, 3).view(
+                bs, num_objects, self.num_heads, self.num_queries, h, w
+            )
 
         return x, pixel, q_weights, p_weights
 
@@ -95,28 +101,34 @@ class QueryTransformer(nn.Module):
         self.pixel_pe_temperature = model_cfg.pixel_pe_temperature
         self.pixel_init_proj = GConv2d(self.embed_dim, self.embed_dim, kernel_size=1)
         self.pixel_emb_proj = GConv2d(self.embed_dim, self.embed_dim, kernel_size=1)
-        self.spatial_pe = PositionalEncoding(self.embed_dim,
-                                             scale=self.pixel_pe_scale,
-                                             temperature=self.pixel_pe_temperature,
-                                             channel_last=False,
-                                             transpose_output=True)
+        self.spatial_pe = PositionalEncoding(
+            self.embed_dim,
+            scale=self.pixel_pe_scale,
+            temperature=self.pixel_pe_temperature,
+            channel_last=False,
+            transpose_output=True,
+        )
 
         # transformer blocks
         self.num_blocks = this_cfg.num_blocks
         self.blocks = nn.ModuleList(
-            QueryTransformerBlock(model_cfg) for _ in range(self.num_blocks))
+            QueryTransformerBlock(model_cfg) for _ in range(self.num_blocks)
+        )
         self.mask_pred = nn.ModuleList(
             nn.Sequential(nn.ReLU(), GConv2d(self.embed_dim, 1, kernel_size=1))
-            for _ in range(self.num_blocks + 1))
+            for _ in range(self.num_blocks + 1)
+        )
 
         self.act = nn.ReLU(inplace=True)
 
-    def forward(self,
-                pixel: torch.Tensor,
-                obj_summaries: torch.Tensor,
-                selector: Optional[torch.Tensor] = None,
-                need_weights: bool = False,
-                seg_pass=False) -> (torch.Tensor, Dict[str, torch.Tensor]):
+    def forward(
+        self,
+        pixel: torch.Tensor,
+        obj_summaries: torch.Tensor,
+        selector: Optional[torch.Tensor] = None,
+        need_weights: bool = False,
+        seg_pass=False,
+    ) -> (torch.Tensor, Dict[str, torch.Tensor]):
         # pixel: B*num_objects*embed_dim*H*W
         # obj_summaries: B*num_objects*T*num_queries*embed_dim
         T = obj_summaries.shape[2]
@@ -124,8 +136,9 @@ class QueryTransformer(nn.Module):
 
         # normalize object values
         # the last channel is the cumulative area of the object
-        obj_summaries = obj_summaries.view(bs * num_objects, T, self.num_queries,
-                                           self.embed_dim + 1)
+        obj_summaries = obj_summaries.view(
+            bs * num_objects, T, self.num_queries, self.embed_dim + 1
+        )
         # sum over time
         # during inference, T=1 as we already did streaming average in memory_manager
         obj_sums = obj_summaries[:, :, :, :-1].sum(dim=1)
@@ -148,36 +161,36 @@ class QueryTransformer(nn.Module):
         pixel = pixel_init
 
         # run the transformer
-        aux_features = {'logits': []}
+        aux_features = {"logits": []}
 
         # first aux output
         aux_logits = self.mask_pred[0](pixel).squeeze(2)
         attn_mask = self._get_aux_mask(aux_logits, selector, seg_pass=seg_pass)
-        aux_features['logits'].append(aux_logits)
+        aux_features["logits"].append(aux_logits)
         for i in range(self.num_blocks):
-            query, pixel, q_weights, p_weights = self.blocks[i](query,
-                                                                pixel,
-                                                                query_emb,
-                                                                pixel_pe,
-                                                                attn_mask,
-                                                                need_weights=need_weights)
+            query, pixel, q_weights, p_weights = self.blocks[i](
+                query, pixel, query_emb, pixel_pe, attn_mask, need_weights=need_weights
+            )
 
             if self.training or i <= self.num_blocks - 1 or need_weights:
                 aux_logits = self.mask_pred[i + 1](pixel).squeeze(2)
                 attn_mask = self._get_aux_mask(aux_logits, selector, seg_pass=seg_pass)
-                aux_features['logits'].append(aux_logits)
+                aux_features["logits"].append(aux_logits)
 
-        aux_features['q_weights'] = q_weights  # last layer only
-        aux_features['p_weights'] = p_weights  # last layer only
+        aux_features["q_weights"] = q_weights  # last layer only
+        aux_features["p_weights"] = p_weights  # last layer only
 
         if self.training:
             # no need to save all heads
-            aux_features['attn_mask'] = attn_mask.view(bs, num_objects, self.num_heads,
-                                                       self.num_queries, H, W)[:, :, 0]
+            aux_features["attn_mask"] = attn_mask.view(
+                bs, num_objects, self.num_heads, self.num_queries, H, W
+            )[:, :, 0]
 
         return pixel, aux_features
 
-    def _get_aux_mask(self, logits: torch.Tensor, selector: torch.Tensor, seg_pass=False) -> torch.Tensor:
+    def _get_aux_mask(
+        self, logits: torch.Tensor, selector: torch.Tensor, seg_pass=False
+    ) -> torch.Tensor:
         # logits: batch_size*num_objects*H*W
         # selector: batch_size*num_objects*1*1
         # returns a mask of shape (batch_size*num_objects*num_heads)*num_queries*(H*W)
@@ -189,15 +202,23 @@ class QueryTransformer(nn.Module):
             prob = logits.sigmoid() * selector
         logits = aggregate(prob, dim=1)
 
-        is_foreground = (logits[:, 1:] >= logits.max(dim=1, keepdim=True)[0])
+        is_foreground = logits[:, 1:] >= logits.max(dim=1, keepdim=True)[0]
         foreground_mask = is_foreground.bool().flatten(start_dim=2)
         inv_foreground_mask = ~foreground_mask
         inv_background_mask = foreground_mask
 
-        aux_foreground_mask = inv_foreground_mask.unsqueeze(2).unsqueeze(2).repeat(
-            1, 1, self.num_heads, self.num_queries // 2, 1).flatten(start_dim=0, end_dim=2)
-        aux_background_mask = inv_background_mask.unsqueeze(2).unsqueeze(2).repeat(
-            1, 1, self.num_heads, self.num_queries // 2, 1).flatten(start_dim=0, end_dim=2)
+        aux_foreground_mask = (
+            inv_foreground_mask.unsqueeze(2)
+            .unsqueeze(2)
+            .repeat(1, 1, self.num_heads, self.num_queries // 2, 1)
+            .flatten(start_dim=0, end_dim=2)
+        )
+        aux_background_mask = (
+            inv_background_mask.unsqueeze(2)
+            .unsqueeze(2)
+            .repeat(1, 1, self.num_heads, self.num_queries // 2, 1)
+            .flatten(start_dim=0, end_dim=2)
+        )
 
         aux_mask = torch.cat([aux_foreground_mask, aux_background_mask], dim=1)
 

--- a/modules/MatAnyone2Module/matanyone2/model/transformer/positional_encoding.py
+++ b/modules/MatAnyone2Module/matanyone2/model/transformer/positional_encoding.py
@@ -19,17 +19,19 @@ def get_emb(sin_inp: torch.Tensor) -> torch.Tensor:
 
 
 class PositionalEncoding(nn.Module):
-    def __init__(self,
-                 dim: int,
-                 scale: float = math.pi * 2,
-                 temperature: float = 10000,
-                 normalize: bool = True,
-                 channel_last: bool = True,
-                 transpose_output: bool = False):
+    def __init__(
+        self,
+        dim: int,
+        scale: float = math.pi * 2,
+        temperature: float = 10000,
+        normalize: bool = True,
+        channel_last: bool = True,
+        transpose_output: bool = False,
+    ):
         super().__init__()
         dim = int(np.ceil(dim / 4) * 2)
         self.dim = dim
-        inv_freq = 1.0 / (temperature**(torch.arange(0, dim, 2).float() / dim))
+        inv_freq = 1.0 / (temperature ** (torch.arange(0, dim, 2).float() / dim))
         self.register_buffer("inv_freq", inv_freq)
         self.normalize = normalize
         self.scale = scale
@@ -41,14 +43,14 @@ class PositionalEncoding(nn.Module):
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         """
-        :param tensor: A 4/5d tensor of size 
+        :param tensor: A 4/5d tensor of size
             channel_last=True: (batch_size, h, w, c) or (batch_size, k, h, w, c)
             channel_last=False: (batch_size, c, h, w) or (batch_size, k, c, h, w)
         :return: positional encoding tensor that has the same shape as the input if the input is 4d
                  if the input is 5d, the output is broadcastable along the k-dimension
         """
         if len(tensor.shape) != 4 and len(tensor.shape) != 5:
-            raise RuntimeError(f'The input tensor has to be 4/5d, got {tensor.shape}!')
+            raise RuntimeError(f"The input tensor has to be 4/5d, got {tensor.shape}!")
 
         if len(tensor.shape) == 5:
             # take a sample from the k dimension
@@ -82,8 +84,8 @@ class PositionalEncoding(nn.Module):
         emb_x = get_emb(sin_inp_x)
 
         emb = torch.zeros((h, w, self.dim * 2), device=tensor.device, dtype=tensor.dtype)
-        emb[:, :, :self.dim] = emb_x
-        emb[:, :, self.dim:] = emb_y
+        emb[:, :, : self.dim] = emb_x
+        emb[:, :, self.dim :] = emb_y
 
         if not self.channel_last and self.transpose_output:
             # cancelled out
@@ -98,7 +100,7 @@ class PositionalEncoding(nn.Module):
             return self.cached_penc.unsqueeze(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     device = get_default_device()
     pe = PositionalEncoding(8).to(device)
     input = torch.ones((1, 8, 8, 8), device=device)

--- a/modules/MatAnyone2Module/matanyone2/model/transformer/transformer_layers.py
+++ b/modules/MatAnyone2Module/matanyone2/model/transformer/transformer_layers.py
@@ -10,23 +10,27 @@ from matanyone2.model.channel_attn import CAResBlock
 
 
 class SelfAttention(nn.Module):
-    def __init__(self,
-                 dim: int,
-                 nhead: int,
-                 dropout: float = 0.0,
-                 batch_first: bool = True,
-                 add_pe_to_qkv: List[bool] = [True, True, False]):
+    def __init__(
+        self,
+        dim: int,
+        nhead: int,
+        dropout: float = 0.0,
+        batch_first: bool = True,
+        add_pe_to_qkv: List[bool] = [True, True, False],
+    ):
         super().__init__()
         self.self_attn = nn.MultiheadAttention(dim, nhead, dropout=dropout, batch_first=batch_first)
         self.norm = nn.LayerNorm(dim)
         self.dropout = nn.Dropout(dropout)
         self.add_pe_to_qkv = add_pe_to_qkv
 
-    def forward(self,
-                x: torch.Tensor,
-                pe: torch.Tensor,
-                attn_mask: bool = None,
-                key_padding_mask: bool = None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        pe: torch.Tensor,
+        attn_mask: bool = None,
+        key_padding_mask: bool = None,
+    ) -> torch.Tensor:
         x = self.norm(x)
         if any(self.add_pe_to_qkv):
             x_with_pe = x + pe
@@ -43,19 +47,20 @@ class SelfAttention(nn.Module):
 
 # https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html#torch.nn.functional.scaled_dot_product_attention
 class CrossAttention(nn.Module):
-    def __init__(self,
-                 dim: int,
-                 nhead: int,
-                 dropout: float = 0.0,
-                 batch_first: bool = True,
-                 add_pe_to_qkv: List[bool] = [True, True, False],
-                 residual: bool = True,
-                 norm: bool = True):
+    def __init__(
+        self,
+        dim: int,
+        nhead: int,
+        dropout: float = 0.0,
+        batch_first: bool = True,
+        add_pe_to_qkv: List[bool] = [True, True, False],
+        residual: bool = True,
+        norm: bool = True,
+    ):
         super().__init__()
-        self.cross_attn = nn.MultiheadAttention(dim,
-                                                nhead,
-                                                dropout=dropout,
-                                                batch_first=batch_first)
+        self.cross_attn = nn.MultiheadAttention(
+            dim, nhead, dropout=dropout, batch_first=batch_first
+        )
         if norm:
             self.norm = nn.LayerNorm(dim)
         else:
@@ -64,14 +69,16 @@ class CrossAttention(nn.Module):
         self.add_pe_to_qkv = add_pe_to_qkv
         self.residual = residual
 
-    def forward(self,
-                x: torch.Tensor,
-                mem: torch.Tensor,
-                x_pe: torch.Tensor,
-                mem_pe: torch.Tensor,
-                attn_mask: bool = None,
-                *,
-                need_weights: bool = False) -> (torch.Tensor, torch.Tensor):
+    def forward(
+        self,
+        x: torch.Tensor,
+        mem: torch.Tensor,
+        x_pe: torch.Tensor,
+        mem_pe: torch.Tensor,
+        attn_mask: bool = None,
+        *,
+        need_weights: bool = False,
+    ) -> (torch.Tensor, torch.Tensor):
         x = self.norm(x)
         if self.add_pe_to_qkv[0]:
             q = x + x_pe
@@ -85,12 +92,9 @@ class CrossAttention(nn.Module):
         else:
             k = v = mem
         r = x
-        x, weights = self.cross_attn(q,
-                                     k,
-                                     v,
-                                     attn_mask=attn_mask,
-                                     need_weights=need_weights,
-                                     average_attn_weights=False)
+        x, weights = self.cross_attn(
+            q, k, v, attn_mask=attn_mask, need_weights=need_weights, average_attn_weights=False
+        )
 
         if self.residual:
             return r + self.dropout(x), weights

--- a/modules/MatAnyone2Module/matanyone2/model/utils/memory_utils.py
+++ b/modules/MatAnyone2Module/matanyone2/model/utils/memory_utils.py
@@ -4,12 +4,14 @@ from typing import Optional, Union, Tuple
 
 
 # @torch.jit.script
-def get_similarity(mk: torch.Tensor,
-                   ms: torch.Tensor,
-                   qk: torch.Tensor,
-                   qe: torch.Tensor,
-                   add_batch_dim: bool = False,
-                   uncert_mask = None) -> torch.Tensor:
+def get_similarity(
+    mk: torch.Tensor,
+    ms: torch.Tensor,
+    qk: torch.Tensor,
+    qe: torch.Tensor,
+    add_batch_dim: bool = False,
+    uncert_mask=None,
+) -> torch.Tensor:
     # used for training/inference and memory reading/memory potentiation
     # mk: B x CK x [N]    - Memory keys
     # ms: B x  1 x [N]    - Memory shrinkage
@@ -27,7 +29,7 @@ def get_similarity(mk: torch.Tensor,
     ms = ms.flatten(start_dim=1).unsqueeze(2) if ms is not None else None
     qk = qk.flatten(start_dim=2)
     qe = qe.flatten(start_dim=2) if qe is not None else None
-    
+
     # query token selection based on temporal sparsity
     if uncert_mask is not None:
         uncert_mask = uncert_mask.flatten(start_dim=2)
@@ -38,15 +40,15 @@ def get_similarity(mk: torch.Tensor,
     if qe is not None:
         # See XMem's appendix for derivation
         mk = mk.transpose(1, 2)
-        a_sq = (mk.pow(2) @ qe)
+        a_sq = mk.pow(2) @ qe
         two_ab = 2 * (mk @ (qk * qe))
         b_sq = (qe * qk.pow(2)).sum(1, keepdim=True)
-        similarity = (-a_sq + two_ab - b_sq)
+        similarity = -a_sq + two_ab - b_sq
     else:
         # similar to STCN if we don't have the selection term
         a_sq = mk.pow(2).sum(1).unsqueeze(2)
         two_ab = 2 * (mk.transpose(1, 2) @ qk)
-        similarity = (-a_sq + two_ab)
+        similarity = -a_sq + two_ab
 
     if ms is not None:
         similarity = similarity * ms / math.sqrt(CK)  # B*N*HW
@@ -57,10 +59,11 @@ def get_similarity(mk: torch.Tensor,
 
 
 def do_softmax(
-        similarity: torch.Tensor,
-        top_k: Optional[int] = None,
-        inplace: bool = False,
-        return_usage: bool = False) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    similarity: torch.Tensor,
+    top_k: Optional[int] = None,
+    inplace: bool = False,
+    return_usage: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     # normalize similarity with top-k softmax
     # similarity: B x N x [HW/P]
     # use inplace with care
@@ -87,14 +90,18 @@ def do_softmax(
     return affinity
 
 
-def get_affinity(mk: torch.Tensor, ms: torch.Tensor, qk: torch.Tensor,
-                 qe: torch.Tensor, uncert_mask = None) -> torch.Tensor:
+def get_affinity(
+    mk: torch.Tensor, ms: torch.Tensor, qk: torch.Tensor, qe: torch.Tensor, uncert_mask=None
+) -> torch.Tensor:
     # shorthand used in training with no top-k
     similarity = get_similarity(mk, ms, qk, qe, uncert_mask=uncert_mask)
     affinity = do_softmax(similarity)
     return affinity
 
-def readout(affinity: torch.Tensor, mv: torch.Tensor, uncert_mask: torch.Tensor=None) -> torch.Tensor:
+
+def readout(
+    affinity: torch.Tensor, mv: torch.Tensor, uncert_mask: torch.Tensor = None
+) -> torch.Tensor:
     B, CV, T, H, W = mv.shape
 
     mo = mv.view(B, CV, T * H * W)

--- a/modules/MatAnyone2Module/matanyone2/model/utils/parameter_groups.py
+++ b/modules/MatAnyone2Module/matanyone2/model/utils/parameter_groups.py
@@ -17,8 +17,8 @@ def get_parameter_groups(model, stage_cfg, print_log=False):
     embed_params = []
     other_params = []
 
-    embedding_names = ['summary_pos', 'query_init', 'query_emb', 'obj_pe']
-    embedding_names = [e + '.weight' for e in embedding_names]
+    embedding_names = ["summary_pos", "query_init", "query_emb", "obj_pe"]
+    embedding_names = [e + ".weight" for e in embedding_names]
 
     # inspired by detectron2
     memo = set()
@@ -30,22 +30,22 @@ def get_parameter_groups(model, stage_cfg, print_log=False):
             continue
         memo.add(param)
 
-        if name.startswith('module'):
+        if name.startswith("module"):
             name = name[7:]
 
         inserted = False
-        if name.startswith('pixel_encoder.'):
+        if name.startswith("pixel_encoder."):
             backbone_params.append(param)
             inserted = True
             if print_log:
-                log.info(f'{name} counted as a backbone parameter.')
+                log.info(f"{name} counted as a backbone parameter.")
         else:
             for e in embedding_names:
                 if name.endswith(e):
                     embed_params.append(param)
                     inserted = True
                     if print_log:
-                        log.info(f'{name} counted as an embedding parameter.')
+                        log.info(f"{name} counted as an embedding parameter.")
                     break
 
         if not inserted:
@@ -53,20 +53,12 @@ def get_parameter_groups(model, stage_cfg, print_log=False):
 
     parameter_groups = [
         {
-            'params': backbone_params,
-            'lr': base_lr * backbone_lr_ratio,
-            'weight_decay': weight_decay
+            "params": backbone_params,
+            "lr": base_lr * backbone_lr_ratio,
+            "weight_decay": weight_decay,
         },
-        {
-            'params': embed_params,
-            'lr': base_lr,
-            'weight_decay': embed_weight_decay
-        },
-        {
-            'params': other_params,
-            'lr': base_lr,
-            'weight_decay': weight_decay
-        },
+        {"params": embed_params, "lr": base_lr, "weight_decay": embed_weight_decay},
+        {"params": other_params, "lr": base_lr, "weight_decay": weight_decay},
     ]
 
     return parameter_groups

--- a/modules/MatAnyone2Module/matanyone2/model/utils/resnet.py
+++ b/modules/MatAnyone2Module/matanyone2/model/utils/resnet.py
@@ -15,7 +15,7 @@ def load_weights_add_extra_dim(target, source_state, extra_dim=1):
     new_dict = OrderedDict()
 
     for k1, v1 in target.state_dict().items():
-        if 'num_batches_tracked' not in k1:
+        if "num_batches_tracked" not in k1:
             if k1 in source_state:
                 tar_v = source_state[k1]
 
@@ -33,19 +33,21 @@ def load_weights_add_extra_dim(target, source_state, extra_dim=1):
 
 
 model_urls = {
-    'resnet18': 'https://download.pytorch.org/models/resnet18-5c106cde.pth',
-    'resnet50': 'https://download.pytorch.org/models/resnet50-19c8e357.pth',
+    "resnet18": "https://download.pytorch.org/models/resnet18-5c106cde.pth",
+    "resnet50": "https://download.pytorch.org/models/resnet50-19c8e357.pth",
 }
 
 
 def conv3x3(in_planes, out_planes, stride=1, dilation=1):
-    return nn.Conv2d(in_planes,
-                     out_planes,
-                     kernel_size=3,
-                     stride=stride,
-                     padding=dilation,
-                     dilation=dilation,
-                     bias=False)
+    return nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=dilation,
+        dilation=dilation,
+        bias=False,
+    )
 
 
 class BasicBlock(nn.Module):
@@ -87,13 +89,15 @@ class Bottleneck(nn.Module):
         super(Bottleneck, self).__init__()
         self.conv1 = nn.Conv2d(inplanes, planes, kernel_size=1, bias=False)
         self.bn1 = nn.BatchNorm2d(planes)
-        self.conv2 = nn.Conv2d(planes,
-                               planes,
-                               kernel_size=3,
-                               stride=stride,
-                               dilation=dilation,
-                               padding=dilation,
-                               bias=False)
+        self.conv2 = nn.Conv2d(
+            planes,
+            planes,
+            kernel_size=3,
+            stride=stride,
+            dilation=dilation,
+            padding=dilation,
+            bias=False,
+        )
         self.bn2 = nn.BatchNorm2d(planes)
         self.conv3 = nn.Conv2d(planes, planes * 4, kernel_size=1, bias=False)
         self.bn3 = nn.BatchNorm2d(planes * 4)
@@ -140,7 +144,7 @@ class ResNet(nn.Module):
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
                 n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
-                m.weight.data.normal_(0, math.sqrt(2. / n))
+                m.weight.data.normal_(0, math.sqrt(2.0 / n))
             elif isinstance(m, nn.BatchNorm2d):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()
@@ -149,11 +153,13 @@ class ResNet(nn.Module):
         downsample = None
         if stride != 1 or self.inplanes != planes * block.expansion:
             downsample = nn.Sequential(
-                nn.Conv2d(self.inplanes,
-                          planes * block.expansion,
-                          kernel_size=1,
-                          stride=stride,
-                          bias=False),
+                nn.Conv2d(
+                    self.inplanes,
+                    planes * block.expansion,
+                    kernel_size=1,
+                    stride=stride,
+                    bias=False,
+                ),
                 nn.BatchNorm2d(planes * block.expansion),
             )
 
@@ -168,12 +174,12 @@ class ResNet(nn.Module):
 def resnet18(pretrained=True, extra_dim=0):
     model = ResNet(BasicBlock, [2, 2, 2, 2], extra_dim)
     if pretrained:
-        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls['resnet18']), extra_dim)
+        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls["resnet18"]), extra_dim)
     return model
 
 
 def resnet50(pretrained=True, extra_dim=0):
     model = ResNet(Bottleneck, [3, 4, 6, 3], extra_dim)
     if pretrained:
-        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls['resnet50']), extra_dim)
+        load_weights_add_extra_dim(model, model_zoo.load_url(model_urls["resnet50"]), extra_dim)
     return model

--- a/modules/MatAnyone2Module/matanyone2/utils/device.py
+++ b/modules/MatAnyone2Module/matanyone2/utils/device.py
@@ -1,6 +1,7 @@
 import torch
 import functools
 
+
 def get_default_device():
     if torch.cuda.is_available():
         return torch.device("cuda")
@@ -8,6 +9,7 @@ def get_default_device():
         return torch.device("mps")
     else:
         return torch.device("cpu")
+
 
 def safe_autocast_decorator(enabled=True):
     def decorator(func):
@@ -19,10 +21,15 @@ def safe_autocast_decorator(enabled=True):
                     return func(*args, **kwargs)
             else:
                 return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
 
+
 import contextlib
+
+
 @contextlib.contextmanager
 def safe_autocast(enabled=True):
     device = get_default_device()

--- a/modules/MatAnyone2Module/matanyone2/utils/get_default_model.py
+++ b/modules/MatAnyone2Module/matanyone2/utils/get_default_model.py
@@ -1,6 +1,7 @@
 """
 A helper function to get a default model for quick testing
 """
+
 from omegaconf import open_dict
 from hydra import compose, initialize
 from hydra.core.global_hydra import GlobalHydra
@@ -8,13 +9,14 @@ from hydra.core.global_hydra import GlobalHydra
 import torch
 from matanyone2.model.matanyone2 import MatAnyone2
 
+
 def get_matanyone2_model(ckpt_path, device=None) -> MatAnyone2:
     GlobalHydra.instance().clear()
-    initialize(version_base='1.3.2', config_path="../config", job_name="eval_our_config")
+    initialize(version_base="1.3.2", config_path="../config", job_name="eval_our_config")
     cfg = compose(config_name="eval_matanyone_config")
-    
+
     with open_dict(cfg):
-        cfg['weights'] = ckpt_path
+        cfg["weights"] = ckpt_path
 
     # Load the network weights
     if device is not None:
@@ -23,7 +25,7 @@ def get_matanyone2_model(ckpt_path, device=None) -> MatAnyone2:
     else:  # if device is not specified, `.cuda()` by default
         matanyone2 = MatAnyone2(cfg, single_object=True).cuda().eval()
         model_weights = torch.load(cfg.weights, weights_only=True)
-        
+
     matanyone2.load_weights(model_weights)
 
     return matanyone2

--- a/modules/MatAnyone2Module/matanyone2/utils/inference_utils.py
+++ b/modules/MatAnyone2Module/matanyone2/utils/inference_utils.py
@@ -6,27 +6,31 @@ import numpy as np
 import torch
 import torchvision
 
-IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.JPG', '.JPEG', '.PNG')
-VIDEO_EXTENSIONS = ('.mp4', '.mov', '.avi', '.MP4', '.MOV', '.AVI')
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG")
+VIDEO_EXTENSIONS = (".mp4", ".mov", ".avi", ".MP4", ".MOV", ".AVI")
+
 
 def read_frame_from_videos(frame_root):
     if frame_root.endswith(VIDEO_EXTENSIONS):  # Video file path
         video_name = os.path.basename(frame_root)[:-4]
-        frames, _, info = torchvision.io.read_video(filename=frame_root, pts_unit='sec', output_format='TCHW') # RGB
-        fps = info['video_fps']
+        frames, _, info = torchvision.io.read_video(
+            filename=frame_root, pts_unit="sec", output_format="TCHW"
+        )  # RGB
+        fps = info["video_fps"]
     else:
         video_name = os.path.basename(frame_root)
         frames = []
         fr_lst = sorted(os.listdir(frame_root))
         for fr in fr_lst:
-            frame = cv2.imread(os.path.join(frame_root, fr))[...,[2,1,0]] # RGB, HWC
+            frame = cv2.imread(os.path.join(frame_root, fr))[..., [2, 1, 0]]  # RGB, HWC
             frames.append(frame)
         fps = 24  # default
-        frames = torch.Tensor(np.array(frames)).permute(0, 3, 1, 2).contiguous() # TCHW
-    
+        frames = torch.Tensor(np.array(frames)).permute(0, 3, 1, 2).contiguous()  # TCHW
+
     length = frames.shape[0]
 
     return frames, fps, length, video_name
+
 
 def get_video_paths(input_root):
     video_paths = []
@@ -36,19 +40,22 @@ def get_video_paths(input_root):
                 video_paths.append(os.path.join(root, file))
     return sorted(video_paths)
 
-def str_to_list(value):
-    return list(map(int, value.split(',')))
 
-def gen_dilate(alpha, min_kernel_size, max_kernel_size): 
+def str_to_list(value):
+    return list(map(int, value.split(",")))
+
+
+def gen_dilate(alpha, min_kernel_size, max_kernel_size):
     kernel_size = random.randint(min_kernel_size, max_kernel_size)
-    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size,kernel_size))
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
     fg_and_unknown = np.array(np.not_equal(alpha, 0).astype(np.float32))
-    dilate = cv2.dilate(fg_and_unknown, kernel, iterations=1)*255
+    dilate = cv2.dilate(fg_and_unknown, kernel, iterations=1) * 255
     return dilate.astype(np.float32)
 
-def gen_erosion(alpha, min_kernel_size, max_kernel_size): 
+
+def gen_erosion(alpha, min_kernel_size, max_kernel_size):
     kernel_size = random.randint(min_kernel_size, max_kernel_size)
-    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size,kernel_size))
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
     fg = np.array(np.equal(alpha, 255).astype(np.float32))
-    erode = cv2.erode(fg, kernel, iterations=1)*255
+    erode = cv2.erode(fg, kernel, iterations=1) * 255
     return erode.astype(np.float32)

--- a/modules/MatAnyone2Module/matanyone2/utils/tensor_utils.py
+++ b/modules/MatAnyone2Module/matanyone2/utils/tensor_utils.py
@@ -1,7 +1,8 @@
-from typing import List, Iterable
+from typing import Iterable
 import torch
 import torch.nn.functional as F
 from matanyone2.utils.device import safe_autocast
+
 
 # STM
 def pad_divide_by(in_img: torch.Tensor, d: int) -> (torch.Tensor, Iterable[int]):
@@ -25,19 +26,19 @@ def pad_divide_by(in_img: torch.Tensor, d: int) -> (torch.Tensor, Iterable[int])
 def unpad(img: torch.Tensor, pad: Iterable[int]) -> torch.Tensor:
     if len(img.shape) == 4:
         if pad[2] + pad[3] > 0:
-            img = img[:, :, pad[2]:-pad[3], :]
+            img = img[:, :, pad[2] : -pad[3], :]
         if pad[0] + pad[1] > 0:
-            img = img[:, :, :, pad[0]:-pad[1]]
+            img = img[:, :, :, pad[0] : -pad[1]]
     elif len(img.shape) == 3:
         if pad[2] + pad[3] > 0:
-            img = img[:, pad[2]:-pad[3], :]
+            img = img[:, pad[2] : -pad[3], :]
         if pad[0] + pad[1] > 0:
-            img = img[:, :, pad[0]:-pad[1]]
+            img = img[:, :, pad[0] : -pad[1]]
     elif len(img.shape) == 5:
         if pad[2] + pad[3] > 0:
-            img = img[:, :, :, pad[2]:-pad[3], :]
+            img = img[:, :, :, pad[2] : -pad[3], :]
         if pad[0] + pad[1] > 0:
-            img = img[:, :, :, :, pad[0]:-pad[1]]
+            img = img[:, :, :, :, pad[0] : -pad[1]]
     else:
         raise NotImplementedError
     return img
@@ -47,8 +48,9 @@ def unpad(img: torch.Tensor, pad: Iterable[int]) -> torch.Tensor:
 def aggregate(prob: torch.Tensor, dim: int) -> torch.Tensor:
     with safe_autocast(enabled=False):
         prob = prob.float()
-        new_prob = torch.cat([torch.prod(1 - prob, dim=dim, keepdim=True), prob],
-                             dim).clamp(1e-7, 1 - 1e-7)
+        new_prob = torch.cat([torch.prod(1 - prob, dim=dim, keepdim=True), prob], dim).clamp(
+            1e-7, 1 - 1e-7
+        )
         logits = torch.log((new_prob / (1 - new_prob)))  # (0, 1) --> (-inf, inf)
 
         return logits

--- a/modules/MatAnyone2Module/wrapper.py
+++ b/modules/MatAnyone2Module/wrapper.py
@@ -13,6 +13,7 @@ Usage:
         cancel_check=fn,
     )
 """
+
 from __future__ import annotations
 
 import logging
@@ -62,6 +63,7 @@ def _ensure_checkpoint(ckpt_path: str | None = None) -> str:
     logger.info("MatAnyone2 checkpoint not found, downloading...")
     os.makedirs(ckpt_dir, exist_ok=True)
     from torch.hub import download_url_to_file
+
     download_url_to_file(_CKPT_URL, local_path)
     logger.info(f"Downloaded checkpoint to {local_path}")
     return local_path
@@ -92,7 +94,7 @@ class MatAnyone2Processor:
         self._r_dilate = r_dilate
         self._max_internal_size = max_internal_size
         self._processor = None  # InferenceCore, loaded lazily
-        self._model = None      # MatAnyone2 nn.Module
+        self._model = None  # MatAnyone2 nn.Module
 
     def _ensure_loaded(self, on_status: Optional[Callable[[str], None]] = None):
         """Load model + InferenceCore if not already loaded."""
@@ -113,7 +115,7 @@ class MatAnyone2Processor:
         from matanyone2.inference.inference_core import InferenceCore
 
         # Enable TF32 for Ampere+ GPUs (RTX 30xx/40xx/50xx) — ~15-30% speedup
-        torch.set_float32_matmul_precision('high')
+        torch.set_float32_matmul_precision("high")
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
 
@@ -132,6 +134,7 @@ class MatAnyone2Processor:
 
         # Clear Hydra global state so it doesn't poison other modules (e.g. SAM2)
         from hydra.core.global_hydra import GlobalHydra
+
         GlobalHydra.instance().clear()
 
         logger.info(f"MatAnyone2 loaded in {time.monotonic() - t0:.1f}s")
@@ -146,7 +149,7 @@ class MatAnyone2Processor:
         self._device = device
 
     @torch.inference_mode()
-    @torch.amp.autocast('cuda')
+    @torch.amp.autocast("cuda")
     def process_frames(
         self,
         input_frames: list[np.ndarray],
@@ -178,9 +181,12 @@ class MatAnyone2Processor:
             RuntimeError: If mask_frame doesn't match first frame dimensions.
         """
         import traceback
+
         logger.info(
             "MatAnyone2 process_frames CALLED: clip=%s, num_frames=%d\n%s",
-            clip_name, len(input_frames), "".join(traceback.format_stack()[-5:])
+            clip_name,
+            len(input_frames),
+            "".join(traceback.format_stack()[-5:]),
         )
         self._ensure_loaded(on_status=on_status)
 
@@ -208,9 +214,11 @@ class MatAnyone2Processor:
         mask_np = mask_frame.astype(np.float32)
         if r_dilate > 0:
             from matanyone2.utils.inference_utils import gen_dilate
+
             mask_np = gen_dilate(mask_np, r_dilate, r_dilate)
         if r_erode > 0:
             from matanyone2.utils.inference_utils import gen_erosion
+
             mask_np = gen_erosion(mask_np, r_erode, r_erode)
 
         mask_tensor = torch.from_numpy(mask_np).float().to(self._device)
@@ -284,8 +292,11 @@ class MatAnyone2Processor:
                             "MatAnyone2 DIAG: frame %d/%d, ti=%d, "
                             "last_50_elapsed=%.1fs (%.2fs/frame), "
                             "curr_ti=%d, last_mem_ti=%d",
-                            frames_written, num_frames, ti,
-                            _elapsed, _elapsed / min(frames_written, 50),
+                            frames_written,
+                            num_frames,
+                            ti,
+                            _elapsed,
+                            _elapsed / min(frames_written, 50),
                             self._processor.curr_ti,
                             self._processor.last_mem_ti,
                         )
@@ -308,20 +319,25 @@ class MatAnyone2Processor:
         except _CancelledError:
             # Clean up temp dir on cancel
             import shutil
+
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
         except Exception:
             # Clean up temp dir on error
             import shutil
+
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
         finally:
             # Always try to clean up temp dir
             if os.path.isdir(tmp_dir):
                 import shutil
+
                 shutil.rmtree(tmp_dir, ignore_errors=True)
 
-        logger.info(f"MatAnyone2 process_frames COMPLETE: wrote {frames_written} alpha frames to {output_dir}")
+        logger.info(
+            f"MatAnyone2 process_frames COMPLETE: wrote {frames_written} alpha frames to {output_dir}"
+        )
         return frames_written
 
     def clear(self):
@@ -332,4 +348,5 @@ class MatAnyone2Processor:
 
 class _CancelledError(Exception):
     """Internal: raised when cancel_check returns True."""
+
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,16 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["backend", "ui", "CorridorKeyModule", "gvm_core", "sam2_tracker", "VideoMaMaInferenceModule", "modules/MatAnyone2Module"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"device_utils.py" = "device_utils.py"
+
+[tool.hatch.build.targets.sdist.force-include]
+"device_utils.py" = "device_utils.py"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.uv]
+[tool.uv.pip]
 torch-backend = "auto"
 
 [tool.uv.sources]
@@ -60,3 +66,21 @@ corridorkey-mlx = { git = "https://github.com/nikopueringer/corridorkey-mlx.git"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "rocm: ROCm/HIP startup tests (mocked; no AMD GPU required)",
+]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+extend-exclude = [
+    ".venv",
+    "build",
+    "dist",
+]
+
+[tool.ruff.lint]
+# Default rule set is E4, E7, E9, F (see Ruff docs). We only relax:
+# E402 — lazy imports after env/path setup (GUI, clip_manager, upstream patterns).
+# E701 — compound statements on one line in dense numeric / legacy code.
+ignore = ["E402", "E701"]

--- a/sam2_tracker/wrapper.py
+++ b/sam2_tracker/wrapper.py
@@ -202,11 +202,11 @@ class SAM2Tracker:
 
         frame_shape = frames[0].shape[:2]
         sanitized_prompts = [
-            self._sanitize_prompt_frame(prompt, frame_shape)
-            for prompt in prompt_frames
+            self._sanitize_prompt_frame(prompt, frame_shape) for prompt in prompt_frames
         ]
         sanitized_prompts = [
-            prompt for prompt in sanitized_prompts
+            prompt
+            for prompt in sanitized_prompts
             if (
                 prompt.mask is not None
                 or prompt.positive_points
@@ -291,7 +291,12 @@ class SAM2Tracker:
                         frame_idx = prompt.frame_index
                         obj_ids = []
                         mask_logits = None
-                        for batch_points, batch_labels, batch_box, clear_old_points in self._iter_prompt_refinement_batches(prompt):
+                        for (
+                            batch_points,
+                            batch_labels,
+                            batch_box,
+                            clear_old_points,
+                        ) in self._iter_prompt_refinement_batches(prompt):
                             if check_cancel:
                                 check_cancel()
                             frame_idx, obj_ids, mask_logits = predictor.add_new_points_or_box(
@@ -377,8 +382,8 @@ class SAM2Tracker:
             return
 
         while pos_cursor < len(prompt.positive_points) or neg_cursor < len(prompt.negative_points):
-            pos_chunk = prompt.positive_points[pos_cursor:pos_cursor + pos_batch]
-            neg_chunk = prompt.negative_points[neg_cursor:neg_cursor + neg_batch]
+            pos_chunk = prompt.positive_points[pos_cursor : pos_cursor + pos_batch]
+            neg_chunk = prompt.negative_points[neg_cursor : neg_cursor + neg_batch]
             points: list[tuple[float, float]] = [*pos_chunk, *neg_chunk]
             labels: list[int] = ([1] * len(pos_chunk)) + ([0] * len(neg_chunk))
             yield (
@@ -441,9 +446,7 @@ class SAM2Tracker:
             if mask.ndim != 2:
                 raise ValueError("SAM2 mask prompts must be 2D arrays")
             if mask.shape != frame_shape:
-                raise ValueError(
-                    "SAM2 mask prompt dimensions must match the input frame size"
-                )
+                raise ValueError("SAM2 mask prompt dimensions must match the input frame size")
             mask = np.where(mask > 0, 255, 0).astype(np.uint8, copy=False)
 
         positive_points = _clamp_points(prompt.positive_points)
@@ -482,4 +485,4 @@ class SAM2Tracker:
 
         idx = ids.index(object_id)
         mask = (mask_logits[idx] > 0.0).detach().cpu().numpy()
-        return (np.squeeze(mask).astype(np.uint8) * 255)
+        return np.squeeze(mask).astype(np.uint8) * 255

--- a/scripts/bench_parallel_frames.py
+++ b/scripts/bench_parallel_frames.py
@@ -15,6 +15,7 @@ Requirements:
     - CorridorKey checkpoint in CorridorKeyModule/checkpoints/
     - Enough VRAM for 2 engine instances (~4 GB minimum)
 """
+
 from __future__ import annotations
 
 import argparse
@@ -25,7 +26,6 @@ import sys
 import time
 import threading
 
-import cv2
 import numpy as np
 import torch
 
@@ -74,8 +74,9 @@ def warmup_engine(engine: CorridorKeyEngine, image: np.ndarray, mask: np.ndarray
     print(f"done ({time.monotonic() - t0:.2f}s)")
 
 
-def bench_sequential(engine: CorridorKeyEngine, image: np.ndarray, mask: np.ndarray,
-                     n_frames: int) -> tuple[float, float]:
+def bench_sequential(
+    engine: CorridorKeyEngine, image: np.ndarray, mask: np.ndarray, n_frames: int
+) -> tuple[float, float]:
     """Scenario 1: One engine, N frames sequentially."""
     torch.cuda.reset_peak_memory_stats()
 
@@ -88,9 +89,13 @@ def bench_sequential(engine: CorridorKeyEngine, image: np.ndarray, mask: np.ndar
     return elapsed, peak
 
 
-def bench_two_engines_sequential(engine1: CorridorKeyEngine, engine2: CorridorKeyEngine,
-                                  image: np.ndarray, mask: np.ndarray,
-                                  n_frames: int) -> tuple[float, float]:
+def bench_two_engines_sequential(
+    engine1: CorridorKeyEngine,
+    engine2: CorridorKeyEngine,
+    image: np.ndarray,
+    mask: np.ndarray,
+    n_frames: int,
+) -> tuple[float, float]:
     """Scenario 2: Two engines, alternating frames (no overlap)."""
     torch.cuda.reset_peak_memory_stats()
 
@@ -106,9 +111,13 @@ def bench_two_engines_sequential(engine1: CorridorKeyEngine, engine2: CorridorKe
     return elapsed, peak
 
 
-def bench_two_engines_concurrent(engine1: CorridorKeyEngine, engine2: CorridorKeyEngine,
-                                  image: np.ndarray, mask: np.ndarray,
-                                  n_frames: int) -> tuple[float, float]:
+def bench_two_engines_concurrent(
+    engine1: CorridorKeyEngine,
+    engine2: CorridorKeyEngine,
+    image: np.ndarray,
+    mask: np.ndarray,
+    n_frames: int,
+) -> tuple[float, float]:
     """Scenario 3: Two engines processing frames concurrently via threads.
 
     PyTorch releases the GIL during CUDA kernel execution, so two Python
@@ -156,16 +165,23 @@ def bench_two_engines_concurrent(engine1: CorridorKeyEngine, engine2: CorridorKe
 
 def main():
     parser = argparse.ArgumentParser(description="Benchmark parallel frame processing")
-    parser.add_argument("--frames", type=int, default=10, help="Number of frames to process per scenario")
+    parser.add_argument(
+        "--frames", type=int, default=10, help="Number of frames to process per scenario"
+    )
     parser.add_argument("--resolution", type=int, default=2048, help="Input resolution (square)")
-    parser.add_argument("--opt-mode", type=str, default="speed", choices=["speed", "lowvram", "auto"],
-                        help="Optimization mode for engines")
+    parser.add_argument(
+        "--opt-mode",
+        type=str,
+        default="speed",
+        choices=["speed", "lowvram", "auto"],
+        help="Optimization mode for engines",
+    )
     args = parser.parse_args()
 
     n_frames = args.frames
     res = args.resolution
 
-    print(f"=== CorridorKey Parallel Frame Benchmark ===")
+    print("=== CorridorKey Parallel Frame Benchmark ===")
     print(f"Frames: {n_frames}, Resolution: {res}x{res}, Opt mode: {args.opt_mode}")
     print()
 
@@ -187,9 +203,10 @@ def main():
 
     # --- Scenario 1: Single engine ---
     print("--- Scenario 1: Single engine, sequential ---")
-    os.environ['CORRIDORKEY_OPT_MODE'] = args.opt_mode
-    engine1 = CorridorKeyEngine(checkpoint_path=ckpt, device='cuda', img_size=2048,
-                                 optimization_mode=args.opt_mode)
+    os.environ["CORRIDORKEY_OPT_MODE"] = args.opt_mode
+    engine1 = CorridorKeyEngine(
+        checkpoint_path=ckpt, device="cuda", img_size=2048, optimization_mode=args.opt_mode
+    )
     vram_after_load1 = get_vram_mb()
     print(f"  VRAM after loading engine 1: {vram_after_load1:.0f} MB")
 
@@ -203,8 +220,9 @@ def main():
 
     # --- Load second engine ---
     print("--- Loading second engine ---")
-    engine2 = CorridorKeyEngine(checkpoint_path=ckpt, device='cuda', img_size=2048,
-                                 optimization_mode=args.opt_mode)
+    engine2 = CorridorKeyEngine(
+        checkpoint_path=ckpt, device="cuda", img_size=2048, optimization_mode=args.opt_mode
+    )
     vram_after_load2 = get_vram_mb()
     print(f"  VRAM after loading engine 2: {vram_after_load2:.0f} MB")
     print(f"  VRAM increase: {vram_after_load2 - vram_after_load1:.0f} MB")
@@ -235,8 +253,10 @@ def main():
     print(f"{'Scenario':<40} {'FPS':>8} {'Speedup':>10} {'Peak VRAM':>12}")
     print("-" * 70)
     print(f"{'1. Single engine, sequential':<40} {fps1:>8.2f} {'1.00x':>10} {peak1:>10.0f} MB")
-    print(f"{'2. Two engines, alternating':<40} {fps2:>8.2f} {fps2/fps1:>9.2f}x {peak2:>10.0f} MB")
-    print(f"{'3. Two engines, concurrent':<40} {fps3:>8.2f} {fps3/fps1:>9.2f}x {peak3:>10.0f} MB")
+    print(
+        f"{'2. Two engines, alternating':<40} {fps2:>8.2f} {fps2 / fps1:>9.2f}x {peak2:>10.0f} MB"
+    )
+    print(f"{'3. Two engines, concurrent':<40} {fps3:>8.2f} {fps3 / fps1:>9.2f}x {peak3:>10.0f} MB")
     print()
 
     if fps3 > fps1 * 1.15:

--- a/scripts/benchmark_quality.py
+++ b/scripts/benchmark_quality.py
@@ -8,13 +8,14 @@ Levels:
 
 Outputs per-pixel difference metrics between each level and baseline.
 """
+
 import os
-os.environ['OPENCV_IO_ENABLE_OPENEXR'] = '1'
+
+os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
 import sys
 import types
 import numpy as np
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 import cv2
 import logging
@@ -37,7 +38,7 @@ def load_exr_frame(path: str):
     return img.astype(np.float32)
 
 
-def create_engine(checkpoint, device='cuda', img_size=2048):
+def create_engine(checkpoint, device="cuda", img_size=2048):
     """Create a fresh CorridorKeyEngine without any patches."""
     from CorridorKeyModule.core.model_transformer import GreenFormer
     import math
@@ -47,21 +48,24 @@ def create_engine(checkpoint, device='cuda', img_size=2048):
     model.eval()
 
     ckpt = torch.load(checkpoint, map_location=device, weights_only=True)
-    state_dict = ckpt.get('state_dict', ckpt)
+    state_dict = ckpt.get("state_dict", ckpt)
     model_state = model.state_dict()
 
     new_state_dict = {}
     for k, v in state_dict.items():
-        if k.startswith('_orig_mod.'):
+        if k.startswith("_orig_mod."):
             k = k[10:]
-        if 'pos_embed' in k and k in model_state:
+        if "pos_embed" in k and k in model_state:
             if v.shape != model_state[k].shape:
                 N_src, N_dst = v.shape[1], model_state[k].shape[1]
                 C = v.shape[2]
                 g_src, g_dst = int(math.sqrt(N_src)), int(math.sqrt(N_dst))
                 v_img = v.permute(0, 2, 1).view(1, C, g_src, g_src)
-                v = F.interpolate(v_img, size=(g_dst, g_dst), mode='bicubic',
-                                  align_corners=False).flatten(2).transpose(1, 2)
+                v = (
+                    F.interpolate(v_img, size=(g_dst, g_dst), mode="bicubic", align_corners=False)
+                    .flatten(2)
+                    .transpose(1, 2)
+                )
         new_state_dict[k] = v
 
     model.load_state_dict(new_state_dict, strict=False)
@@ -93,6 +97,7 @@ def patch_hiera(model):
                 x = x.transpose(1, 2).reshape(B, -1, self.dim_out)
                 x = self.proj(x)
                 return x
+
             return types.MethodType(_patched_forward, original_attn)
 
         attn.forward = _make_patched_forward(attn)
@@ -117,7 +122,7 @@ def run_inference(model, image: np.ndarray, img_size=2048):
     inp = torch.cat([img_t, mask_t], dim=1)
 
     out = model(inp)
-    pred_alpha = out['alpha']
+    pred_alpha = out["alpha"]
     res = pred_alpha[0].permute(1, 2, 0).float().cpu().numpy()
     res = cv2.resize(res, (w, h), interpolation=cv2.INTER_LANCZOS4)
     return res
@@ -130,15 +135,15 @@ def compare(name_a, alpha_a, name_b, alpha_b):
     mae = float(diff.mean())
     mse = float(np.mean((alpha_a - alpha_b) ** 2))
     if mse == 0:
-        psnr_val = float('inf')
+        psnr_val = float("inf")
     else:
         psnr_val = 10 * np.log10(1.0 / mse)
 
     return {
-        'pair': f"{name_a} vs {name_b}",
-        'max_diff': max_diff,
-        'mae': mae,
-        'psnr': psnr_val,
+        "pair": f"{name_a} vs {name_b}",
+        "max_diff": max_diff,
+        "mae": mae,
+        "psnr": psnr_val,
     }
 
 
@@ -146,8 +151,10 @@ def main():
     ckpt = "CorridorKeyModule/CorridorKey.pth"
     if not os.path.isfile(ckpt):
         # Try finding it
-        for candidate in ["checkpoints/CorridorKey.pth",
-                          "CorridorKeyModule/checkpoints/CorridorKey.pth"]:
+        for candidate in [
+            "checkpoints/CorridorKey.pth",
+            "CorridorKeyModule/checkpoints/CorridorKey.pth",
+        ]:
             if os.path.isfile(candidate):
                 ckpt = candidate
                 break
@@ -199,10 +206,10 @@ def main():
     print("=" * 60)
     print("Level 0: BASELINE (no patches)")
     print("=" * 60)
-    torch.set_float32_matmul_precision('highest')  # Reset to default
+    torch.set_float32_matmul_precision("highest")  # Reset to default
     model = create_engine(ckpt)
     alpha_baseline = run_inference(model, image)
-    results['baseline'] = alpha_baseline
+    results["baseline"] = alpha_baseline
     del model
     torch.cuda.empty_cache()
     print(f"  Alpha range: [{alpha_baseline.min():.4f}, {alpha_baseline.max():.4f}]")
@@ -212,12 +219,12 @@ def main():
     print("=" * 60)
     print("Level 1: HIERA FlashAttention patch")
     print("=" * 60)
-    torch.set_float32_matmul_precision('highest')
+    torch.set_float32_matmul_precision("highest")
     model = create_engine(ckpt)
     n = patch_hiera(model)
     print(f"  Patched {n} blocks")
     alpha_hiera = run_inference(model, image)
-    results['hiera'] = alpha_hiera
+    results["hiera"] = alpha_hiera
     del model
     torch.cuda.empty_cache()
     print(f"  Alpha range: [{alpha_hiera.min():.4f}, {alpha_hiera.max():.4f}]")
@@ -227,12 +234,12 @@ def main():
     print("=" * 60)
     print("Level 2: HIERA + TF32")
     print("=" * 60)
-    torch.set_float32_matmul_precision('high')  # Enable TF32
+    torch.set_float32_matmul_precision("high")  # Enable TF32
     model = create_engine(ckpt)
     n = patch_hiera(model)
     print(f"  Patched {n} blocks, TF32 enabled")
     alpha_tf32 = run_inference(model, image)
-    results['hiera_tf32'] = alpha_tf32
+    results["hiera_tf32"] = alpha_tf32
     del model
     torch.cuda.empty_cache()
     print(f"  Alpha range: [{alpha_tf32.min():.4f}, {alpha_tf32.max():.4f}]")
@@ -242,16 +249,19 @@ def main():
     print("=" * 60)
     print("Level 3: HIERA + TF32 + torch.compile")
     print("=" * 60)
-    torch.set_float32_matmul_precision('high')
+    torch.set_float32_matmul_precision("high")
     model = create_engine(ckpt)
     n = patch_hiera(model)
     try:
         import subprocess
-        if sys.platform == 'win32':
+
+        if sys.platform == "win32":
             _orig = subprocess.Popen.__init__
+
             def _silent(self, *a, **kw):
-                kw.setdefault('creationflags', subprocess.CREATE_NO_WINDOW)
+                kw.setdefault("creationflags", subprocess.CREATE_NO_WINDOW)
                 _orig(self, *a, **kw)
+
             subprocess.Popen.__init__ = _silent
         model = torch.compile(model)
         print(f"  Patched {n} blocks, TF32 enabled, torch.compile active")
@@ -260,7 +270,7 @@ def main():
         _ = run_inference(model, image)
         # Real run
         alpha_compile = run_inference(model, image)
-        results['hiera_tf32_compile'] = alpha_compile
+        results["hiera_tf32_compile"] = alpha_compile
         print(f"  Alpha range: [{alpha_compile.min():.4f}, {alpha_compile.max():.4f}]")
     except Exception as e:
         print(f"  torch.compile FAILED: {e}")
@@ -278,10 +288,10 @@ def main():
     print("-" * 68)
 
     for name, alpha in results.items():
-        if name == 'baseline':
+        if name == "baseline":
             continue
-        c = compare('baseline', results['baseline'], name, alpha)
-        psnr_str = f"{c['psnr']:.1f}" if c['psnr'] != float('inf') else "inf (identical)"
+        c = compare("baseline", results["baseline"], name, alpha)
+        psnr_str = f"{c['psnr']:.1f}" if c["psnr"] != float("inf") else "inf (identical)"
         print(f"{name:<30} {c['max_diff']:>12.8f} {c['mae']:>12.8f} {psnr_str:>15}")
 
     print()
@@ -302,14 +312,13 @@ def _make_checkerboard(h: int, w: int, tile: int = 32) -> np.ndarray:
     for y in range(0, h, tile):
         for x in range(0, w, tile):
             if ((y // tile) + (x // tile)) % 2 == 0:
-                board[y:y+tile, x:x+tile] = 0.25
+                board[y : y + tile, x : x + tile] = 0.25
             else:
-                board[y:y+tile, x:x+tile] = 0.15
+                board[y : y + tile, x : x + tile] = 0.15
     return board
 
 
-def _composite_over_checker(fg: np.ndarray, alpha: np.ndarray,
-                            tile: int = 32) -> np.ndarray:
+def _composite_over_checker(fg: np.ndarray, alpha: np.ndarray, tile: int = 32) -> np.ndarray:
     """Composite foreground RGB [H,W,3] over checkerboard using alpha [H,W].
 
     Returns float32 [H,W,3] clipped to [0,1].
@@ -323,8 +332,7 @@ def _composite_over_checker(fg: np.ndarray, alpha: np.ndarray,
     return np.clip(comp, 0, 1)
 
 
-def generate_report(frame_path: str, image: np.ndarray, results: dict,
-                    version: str = "1.5.0"):
+def generate_report(frame_path: str, image: np.ndarray, results: dict, version: str = "1.5.0"):
     """Save a dated, branded visual quality report as PNG.
 
     Shows the actual keyed output: source frame composited over a checkerboard
@@ -334,32 +342,32 @@ def generate_report(frame_path: str, image: np.ndarray, results: dict,
     Uses CorridorKey brand palette: #FFF203 yellow on #141300 near-black.
     """
     import matplotlib
-    matplotlib.use('Agg')
+
+    matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     from datetime import datetime
 
     # --- Brand palette ---
-    BG = '#141300'
-    BG_CARD = '#1A1900'
-    BORDER = '#2A2910'
-    YELLOW = '#FFF203'
-    TEXT = '#E0E0E0'
-    TEXT_DIM = '#888870'
-    PASS_GREEN = '#44ff44'
-    WARN_ORANGE = '#ffaa00'
-    FAIL_RED = '#ff4444'
+    BG = "#141300"
+    BG_CARD = "#1A1900"
+    BORDER = "#2A2910"
+    YELLOW = "#FFF203"
+    TEXT = "#E0E0E0"
+    PASS_GREEN = "#44ff44"
+    WARN_ORANGE = "#ffaa00"
+    FAIL_RED = "#ff4444"
 
     timestamp = datetime.now().strftime("%Y-%m-%d  %H:%M:%S")
     date_slug = datetime.now().strftime("%y%m%d_%H%M%S")
     h, w = image.shape[:2]
 
-    baseline = results['baseline']
-    opt_names = [k for k in results if k != 'baseline']
+    baseline = results["baseline"]
+    opt_names = [k for k in results if k != "baseline"]
 
     level_labels = {
-        'hiera': 'Level 1 — Hiera FlashAttn',
-        'hiera_tf32': 'Level 2 — Hiera + TF32',
-        'hiera_tf32_compile': 'Level 3 — Hiera + TF32 + compile',
+        "hiera": "Level 1 — Hiera FlashAttn",
+        "hiera_tf32": "Level 2 — Hiera + TF32",
+        "hiera_tf32_compile": "Level 3 — Hiera + TF32 + compile",
     }
 
     # Pick the highest optimization level — that's what ships
@@ -375,9 +383,9 @@ def generate_report(frame_path: str, image: np.ndarray, results: dict,
         max_diff = float(diff.max())
         mae = float(diff.mean())
         mse = float(np.mean((results[name] - baseline) ** 2))
-        psnr_val = float('inf') if mse == 0 else 10 * np.log10(1.0 / mse)
+        psnr_val = float("inf") if mse == 0 else 10 * np.log10(1.0 / mse)
 
-        if psnr_val == float('inf'):
+        if psnr_val == float("inf"):
             psnr_str, verdict = "inf", "BIT-IDENTICAL"
         elif psnr_val > 80:
             psnr_str, verdict = f"{psnr_val:.1f}", "PASS — below noise floor"
@@ -391,8 +399,11 @@ def generate_report(frame_path: str, image: np.ndarray, results: dict,
             all_pass = False
 
         metrics[name] = {
-            'max_diff': max_diff, 'mae': mae, 'psnr': psnr_val,
-            'psnr_str': psnr_str, 'verdict': verdict,
+            "max_diff": max_diff,
+            "mae": mae,
+            "psnr": psnr_val,
+            "psnr_str": psnr_str,
+            "verdict": verdict,
         }
 
     # --- Build composites: source keyed over checkerboard ---
@@ -411,9 +422,9 @@ def generate_report(frame_path: str, image: np.ndarray, results: dict,
     fig = plt.figure(figsize=(20, 14), facecolor=BG)
 
     # Image row: 3 equal subplots in top half
-    ax1 = fig.add_axes([0.02, 0.42, 0.31, 0.45])   # left
-    ax2 = fig.add_axes([0.345, 0.42, 0.31, 0.45])   # center
-    ax3 = fig.add_axes([0.67, 0.42, 0.31, 0.45])    # right
+    ax1 = fig.add_axes([0.02, 0.42, 0.31, 0.45])  # left
+    ax2 = fig.add_axes([0.345, 0.42, 0.31, 0.45])  # center
+    ax3 = fig.add_axes([0.67, 0.42, 0.31, 0.45])  # right
 
     panels = [
         (ax1, source_disp, "Source Frame\n(green screen input)", TEXT),
@@ -423,38 +434,64 @@ def generate_report(frame_path: str, image: np.ndarray, results: dict,
 
     for ax, img, title, color in panels:
         ax.imshow(img)
-        ax.set_title(title, color=color, fontsize=12, fontweight='bold', pad=10)
-        ax.axis('off')
+        ax.set_title(title, color=color, fontsize=12, fontweight="bold", pad=10)
+        ax.axis("off")
 
     # --- Header ---
-    fig.text(0.5, 0.96, "C O R R I D O R K E Y", color=YELLOW,
-             fontsize=18, fontweight='bold', ha='center', fontfamily='sans-serif')
-    fig.text(0.5, 0.92,
-             f"Quality Validation Report   |   v{version}   |   {timestamp}",
-             color=TEXT, fontsize=11, ha='center', fontfamily='sans-serif')
-    fig.patches.append(matplotlib.patches.Rectangle(
-        (0.02, 0.905), 0.96, 0.003, transform=fig.transFigure,
-        facecolor=YELLOW, edgecolor='none',
-    ))
+    fig.text(
+        0.5,
+        0.96,
+        "C O R R I D O R K E Y",
+        color=YELLOW,
+        fontsize=18,
+        fontweight="bold",
+        ha="center",
+        fontfamily="sans-serif",
+    )
+    fig.text(
+        0.5,
+        0.92,
+        f"Quality Validation Report   |   v{version}   |   {timestamp}",
+        color=TEXT,
+        fontsize=11,
+        ha="center",
+        fontfamily="sans-serif",
+    )
+    fig.patches.append(
+        matplotlib.patches.Rectangle(
+            (0.02, 0.905),
+            0.96,
+            0.003,
+            transform=fig.transFigure,
+            facecolor=YELLOW,
+            edgecolor="none",
+        )
+    )
 
     # --- Metrics table in its own axes ---
     ax_tbl = fig.add_axes([0.05, 0.10, 0.90, 0.28])
-    ax_tbl.axis('off')
+    ax_tbl.axis("off")
 
-    col_labels = ['Optimization Level', 'Max Pixel Diff', 'MAE',
-                  'PSNR (dB)', 'Verdict']
+    col_labels = ["Optimization Level", "Max Pixel Diff", "MAE", "PSNR (dB)", "Verdict"]
     table_data = []
     for name in opt_names:
         m = metrics[name]
         display = level_labels.get(name, name)
-        table_data.append([
-            display, f"{m['max_diff']:.10f}", f"{m['mae']:.10f}",
-            m['psnr_str'], m['verdict'],
-        ])
+        table_data.append(
+            [
+                display,
+                f"{m['max_diff']:.10f}",
+                f"{m['mae']:.10f}",
+                m["psnr_str"],
+                m["verdict"],
+            ]
+        )
 
     tbl = ax_tbl.table(
-        cellText=table_data, colLabels=col_labels,
-        cellLoc='center', loc='center',
+        cellText=table_data,
+        colLabels=col_labels,
+        cellLoc="center",
+        loc="center",
     )
     tbl.auto_set_font_size(False)
     tbl.set_fontsize(11)
@@ -464,36 +501,42 @@ def generate_report(frame_path: str, image: np.ndarray, results: dict,
         cell.set_edgecolor(BORDER)
         if row == 0:
             cell.set_facecolor(BORDER)
-            cell.set_text_props(color=YELLOW, fontweight='bold', fontsize=11)
+            cell.set_text_props(color=YELLOW, fontweight="bold", fontsize=11)
         else:
             cell.set_facecolor(BG_CARD)
             cell.set_text_props(color=TEXT, fontsize=11)
             if col == 4:
                 text = cell.get_text().get_text()
-                if 'FAIL' in text:
-                    cell.set_text_props(color=FAIL_RED, fontweight='bold')
-                elif 'WARN' in text:
-                    cell.set_text_props(color=WARN_ORANGE, fontweight='bold')
-                elif 'BIT-IDENTICAL' in text:
-                    cell.set_text_props(color=YELLOW, fontweight='bold')
+                if "FAIL" in text:
+                    cell.set_text_props(color=FAIL_RED, fontweight="bold")
+                elif "WARN" in text:
+                    cell.set_text_props(color=WARN_ORANGE, fontweight="bold")
+                elif "BIT-IDENTICAL" in text:
+                    cell.set_text_props(color=YELLOW, fontweight="bold")
                 else:
-                    cell.set_text_props(color=PASS_GREEN, fontweight='bold')
+                    cell.set_text_props(color=PASS_GREEN, fontweight="bold")
 
     # --- Footer ---
-    overall = "ALL OPTIMIZATIONS PRODUCE IDENTICAL OUTPUT" if all_pass \
+    overall = (
+        "ALL OPTIMIZATIONS PRODUCE IDENTICAL OUTPUT"
+        if all_pass
         else "DIFFERENCES DETECTED — INVESTIGATE"
+    )
     overall_color = YELLOW if all_pass else FAIL_RED
     fig.text(
-        0.5, 0.04,
+        0.5,
+        0.04,
         f"v{version}   |   Frame: {os.path.basename(frame_path)}   |   "
         f"Resolution: {w}x{h}   |   {overall}",
-        ha='center', color=overall_color, fontsize=12, fontweight='bold',
-        fontfamily='sans-serif',
+        ha="center",
+        color=overall_color,
+        fontsize=12,
+        fontweight="bold",
+        fontfamily="sans-serif",
     )
 
     # --- Save ---
-    out_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                           "reports")
+    out_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "reports")
     os.makedirs(out_dir, exist_ok=True)
     out_path = os.path.join(out_dir, f"{date_slug}_quality_report_v{version}.png")
     fig.savefig(out_path, dpi=150, facecolor=fig.get_facecolor())

--- a/scripts/check_ffmpeg.py
+++ b/scripts/check_ffmpeg.py
@@ -1,4 +1,5 @@
 """Validate the local FFmpeg install without importing the full backend package."""
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/ci_smoke.py
+++ b/scripts/ci_smoke.py
@@ -10,6 +10,7 @@ This script is intentionally narrow:
 
 It is meant for CI and post-install smoke tests, not full GPU QA.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -108,9 +109,15 @@ def _exercise_ffmpeg_repair_button(app, prefs) -> None:
         ffmpeg_tools.get_ffmpeg_install_help = fake_help
         ffmpeg_tools.repair_ffmpeg_install = fake_repair
 
-        QMessageBox.information = lambda parent, title, text: dialogs.append((title, text)) or QMessageBox.Ok
-        QMessageBox.critical = lambda parent, title, text: dialogs.append((title, text)) or QMessageBox.Ok
-        QMessageBox.question = lambda parent, title, text: dialogs.append((title, text)) or QMessageBox.Yes
+        QMessageBox.information = lambda parent, title, text: (
+            dialogs.append((title, text)) or QMessageBox.Ok
+        )
+        QMessageBox.critical = lambda parent, title, text: (
+            dialogs.append((title, text)) or QMessageBox.Ok
+        )
+        QMessageBox.question = lambda parent, title, text: (
+            dialogs.append((title, text)) or QMessageBox.Yes
+        )
 
         prefs._refresh_ffmpeg_status()
         prefs._repair_ffmpeg_btn.click()

--- a/scripts/color_analysis.py
+++ b/scripts/color_analysis.py
@@ -2,7 +2,9 @@
 
 Loads the same frame+mask, runs both engines, compares RGB channels in detail.
 """
+
 import os
+
 os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
 
 import sys
@@ -32,7 +34,7 @@ def load_mask(path):
 
 
 def run_engine(engine_class, frame, mask, ckpt):
-    engine = engine_class(checkpoint_path=ckpt, device='cuda', img_size=2048)
+    engine = engine_class(checkpoint_path=ckpt, device="cuda", img_size=2048)
     result = engine.process_frame(frame, mask)
     del engine
     torch.cuda.empty_cache()
@@ -44,11 +46,13 @@ def channel_stats(name, img):
     if img.ndim == 2:
         print(f"  {name}: min={img.min():.6f} max={img.max():.6f} mean={img.mean():.6f}")
         return
-    labels = ['R', 'G', 'B', 'A'][:img.shape[2]]
+    labels = ["R", "G", "B", "A"][: img.shape[2]]
     for i, ch in enumerate(labels):
         c = img[:, :, i]
-        print(f"  {name}[{ch}]: min={c.min():.6f} max={c.max():.6f} "
-              f"mean={c.mean():.6f} std={c.std():.6f}")
+        print(
+            f"  {name}[{ch}]: min={c.min():.6f} max={c.max():.6f} "
+            f"mean={c.mean():.6f} std={c.std():.6f}"
+        )
 
 
 def compare_channels(name, a, b):
@@ -57,13 +61,12 @@ def compare_channels(name, a, b):
         a = a[:, :, np.newaxis]
     if b.ndim == 2:
         b = b[:, :, np.newaxis]
-    labels = ['R', 'G', 'B', 'A'][:a.shape[2]]
+    labels = ["R", "G", "B", "A"][: a.shape[2]]
     for i, ch in enumerate(labels):
         diff = np.abs(a[:, :, i] - b[:, :, i])
         mse = float(np.mean((a[:, :, i] - b[:, :, i]) ** 2))
-        psnr = float('inf') if mse == 0 else 10 * np.log10(1.0 / mse)
-        print(f"  {name}[{ch}]: max_diff={diff.max():.8f} mae={diff.mean():.8f} "
-              f"psnr={psnr:.1f}dB")
+        psnr = float("inf") if mse == 0 else 10 * np.log10(1.0 / mse)
+        print(f"  {name}[{ch}]: max_diff={diff.max():.8f} mae={diff.mean():.8f} psnr={psnr:.1f}dB")
 
 
 def main():
@@ -84,24 +87,25 @@ def main():
     print("UPSTREAM ENGINE")
     print("=" * 60)
     sys.path.insert(0, UPSTREAM_ROOT)
-    mods = [k for k in sys.modules if k.startswith('CorridorKeyModule')]
+    mods = [k for k in sys.modules if k.startswith("CorridorKeyModule")]
     for m in mods:
         del sys.modules[m]
     from CorridorKeyModule.inference_engine import CorridorKeyEngine as UpEngine
+
     sys.path.pop(0)
 
     res_up = run_engine(UpEngine, frame, mask, ckpt)
     print("\nUpstream outputs:")
-    channel_stats("alpha", res_up['alpha'])
-    channel_stats("fg", res_up['fg'])
-    channel_stats("comp", res_up['comp'])
+    channel_stats("alpha", res_up["alpha"])
+    channel_stats("fg", res_up["fg"])
+    channel_stats("comp", res_up["comp"])
     print()
 
     # --- Ours ---
     print("=" * 60)
     print("OUR ENGINE")
     print("=" * 60)
-    mods = [k for k in sys.modules if k.startswith('CorridorKeyModule')]
+    mods = [k for k in sys.modules if k.startswith("CorridorKeyModule")]
     for m in mods:
         del sys.modules[m]
     sys.path.insert(0, PROJECT_ROOT)
@@ -110,9 +114,9 @@ def main():
     res_ours = run_engine(OurEngine, frame, mask, ckpt)
     torch._dynamo.reset()
     print("\nOur outputs:")
-    channel_stats("alpha", res_ours['alpha'])
-    channel_stats("fg", res_ours['fg'])
-    channel_stats("comp", res_ours['comp'])
+    channel_stats("alpha", res_ours["alpha"])
+    channel_stats("fg", res_ours["fg"])
+    channel_stats("comp", res_ours["comp"])
     print()
 
     # --- Comparison ---
@@ -121,13 +125,13 @@ def main():
     print("=" * 60)
 
     print("\nAlpha comparison:")
-    compare_channels("alpha", res_up['alpha'], res_ours['alpha'])
+    compare_channels("alpha", res_up["alpha"], res_ours["alpha"])
 
     print("\nFG comparison:")
-    compare_channels("fg", res_up['fg'], res_ours['fg'])
+    compare_channels("fg", res_up["fg"], res_ours["fg"])
 
     print("\nComp comparison:")
-    compare_channels("comp", res_up['comp'], res_ours['comp'])
+    compare_channels("comp", res_up["comp"], res_ours["comp"])
 
     # --- Saturation analysis ---
     print("\n" + "=" * 60)
@@ -135,13 +139,12 @@ def main():
     print("=" * 60)
 
     # Compare mean color of the subject region (where alpha > 0.5)
-    a_up = res_up['alpha'][:, :, 0] if res_up['alpha'].ndim == 3 else res_up['alpha']
-    a_ours = res_ours['alpha'][:, :, 0] if res_ours['alpha'].ndim == 3 else res_ours['alpha']
+    a_up = res_up["alpha"][:, :, 0] if res_up["alpha"].ndim == 3 else res_up["alpha"]
 
     # Subject mask (high alpha = foreground)
     subj_mask = a_up > 0.5
 
-    for name, comp in [("Upstream comp", res_up['comp']), ("Our comp", res_ours['comp'])]:
+    for name, comp in [("Upstream comp", res_up["comp"]), ("Our comp", res_ours["comp"])]:
         r = comp[:, :, 0][subj_mask]
         g = comp[:, :, 1][subj_mask]
         b = comp[:, :, 2][subj_mask]
@@ -157,12 +160,11 @@ def main():
         print(f"    Mean luminance:  {lum.mean():.6f}")
 
     # Direct diff of comp in subject region
-    comp_diff = res_up['comp'] - res_ours['comp']
-    print(f"\n  Comp diff (subject region):")
-    for i, ch in enumerate(['R', 'G', 'B']):
+    comp_diff = res_up["comp"] - res_ours["comp"]
+    print("\n  Comp diff (subject region):")
+    for i, ch in enumerate(["R", "G", "B"]):
         d = comp_diff[:, :, i][subj_mask]
-        print(f"    {ch}: mean_diff={d.mean():.8f} std={d.std():.8f} "
-              f"(positive=upstream brighter)")
+        print(f"    {ch}: mean_diff={d.mean():.8f} std={d.std():.8f} (positive=upstream brighter)")
 
 
 if __name__ == "__main__":

--- a/scripts/compare_quality.py
+++ b/scripts/compare_quality.py
@@ -12,6 +12,7 @@ Metrics:
     - PSNR (Peak Signal-to-Noise Ratio) — >60dB is essentially identical
     - SSIM (Structural Similarity) — >0.999 is perceptually identical
 """
+
 import sys
 import os
 import glob
@@ -20,12 +21,14 @@ import numpy as np
 try:
     import OpenEXR
     import Imath
+
     HAS_OPENEXR = True
 except ImportError:
     HAS_OPENEXR = False
 
 try:
     import cv2
+
     HAS_CV2 = True
 except ImportError:
     HAS_CV2 = False
@@ -36,12 +39,12 @@ def load_exr_alpha(path: str) -> np.ndarray:
     if HAS_OPENEXR:
         exr = OpenEXR.InputFile(path)
         header = exr.header()
-        dw = header['dataWindow']
+        dw = header["dataWindow"]
         w = dw.max.x - dw.min.x + 1
         h = dw.max.y - dw.min.y + 1
         # Try A channel first, fall back to R
-        channels = header['channels']
-        ch_name = 'A' if 'A' in channels else 'R'
+        channels = header["channels"]
+        ch_name = "A" if "A" in channels else "R"
         raw = exr.channel(ch_name, Imath.PixelType(Imath.PixelType.FLOAT))
         return np.frombuffer(raw, dtype=np.float32).reshape(h, w)
     elif HAS_CV2:
@@ -60,14 +63,14 @@ def load_exr_alpha(path: str) -> np.ndarray:
 def psnr(a: np.ndarray, b: np.ndarray) -> float:
     mse = np.mean((a - b) ** 2)
     if mse == 0:
-        return float('inf')
+        return float("inf")
     return 10 * np.log10(1.0 / mse)
 
 
 def ssim_simple(a: np.ndarray, b: np.ndarray) -> float:
     """Simplified SSIM (no windowing, whole-image)."""
-    c1 = 0.01 ** 2
-    c2 = 0.03 ** 2
+    c1 = 0.01**2
+    c2 = 0.03**2
     mu_a, mu_b = a.mean(), b.mean()
     var_a, var_b = a.var(), b.var()
     cov = np.mean((a - mu_a) * (b - mu_b))
@@ -133,17 +136,22 @@ def main():
 
     print(f"{'Metric':<25} {'Min':>12} {'Mean':>12} {'Max':>12}")
     print("-" * 63)
-    print(f"{'Max pixel difference':<25} {min(all_max_diff):>12.8f} {np.mean(all_max_diff):>12.8f} {max(all_max_diff):>12.8f}")
-    print(f"{'Mean absolute error':<25} {min(all_mae):>12.8f} {np.mean(all_mae):>12.8f} {max(all_mae):>12.8f}")
-    print(f"{'PSNR (dB)':<25} {min(all_psnr):>12.2f} {np.mean(all_psnr):>12.2f} {max(all_psnr):>12.2f}")
+    print(
+        f"{'Max pixel difference':<25} {min(all_max_diff):>12.8f} {np.mean(all_max_diff):>12.8f} {max(all_max_diff):>12.8f}"
+    )
+    print(
+        f"{'Mean absolute error':<25} {min(all_mae):>12.8f} {np.mean(all_mae):>12.8f} {max(all_mae):>12.8f}"
+    )
+    print(
+        f"{'PSNR (dB)':<25} {min(all_psnr):>12.2f} {np.mean(all_psnr):>12.2f} {max(all_psnr):>12.2f}"
+    )
     print(f"{'SSIM':<25} {min(all_ssim):>12.8f} {np.mean(all_ssim):>12.8f} {max(all_ssim):>12.8f}")
     print()
 
     avg_psnr = np.mean(all_psnr)
-    avg_ssim = np.mean(all_ssim)
     avg_max = np.mean(all_max_diff)
 
-    if avg_psnr == float('inf'):
+    if avg_psnr == float("inf"):
         print("RESULT: IDENTICAL — zero difference between A and B")
     elif avg_psnr > 60:
         print(f"RESULT: EFFECTIVELY IDENTICAL — PSNR {avg_psnr:.1f}dB (>60dB)")

--- a/scripts/compare_upstream.py
+++ b/scripts/compare_upstream.py
@@ -7,7 +7,9 @@ Runs the SAME source frame + alpha mask through:
 Compares the actual output alphas, FGs, and composites.
 Generates a branded visual report PNG.
 """
+
 import os
+
 os.environ["OPENCV_IO_ENABLE_OPENEXR"] = "1"
 
 import sys
@@ -82,14 +84,17 @@ def run_upstream(frame, mask, checkpoint):
     sys.path.insert(0, UPSTREAM_ROOT)
     # Import upstream's engine
     from CorridorKeyModule.inference_engine import CorridorKeyEngine as UpstreamEngine
+
     sys.path.pop(0)
 
     engine = UpstreamEngine(
-        checkpoint_path=checkpoint, device='cuda', img_size=2048,
+        checkpoint_path=checkpoint,
+        device="cuda",
+        img_size=2048,
     )
     result = engine.process_frame(frame, mask)
-    alpha = result['alpha']
-    comp = result['comp']
+    alpha = result["alpha"]
+    comp = result["comp"]
     del engine
     torch.cuda.empty_cache()
     return alpha, comp
@@ -100,41 +105,41 @@ def run_ours(frame, mask, checkpoint):
     sys.path.insert(0, PROJECT_ROOT)
     # Force fresh import of our engine (not upstream's cached one)
     # Remove any cached CorridorKeyModule imports
-    mods_to_remove = [k for k in sys.modules if k.startswith('CorridorKeyModule')]
+    mods_to_remove = [k for k in sys.modules if k.startswith("CorridorKeyModule")]
     for m in mods_to_remove:
         del sys.modules[m]
 
     from CorridorKeyModule.inference_engine import CorridorKeyEngine as OurEngine
 
     engine = OurEngine(
-        checkpoint_path=checkpoint, device='cuda', img_size=2048,
+        checkpoint_path=checkpoint,
+        device="cuda",
+        img_size=2048,
     )
     result = engine.process_frame(frame, mask)
-    alpha = result['alpha']
-    comp = result['comp']
+    alpha = result["alpha"]
+    comp = result["comp"]
     del engine
     torch.cuda.empty_cache()
     torch._dynamo.reset()
     return alpha, comp
 
 
-def generate_report(frame_path, source, mask,
-                    alpha_up, comp_up,
-                    alpha_ours, comp_ours,
-                    metrics):
+def generate_report(frame_path, source, mask, alpha_up, comp_up, alpha_ours, comp_ours, metrics):
     """Generate branded visual comparison report."""
     import matplotlib
-    matplotlib.use('Agg')
+
+    matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     from datetime import datetime
 
-    BG = '#141300'
-    BG_CARD = '#1A1900'
-    BORDER = '#2A2910'
-    YELLOW = '#FFF203'
-    TEXT = '#E0E0E0'
-    PASS_GREEN = '#44ff44'
-    FAIL_RED = '#ff4444'
+    BG = "#141300"
+    BG_CARD = "#1A1900"
+    BORDER = "#2A2910"
+    YELLOW = "#FFF203"
+    TEXT = "#E0E0E0"
+    PASS_GREEN = "#44ff44"
+    FAIL_RED = "#ff4444"
 
     timestamp = datetime.now().strftime("%Y-%m-%d  %H:%M:%S")
     date_slug = datetime.now().strftime("%y%m%d_%H%M%S")
@@ -166,73 +171,96 @@ def generate_report(frame_path, source, mask,
     # Row 2: Alpha Mask Input | Upstream Alpha Output | Our Alpha Output
     positions = [
         # Row 1
-        [0.02,  0.52, 0.31, 0.34],  # source
+        [0.02, 0.52, 0.31, 0.34],  # source
         [0.345, 0.52, 0.31, 0.34],  # upstream comp
-        [0.67,  0.52, 0.31, 0.34],  # ours comp
+        [0.67, 0.52, 0.31, 0.34],  # ours comp
         # Row 2
-        [0.02,  0.15, 0.31, 0.34],  # mask input
+        [0.02, 0.15, 0.31, 0.34],  # mask input
         [0.345, 0.15, 0.31, 0.34],  # upstream alpha
-        [0.67,  0.15, 0.31, 0.34],  # ours alpha
+        [0.67, 0.15, 0.31, 0.34],  # ours alpha
     ]
 
     panels = [
-        (src_disp,        "Source Frame",                              TEXT),
-        (comp_ours_disp,  "EZ-CorridorKey Output\n(composited key)",   PASS_GREEN),
-        (comp_up_disp,    "CorridorKey Output\n(composited key)",      YELLOW),
-        (mask_disp,       "Alpha Hint Input\n(GVM coarse mask)",       TEXT),
-        (alpha_ours_disp, "EZ-CorridorKey Alpha\n(raw matte output)",  PASS_GREEN),
-        (alpha_up_disp,   "CorridorKey Alpha\n(raw matte output)",     YELLOW),
+        (src_disp, "Source Frame", TEXT),
+        (comp_ours_disp, "EZ-CorridorKey Output\n(composited key)", PASS_GREEN),
+        (comp_up_disp, "CorridorKey Output\n(composited key)", YELLOW),
+        (mask_disp, "Alpha Hint Input\n(GVM coarse mask)", TEXT),
+        (alpha_ours_disp, "EZ-CorridorKey Alpha\n(raw matte output)", PASS_GREEN),
+        (alpha_up_disp, "CorridorKey Alpha\n(raw matte output)", YELLOW),
     ]
 
     for pos, (img, title, color) in zip(positions, panels):
         ax = fig.add_axes(pos)
         ax.imshow(img)
-        ax.set_title(title, color=color, fontsize=11, fontweight='bold', pad=8)
-        ax.axis('off')
+        ax.set_title(title, color=color, fontsize=11, fontweight="bold", pad=8)
+        ax.axis("off")
 
     # --- Header ---
-    fig.text(0.5, 0.97, "C O R R I D O R K E Y", color=YELLOW,
-             fontsize=18, fontweight='bold', ha='center', fontfamily='sans-serif')
-    fig.text(0.5, 0.935,
-             f"EZ-CorridorKey vs CorridorKey — End-to-End Comparison   |   "
-             f"v{VERSION}   |   {timestamp}",
-             color=TEXT, fontsize=11, ha='center', fontfamily='sans-serif')
-    fig.patches.append(matplotlib.patches.Rectangle(
-        (0.02, 0.925), 0.96, 0.003, transform=fig.transFigure,
-        facecolor=YELLOW, edgecolor='none',
-    ))
+    fig.text(
+        0.5,
+        0.97,
+        "C O R R I D O R K E Y",
+        color=YELLOW,
+        fontsize=18,
+        fontweight="bold",
+        ha="center",
+        fontfamily="sans-serif",
+    )
+    fig.text(
+        0.5,
+        0.935,
+        f"EZ-CorridorKey vs CorridorKey — End-to-End Comparison   |   v{VERSION}   |   {timestamp}",
+        color=TEXT,
+        fontsize=11,
+        ha="center",
+        fontfamily="sans-serif",
+    )
+    fig.patches.append(
+        matplotlib.patches.Rectangle(
+            (0.02, 0.925),
+            0.96,
+            0.003,
+            transform=fig.transFigure,
+            facecolor=YELLOW,
+            edgecolor="none",
+        )
+    )
 
     # --- Metrics table ---
     ax_tbl = fig.add_axes([0.10, 0.02, 0.80, 0.10])
-    ax_tbl.axis('off')
+    ax_tbl.axis("off")
 
     m = metrics
-    psnr_str = f"{m['psnr']:.1f}" if m['psnr'] != float('inf') else "inf"
-    if m['psnr'] == float('inf'):
+    psnr_str = f"{m['psnr']:.1f}" if m["psnr"] != float("inf") else "inf"
+    if m["psnr"] == float("inf"):
         verdict = "BIT-IDENTICAL"
         v_color = YELLOW
-    elif m['psnr'] > 80:
+    elif m["psnr"] > 80:
         verdict = "PASS — below float32 noise floor"
         v_color = PASS_GREEN
-    elif m['psnr'] > 60:
+    elif m["psnr"] > 60:
         verdict = "PASS — imperceptible"
         v_color = PASS_GREEN
     else:
         verdict = "INVESTIGATE"
         v_color = FAIL_RED
 
-    col_labels = ['Comparison', 'Max Pixel Diff', 'MAE', 'PSNR (dB)', 'Verdict']
-    table_data = [[
-        "EZ-CorridorKey vs CorridorKey (alpha)",
-        f"{m['max_diff']:.10f}",
-        f"{m['mae']:.10f}",
-        psnr_str,
-        verdict,
-    ]]
+    col_labels = ["Comparison", "Max Pixel Diff", "MAE", "PSNR (dB)", "Verdict"]
+    table_data = [
+        [
+            "EZ-CorridorKey vs CorridorKey (alpha)",
+            f"{m['max_diff']:.10f}",
+            f"{m['mae']:.10f}",
+            psnr_str,
+            verdict,
+        ]
+    ]
 
     tbl = ax_tbl.table(
-        cellText=table_data, colLabels=col_labels,
-        cellLoc='center', loc='center',
+        cellText=table_data,
+        colLabels=col_labels,
+        cellLoc="center",
+        loc="center",
     )
     tbl.auto_set_font_size(False)
     tbl.set_fontsize(11)
@@ -242,20 +270,24 @@ def generate_report(frame_path, source, mask,
         cell.set_edgecolor(BORDER)
         if row == 0:
             cell.set_facecolor(BORDER)
-            cell.set_text_props(color=YELLOW, fontweight='bold', fontsize=11)
+            cell.set_text_props(color=YELLOW, fontweight="bold", fontsize=11)
         else:
             cell.set_facecolor(BG_CARD)
             cell.set_text_props(color=TEXT, fontsize=11)
             if col == 4:
-                cell.set_text_props(color=v_color, fontweight='bold', fontsize=11)
+                cell.set_text_props(color=v_color, fontweight="bold", fontsize=11)
 
     # --- Footer ---
     fig.text(
-        0.5, 0.005,
+        0.5,
+        0.005,
         f"v{VERSION}   |   Frame: {os.path.basename(frame_path)}   |   "
         f"Resolution: {w}x{h}   |   {verdict}",
-        ha='center', color=YELLOW if 'PASS' in verdict or 'IDENTICAL' in verdict else FAIL_RED,
-        fontsize=12, fontweight='bold', fontfamily='sans-serif',
+        ha="center",
+        color=YELLOW if "PASS" in verdict or "IDENTICAL" in verdict else FAIL_RED,
+        fontsize=12,
+        fontweight="bold",
+        fontfamily="sans-serif",
     )
 
     # Save
@@ -277,7 +309,7 @@ def main():
         if candidates:
             ckpt = os.path.join(ckpt_dir, candidates[0])
     if not os.path.isfile(ckpt):
-        print(f"Checkpoint not found")
+        print("Checkpoint not found")
         sys.exit(1)
     print(f"Checkpoint: {ckpt}")
 
@@ -325,24 +357,21 @@ def main():
     max_diff = float(diff.max())
     mae = float(diff.mean())
     mse = float(np.mean((a - b) ** 2))
-    psnr_val = float('inf') if mse == 0 else 10 * np.log10(1.0 / mse)
+    psnr_val = float("inf") if mse == 0 else 10 * np.log10(1.0 / mse)
 
     print("=" * 60)
     print("COMPARISON: Upstream vs Ours")
     print("=" * 60)
-    psnr_str = f"{psnr_val:.1f}" if psnr_val != float('inf') else "inf (bit-identical)"
+    psnr_str = f"{psnr_val:.1f}" if psnr_val != float("inf") else "inf (bit-identical)"
     print(f"  Max pixel diff: {max_diff:.10f}")
     print(f"  MAE:            {mae:.10f}")
     print(f"  PSNR:           {psnr_str} dB")
     print()
 
-    metrics = {'max_diff': max_diff, 'mae': mae, 'psnr': psnr_val}
+    metrics = {"max_diff": max_diff, "mae": mae, "psnr": psnr_val}
 
     # --- Generate report ---
-    generate_report(frame_path, frame, mask,
-                    alpha_up, comp_up,
-                    alpha_ours, comp_ours,
-                    metrics)
+    generate_report(frame_path, frame, mask, alpha_up, comp_up, alpha_ours, comp_ours, metrics)
 
 
 if __name__ == "__main__":

--- a/scripts/compare_upstream_d2.py
+++ b/scripts/compare_upstream_d2.py
@@ -187,9 +187,7 @@ def find_checkpoint(user_path: str | None) -> str:
 
     ckpt_dir = os.path.join(PROJECT_ROOT, "CorridorKeyModule", "checkpoints")
     candidates = sorted(
-        os.path.join(ckpt_dir, fname)
-        for fname in os.listdir(ckpt_dir)
-        if fname.endswith(".pth")
+        os.path.join(ckpt_dir, fname) for fname in os.listdir(ckpt_dir) if fname.endswith(".pth")
     )
     if not candidates:
         raise FileNotFoundError("Checkpoint not found in CorridorKeyModule/checkpoints")
@@ -223,6 +221,7 @@ def import_engine(repo_root: str):
     sys.path.insert(0, repo_root)
     try:
         from CorridorKeyModule.inference_engine import CorridorKeyEngine
+
         return CorridorKeyEngine
     finally:
         sys.path.pop(0)
@@ -272,7 +271,9 @@ def verdict_for_psnr(psnr: float) -> str:
     return "INVESTIGATE"
 
 
-def compute_metrics(name: str, a: np.ndarray, b: np.ndarray, mask: np.ndarray | None = None) -> MetricRow:
+def compute_metrics(
+    name: str, a: np.ndarray, b: np.ndarray, mask: np.ndarray | None = None
+) -> MetricRow:
     a_sel = np.asarray(_select_values(a, mask), dtype=np.float64)
     b_sel = np.asarray(_select_values(b, mask), dtype=np.float64)
     if a_sel.shape != b_sel.shape:
@@ -282,7 +283,7 @@ def compute_metrics(name: str, a: np.ndarray, b: np.ndarray, mask: np.ndarray | 
 
     diff = a_sel - b_sel
     abs_diff = np.abs(diff)
-    mse = float(np.mean(diff ** 2))
+    mse = float(np.mean(diff**2))
     psnr = float("inf") if mse == 0.0 else 10.0 * np.log10(1.0 / mse)
     pixel_count = int(a_sel.shape[0]) if a_sel.ndim > 1 else int(a_sel.size)
 
@@ -296,7 +297,9 @@ def compute_metrics(name: str, a: np.ndarray, b: np.ndarray, mask: np.ndarray | 
     )
 
 
-def compute_subject_mask(alpha_up: np.ndarray, alpha_ours: np.ndarray, threshold: float) -> np.ndarray:
+def compute_subject_mask(
+    alpha_up: np.ndarray, alpha_ours: np.ndarray, threshold: float
+) -> np.ndarray:
     a = alpha_up[:, :, 0] if alpha_up.ndim == 3 else alpha_up
     b = alpha_ours[:, :, 0] if alpha_ours.ndim == 3 else alpha_ours
     return np.maximum(np.clip(a, 0.0, 1.0), np.clip(b, 0.0, 1.0)) > threshold
@@ -314,7 +317,9 @@ def compute_luminance(rgb: np.ndarray) -> np.ndarray:
     return 0.2126 * rgb[:, 0] + 0.7152 * rgb[:, 1] + 0.0722 * rgb[:, 2]
 
 
-def attach_color_drift(row: MetricRow, comp_up: np.ndarray, comp_ours: np.ndarray, mask: np.ndarray) -> None:
+def attach_color_drift(
+    row: MetricRow, comp_up: np.ndarray, comp_ours: np.ndarray, mask: np.ndarray
+) -> None:
     up = np.clip(comp_up[mask], 0.0, 1.0).astype(np.float64)
     ours = np.clip(comp_ours[mask], 0.0, 1.0).astype(np.float64)
     if up.size == 0 or ours.size == 0:
@@ -343,13 +348,7 @@ def detect_skin_mask(
     cb = ycrcb[:, :, 2]
 
     skin_mask = (
-        subject_mask
-        & alpha_mask
-        & (y > 40)
-        & (cr >= 133)
-        & (cr <= 173)
-        & (cb >= 77)
-        & (cb <= 127)
+        subject_mask & alpha_mask & (y > 40) & (cr >= 133) & (cr <= 173) & (cb >= 77) & (cb <= 127)
     )
     if int(skin_mask.sum()) < MIN_SKIN_PIXELS:
         return None
@@ -364,8 +363,12 @@ def alpha_to_rgb(alpha: np.ndarray) -> np.ndarray:
 
 def _backend_status() -> list[str]:
     status = []
-    status.append("SSIM/DeltaE: ready" if skimage_ssim is not None else "SSIM/DeltaE: missing scikit-image")
-    status.append("MS-SSIM: ready" if torch_ms_ssim is not None else "MS-SSIM: missing pytorch-msssim")
+    status.append(
+        "SSIM/DeltaE: ready" if skimage_ssim is not None else "SSIM/DeltaE: missing scikit-image"
+    )
+    status.append(
+        "MS-SSIM: ready" if torch_ms_ssim is not None else "MS-SSIM: missing pytorch-msssim"
+    )
     if lpips is not None:
         status.append("LPIPS: ready")
     else:
@@ -373,7 +376,9 @@ def _backend_status() -> list[str]:
     return status
 
 
-def _bbox_from_mask(mask: np.ndarray, pad: int = DEFAULT_MASK_PAD) -> tuple[int, int, int, int] | None:
+def _bbox_from_mask(
+    mask: np.ndarray, pad: int = DEFAULT_MASK_PAD
+) -> tuple[int, int, int, int] | None:
     ys, xs = np.nonzero(mask)
     if ys.size == 0:
         return None
@@ -469,7 +474,9 @@ def _compute_lpips(a: np.ndarray, b: np.ndarray) -> float | None:
     return float(value.item())
 
 
-def _compute_deltae(comp_up: np.ndarray, comp_ours: np.ndarray, mask: np.ndarray) -> tuple[float, float] | tuple[None, None]:
+def _compute_deltae(
+    comp_up: np.ndarray, comp_ours: np.ndarray, mask: np.ndarray
+) -> tuple[float, float] | tuple[None, None]:
     if rgb2lab is None or deltaE_ciede2000 is None:
         return None, None
     if not np.any(mask):
@@ -483,13 +490,17 @@ def _compute_deltae(comp_up: np.ndarray, comp_ours: np.ndarray, mask: np.ndarray
     return float(masked.mean()), float(np.percentile(masked, 95))
 
 
-def _attach_image_metrics(row: MetricRow, a: np.ndarray, b: np.ndarray, allow_lpips: bool = True) -> None:
+def _attach_image_metrics(
+    row: MetricRow, a: np.ndarray, b: np.ndarray, allow_lpips: bool = True
+) -> None:
     row.ssim = _compute_ssim(a, b)
     row.ms_ssim = _compute_ms_ssim(a, b)
     row.lpips = _compute_lpips(a, b) if allow_lpips else None
 
 
-def _attach_subject_patch_metrics(row: MetricRow, up: np.ndarray, ours: np.ndarray, mask: np.ndarray, fill: float = 0.5) -> None:
+def _attach_subject_patch_metrics(
+    row: MetricRow, up: np.ndarray, ours: np.ndarray, mask: np.ndarray, fill: float = 0.5
+) -> None:
     patch_up = _crop_and_fill(up, mask, fill)
     patch_ours = _crop_and_fill(ours, mask, fill)
     if patch_up is None or patch_ours is None:
@@ -558,7 +569,13 @@ def summarize_overall(rows: list[MetricRow]) -> tuple[str, str]:
     return "BIT-IDENTICAL", "#FFF203"
 
 
-def _render_table(ax, rows: list[MetricRow], col_labels: list[str], cell_text: list[list[str]], highlight_verdict: bool) -> None:
+def _render_table(
+    ax,
+    rows: list[MetricRow],
+    col_labels: list[str],
+    cell_text: list[list[str]],
+    highlight_verdict: bool,
+) -> None:
     BG_CARD = "#1A1900"
     BORDER = "#2A2910"
     YELLOW = "#FFF203"
@@ -621,13 +638,11 @@ def generate_report(
         pil.save(buf, format="PNG", optimize=True)
         return base64.b64encode(buf.getvalue()).decode()
 
-    src_disp = np.clip(source / max(float(source.max()), 1e-6), 0.0, 1.0)
     comp_up_disp = np.clip(res_up["comp"], 0.0, 1.0)
     comp_ours_disp = np.clip(res_ours["comp"], 0.0, 1.0)
     alpha_up_disp = alpha_to_rgb(res_up["alpha"])
     alpha_ours_disp = alpha_to_rgb(res_ours["alpha"])
 
-    src_b64 = to_b64_png(src_disp)
     comp_up_b64 = to_b64_png(comp_up_disp)
     comp_ours_b64 = to_b64_png(comp_ours_disp)
     alpha_up_b64 = to_b64_png(alpha_up_disp)
@@ -659,11 +674,11 @@ def generate_report(
     for row in rows:
         perc_rows_html += f"""<tr>
             <td>{row.name}</td>
-            <td>{'-' if row.ssim is None else f'{row.ssim:.6f}'}</td>
-            <td>{'-' if row.ms_ssim is None else f'{row.ms_ssim:.6f}'}</td>
-            <td>{'-' if row.lpips is None else f'{row.lpips:.6f}'}</td>
-            <td>{'-' if row.deltae_mean is None else f'{row.deltae_mean:.6f}'}</td>
-            <td>{'-' if row.deltae_p95 is None else f'{row.deltae_p95:.6f}'}</td></tr>\n"""
+            <td>{"-" if row.ssim is None else f"{row.ssim:.6f}"}</td>
+            <td>{"-" if row.ms_ssim is None else f"{row.ms_ssim:.6f}"}</td>
+            <td>{"-" if row.lpips is None else f"{row.lpips:.6f}"}</td>
+            <td>{"-" if row.deltae_mean is None else f"{row.deltae_mean:.6f}"}</td>
+            <td>{"-" if row.deltae_p95 is None else f"{row.deltae_p95:.6f}"}</td></tr>\n"""
 
     # Inline logo SVG (from ui/theme/corridorkey_logo.svg)
     logo_svg = (
@@ -675,7 +690,7 @@ def generate_report(
         '<path d="M269.54 474L330 413.54V320L176 474H269.54Z" fill="#FFF203"/>'
         '<path d="M330 562.46L269.54 502H176L330 656V562.46Z" fill="#FFF203"/>'
         '<path d="M418.46 502L358 562.46V656L512 502H418.46Z" fill="#FFF203"/>'
-        '</svg>'
+        "</svg>"
     )
 
     html = f"""<!DOCTYPE html>
@@ -740,6 +755,7 @@ td {{ background:#1A1900; padding:4px 8px; border:1px solid #2A2910; text-align:
     # Try headless screenshot via Playwright if available
     try:
         from playwright.sync_api import sync_playwright
+
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page(viewport={"width": 1600, "height": 900})
@@ -813,7 +829,9 @@ def build_rows(
     rows.append(comp_row)
 
     subject_mask = compute_subject_mask(res_up["alpha"], res_ours["alpha"], subject_alpha)
-    subject_row = compute_metrics("Composite RGB (Subject)", res_up["comp"], res_ours["comp"], mask=subject_mask)
+    subject_row = compute_metrics(
+        "Composite RGB (Subject)", res_up["comp"], res_ours["comp"], mask=subject_mask
+    )
     attach_color_drift(subject_row, res_up["comp"], res_ours["comp"], subject_mask)
     _attach_subject_patch_metrics(subject_row, res_up["comp"], res_ours["comp"], subject_mask)
     subject_row.note = f"Mask = max(alpha_up, alpha_ours) > {subject_alpha:.2f}"
@@ -823,12 +841,15 @@ def build_rows(
     alpha_mask = compute_subject_mask(res_up["alpha"], res_ours["alpha"], skin_alpha)
     skin_mask = detect_skin_mask(res_up["comp"], res_ours["comp"], subject_mask, alpha_mask)
     if skin_mask is not None:
-        skin_row = compute_metrics("Composite RGB (Skin-Like)", res_up["comp"], res_ours["comp"], mask=skin_mask)
+        skin_row = compute_metrics(
+            "Composite RGB (Skin-Like)", res_up["comp"], res_ours["comp"], mask=skin_mask
+        )
         attach_color_drift(skin_row, res_up["comp"], res_ours["comp"], skin_mask)
-        skin_row.deltae_mean, skin_row.deltae_p95 = _compute_deltae(res_up["comp"], res_ours["comp"], skin_mask)
+        skin_row.deltae_mean, skin_row.deltae_p95 = _compute_deltae(
+            res_up["comp"], res_ours["comp"], skin_mask
+        )
         skin_row.note = (
-            "Mask = skin-like YCrCb thresholds on mean composite "
-            f"and alpha > {skin_alpha:.2f}"
+            f"Mask = skin-like YCrCb thresholds on mean composite and alpha > {skin_alpha:.2f}"
         )
         _apply_supplemental_verdict(skin_row)
         rows.append(skin_row)
@@ -920,7 +941,12 @@ def main() -> None:
     print("Completed.")
     print()
 
-    rows = build_rows(res_up=res_up, res_ours=res_ours, subject_alpha=args.subject_alpha, skin_alpha=args.skin_alpha)
+    rows = build_rows(
+        res_up=res_up,
+        res_ours=res_ours,
+        subject_alpha=args.subject_alpha,
+        skin_alpha=args.skin_alpha,
+    )
     print_metric_rows(rows)
 
     generate_report(

--- a/scripts/detect_windows_torch_index.py
+++ b/scripts/detect_windows_torch_index.py
@@ -4,6 +4,7 @@ This helper is intentionally stdlib-only so it can run before the project
 environment exists. It prefers real `nvidia-smi` output, but supports mocked
 output via environment variables for batch smoke tests.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -11,7 +12,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 CU130_URL = "https://download.pytorch.org/whl/cu130"
@@ -128,14 +128,22 @@ def parse_cuda_version(text: str) -> str | None:
 
 def choose_index_url(cuda_version: str | None) -> tuple[str, str, str]:
     if not cuda_version:
-        return CPU_URL, "CPU-only PyTorch", "Could not determine CUDA version from nvidia-smi; installing CPU-only PyTorch."
+        return (
+            CPU_URL,
+            "CPU-only PyTorch",
+            "Could not determine CUDA version from nvidia-smi; installing CPU-only PyTorch.",
+        )
 
     try:
         major_s, minor_s = cuda_version.split(".", 1)
         major = int(major_s)
         minor = int(re.match(r"\d+", minor_s).group(0)) if re.match(r"\d+", minor_s) else 0
     except Exception:
-        return CPU_URL, "CPU-only PyTorch", f"Could not parse CUDA version '{cuda_version}'; installing CPU-only PyTorch."
+        return (
+            CPU_URL,
+            "CPU-only PyTorch",
+            f"Could not parse CUDA version '{cuda_version}'; installing CPU-only PyTorch.",
+        )
 
     if major >= 13:
         return CU130_URL, "PyTorch CUDA 13.0 wheels", ""
@@ -190,7 +198,9 @@ def detect() -> dict[str, str]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Detect Windows PyTorch wheel index from nvidia-smi output")
+    parser = argparse.ArgumentParser(
+        description="Detect Windows PyTorch wheel index from nvidia-smi output"
+    )
     parser.add_argument("--format", choices=("env",), default="env")
     args = parser.parse_args()
 

--- a/scripts/gui_smoke_test.py
+++ b/scripts/gui_smoke_test.py
@@ -11,6 +11,7 @@ Systematically checks that:
 
 Run: python scripts/gui_smoke_test.py
 """
+
 import os
 import sys
 
@@ -21,7 +22,6 @@ sys.path.insert(0, ".")
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PySide6.QtWidgets import QApplication
-from PySide6.QtCore import QTimer
 
 app = QApplication.instance() or QApplication(sys.argv)
 
@@ -47,6 +47,7 @@ print("=" * 60)
 print("\n[1] MainWindow Construction...")
 try:
     from ui.main_window import MainWindow
+
     win = MainWindow()
     check("MainWindow instantiated", True)
 except Exception as e:
@@ -70,7 +71,10 @@ for attr, expected_type in EXPECTED_WIDGETS:
 
 # Check optional widgets that may be created lazily
 OPTIONAL_ATTRS = [
-    "_io_tray", "_param_panel", "_queue_panel", "_welcome",
+    "_io_tray",
+    "_param_panel",
+    "_queue_panel",
+    "_welcome",
     "_dual_viewer",
 ]
 for attr in OPTIONAL_ATTRS:
@@ -85,8 +89,13 @@ MIXIN_METHODS = {
     "ShortcutsMixin": ["_setup_shortcuts", "_toggle_mute", "_toggle_playback", "_on_escape"],
     "ClipMixin": ["_on_clip_selected", "_on_selection_changed", "_switch_to_workspace"],
     "ImportMixin": ["_on_import_folder", "_on_import_videos", "_add_videos_to_project"],
-    "InferenceMixin": ["_on_run_inference", "_cancel_inference", "_on_run_gvm",
-                        "_on_run_pipeline", "_start_worker_if_needed"],
+    "InferenceMixin": [
+        "_on_run_inference",
+        "_cancel_inference",
+        "_on_run_gvm",
+        "_on_run_pipeline",
+        "_start_worker_if_needed",
+    ],
     "WorkerMixin": ["_on_worker_progress", "_on_worker_clip_finished", "_on_worker_error"],
     "AnnotationMixin": ["_toggle_annotation_fg", "_on_track_masks", "_auto_save_annotations"],
     "ExportMixin": ["_auto_extract_clips", "_on_export_video", "_set_in_point", "_set_out_point"],
@@ -96,8 +105,9 @@ MIXIN_METHODS = {
 for mixin_name, methods in MIXIN_METHODS.items():
     for method in methods:
         fn = getattr(win, method, None)
-        check(f"{mixin_name}.{method} bound", callable(fn),
-              f"Method {method} not found on MainWindow")
+        check(
+            f"{mixin_name}.{method} bound", callable(fn), f"Method {method} not found on MainWindow"
+        )
 
 # --- 4. Menu Bar ---
 print("[4] Checking menu bar...")
@@ -112,11 +122,11 @@ if menubar:
 
 # --- 5. Keyboard Shortcuts ---
 print("[5] Checking keyboard shortcuts...")
-from ui.shortcut_registry import ShortcutRegistry
 registry = getattr(win, "_shortcut_registry", None)
 if registry is None:
     # Try finding shortcuts via QShortcut children
     from PySide6.QtWidgets import QShortcut
+
     shortcuts = win.findChildren(QShortcut)
     check("Shortcuts registered", len(shortcuts) > 0, f"Found {len(shortcuts)} shortcuts")
 else:
@@ -153,6 +163,7 @@ if service:
 # --- 8. View Modes ---
 print("[8] Checking view mode handlers...")
 from ui.preview.frame_index import ViewMode
+
 for mode in ViewMode:
     method_name = f"_view_mode_{mode.name.lower()}"
     # Some modes map differently
@@ -163,6 +174,7 @@ for mode in ViewMode:
 # --- 9. Helper Classes ---
 print("[9] Checking helper classes...")
 from ui.main_window import _Toast, _MuteOverlay, _UpdateChecker
+
 check("_Toast class exists", _Toast is not None)
 check("_MuteOverlay class exists", _MuteOverlay is not None)
 check("_UpdateChecker class exists", _UpdateChecker is not None)
@@ -170,6 +182,7 @@ check("_UpdateChecker class exists", _UpdateChecker is not None)
 # --- 10. Standalone Functions ---
 print("[10] Checking standalone functions...")
 from ui.main_window import _remove_alpha_hint_assets, _import_alpha_video_as_sequence
+
 check("_remove_alpha_hint_assets exists", callable(_remove_alpha_hint_assets))
 check("_import_alpha_video_as_sequence exists", callable(_import_alpha_video_as_sequence))
 

--- a/scripts/import_smoke_test.py
+++ b/scripts/import_smoke_test.py
@@ -1,4 +1,5 @@
 """Import smoke test — verify every module in backend/ and ui/ can be loaded."""
+
 import sys
 import importlib
 import os
@@ -7,9 +8,16 @@ os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, ".")
 
 SKIP_PREFIXES = (
-    "scripts", "tests", "CorridorKeyModule.core", "gvm_core",
-    "VideoMaMaInferenceModule", "modules", "docker", "clip_manager",
-    "sam2_tracker", "main",
+    "scripts",
+    "tests",
+    "CorridorKeyModule.core",
+    "gvm_core",
+    "VideoMaMaInferenceModule",
+    "modules",
+    "docker",
+    "clip_manager",
+    "sam2_tracker",
+    "main",
 )
 
 errors = []

--- a/scripts/local_gpu_qa.py
+++ b/scripts/local_gpu_qa.py
@@ -75,9 +75,9 @@ def _make_fixture_frame(
     xs = np.linspace(0.0, 1.0, width, dtype=np.float32)
     ys = np.linspace(0.0, 1.0, height, dtype=np.float32)
     xv, yv = np.meshgrid(xs, ys)
-    bg[..., 0] = np.clip(30 + 18 * xv, 0, 255).astype(np.uint8)   # B
+    bg[..., 0] = np.clip(30 + 18 * xv, 0, 255).astype(np.uint8)  # B
     bg[..., 1] = np.clip(135 + 55 * (1.0 - yv), 0, 255).astype(np.uint8)  # G
-    bg[..., 2] = np.clip(25 + 10 * xv, 0, 255).astype(np.uint8)   # R
+    bg[..., 2] = np.clip(25 + 10 * xv, 0, 255).astype(np.uint8)  # R
 
     # Humanoid motion path.
     t = index / max(total - 1, 1)
@@ -106,22 +106,28 @@ def _make_fixture_frame(
     _human_part(frame, mask, (58, 62, 78), line=((cx + 10, cy + 18), right_foot, 14))
 
     # Add a simple white shirt highlight so the figure has internal structure.
-    cv2.ellipse(frame, (cx, cy - 18), (12, 24), 0, 0, 360, (180, 190, 220), -1, lineType=cv2.LINE_AA)
+    cv2.ellipse(
+        frame, (cx, cy - 18), (12, 24), 0, 0, 360, (180, 190, 220), -1, lineType=cv2.LINE_AA
+    )
 
-    return frame, mask, {
-        "head": head,
-        "torso": torso,
-        "hips": (cx, cy + 18),
-        "left_shoulder": (cx - 26, cy - 34),
-        "right_shoulder": (cx + 26, cy - 34),
-        "left_hand": left_hand,
-        "right_hand": right_hand,
-        "left_foot": left_foot,
-        "right_foot": right_foot,
-        "left_bg": (max(18, cx - 86), cy - 12),
-        "right_bg": (min(width - 18, cx + 86), cy - 12),
-        "low_bg": (cx, min(height - 18, cy + 108)),
-    }
+    return (
+        frame,
+        mask,
+        {
+            "head": head,
+            "torso": torso,
+            "hips": (cx, cy + 18),
+            "left_shoulder": (cx - 26, cy - 34),
+            "right_shoulder": (cx + 26, cy - 34),
+            "left_hand": left_hand,
+            "right_hand": right_hand,
+            "left_foot": left_foot,
+            "right_foot": right_foot,
+            "left_bg": (max(18, cx - 86), cy - 12),
+            "right_bg": (min(width - 18, cx + 86), cy - 12),
+            "low_bg": (cx, min(height - 18, cy + 108)),
+        },
+    )
 
 
 def _write_fixture_clip(root: Path, *, frames: int, width: int, height: int) -> tuple[Path, Path]:
@@ -375,7 +381,9 @@ def run_local_gpu_qa(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Local GPU QA harness for SAM2 + VideoMaMa")
-    parser.add_argument("--frames", type=int, default=8, help="Number of synthetic frames to generate")
+    parser.add_argument(
+        "--frames", type=int, default=8, help="Number of synthetic frames to generate"
+    )
     parser.add_argument("--width", type=int, default=320, help="Fixture frame width")
     parser.add_argument("--height", type=int, default=256, help="Fixture frame height")
     parser.add_argument("--chunk-size", type=int, default=8, help="VideoMaMa chunk size")
@@ -385,9 +393,18 @@ def main() -> int:
         default="base-plus",
         help="SAM2 checkpoint to test. Default: base-plus.",
     )
-    parser.add_argument("--keep-dir", type=str, default="", help="Directory to keep outputs instead of using a temp dir")
-    parser.add_argument("--json-out", type=str, default="", help="Optional path to write the JSON summary")
-    parser.add_argument("--min-sam2-iou", type=float, default=0.75, help="Fail if SAM2 mean IoU drops below this")
+    parser.add_argument(
+        "--keep-dir",
+        type=str,
+        default="",
+        help="Directory to keep outputs instead of using a temp dir",
+    )
+    parser.add_argument(
+        "--json-out", type=str, default="", help="Optional path to write the JSON summary"
+    )
+    parser.add_argument(
+        "--min-sam2-iou", type=float, default=0.75, help="Fail if SAM2 mean IoU drops below this"
+    )
     parser.add_argument(
         "--min-videomama-iou",
         type=float,

--- a/scripts/macos/pyi_rth_cv2.py
+++ b/scripts/macos/pyi_rth_cv2.py
@@ -7,6 +7,7 @@
    ships a bootstrap __init__.py that calls importlib.import_module("cv2")
    which in a frozen build finds itself again → infinite recursion.
 """
+
 import importlib.util
 import os
 import sys
@@ -31,8 +32,7 @@ def _preload_cv2_native():
             else:
                 continue
         if os.path.isfile(so):
-            spec = importlib.util.spec_from_file_location("cv2", so,
-                                                           submodule_search_locations=[])
+            spec = importlib.util.spec_from_file_location("cv2", so, submodule_search_locations=[])
             if spec and spec.loader:
                 mod = importlib.util.module_from_spec(spec)
                 sys.modules["cv2"] = mod

--- a/scripts/macos/pyi_rth_mlx.py
+++ b/scripts/macos/pyi_rth_mlx.py
@@ -9,27 +9,29 @@ so we help MLX find the kernels by:
 2. Ensuring the mlx package directory is on sys.path so that
    ``import mlx.core`` can find the native extension and its resources.
 """
+
 import os
 import sys
 import glob
 
+
 def _fixup_mlx_paths():
     """Locate bundled .metallib files and set MLX_METAL_PATH."""
     # In a PyInstaller bundle, _MEIPASS is the temp extraction directory
-    bundle_dir = getattr(sys, '_MEIPASS', os.path.dirname(sys.executable))
+    bundle_dir = getattr(sys, "_MEIPASS", os.path.dirname(sys.executable))
 
     # Search common locations where PyInstaller places MLX files
     search_dirs = [
-        os.path.join(bundle_dir, 'mlx', 'lib'),
-        os.path.join(bundle_dir, 'mlx'),
-        os.path.join(bundle_dir, 'mlx_metal'),
+        os.path.join(bundle_dir, "mlx", "lib"),
+        os.path.join(bundle_dir, "mlx"),
+        os.path.join(bundle_dir, "mlx_metal"),
         bundle_dir,
     ]
 
     # Find .metallib files
     metallib_path = None
     for search_dir in search_dirs:
-        pattern = os.path.join(search_dir, '*.metallib')
+        pattern = os.path.join(search_dir, "*.metallib")
         matches = glob.glob(pattern)
         if matches:
             metallib_path = matches[0]
@@ -37,19 +39,19 @@ def _fixup_mlx_paths():
 
     # Also do a recursive search if not found in expected locations
     if metallib_path is None:
-        for match in glob.glob(os.path.join(bundle_dir, '**', '*.metallib'), recursive=True):
+        for match in glob.glob(os.path.join(bundle_dir, "**", "*.metallib"), recursive=True):
             metallib_path = match
             break
 
     if metallib_path:
         metallib_dir = os.path.dirname(metallib_path)
         # MLX checks MLX_METAL_PATH for the directory containing metallib files
-        os.environ['MLX_METAL_PATH'] = metallib_dir
+        os.environ["MLX_METAL_PATH"] = metallib_dir
         # Also set the individual file path variant some versions use
-        os.environ['MLX_METALLIB_PATH'] = metallib_path
+        os.environ["MLX_METALLIB_PATH"] = metallib_path
 
     # Ensure mlx package directory is findable
-    mlx_dir = os.path.join(bundle_dir, 'mlx')
+    mlx_dir = os.path.join(bundle_dir, "mlx")
     if os.path.isdir(mlx_dir) and bundle_dir not in sys.path:
         sys.path.insert(0, bundle_dir)
 
@@ -65,6 +67,7 @@ def _prewarm_mlx():
     """
     try:
         import mlx.core as mx
+
         # Force Metal device initialization by running a trivial op
         mx.eval(mx.zeros(1))
     except Exception:

--- a/scripts/open_installer_issue.py
+++ b/scripts/open_installer_issue.py
@@ -4,11 +4,11 @@ This mirrors the in-app "Report Issue" experience closely enough for installer
 errors, but keeps the implementation stdlib-only so it can run before the full
 project environment is healthy.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import platform
 import subprocess
 import sys
@@ -38,7 +38,11 @@ def _copy_to_clipboard(text: str) -> bool:
         except Exception:
             return False
 
-    for cmd in (["wl-copy"], ["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]):
+    for cmd in (
+        ["wl-copy"],
+        ["xclip", "-selection", "clipboard"],
+        ["xsel", "--clipboard", "--input"],
+    ):
         try:
             subprocess.run(cmd, input=text, text=True, check=True)
             return True
@@ -102,10 +106,16 @@ def _build_url(title: str, body: str) -> str:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Open a pre-filled GitHub issue for an installer failure")
+    parser = argparse.ArgumentParser(
+        description="Open a pre-filled GitHub issue for an installer failure"
+    )
     parser.add_argument("--json", required=True, help="Path to installer diagnostic JSON")
-    parser.add_argument("--stage", default="installer-runtime-verification", help="Short failure stage label")
-    parser.add_argument("--title", default="Installer failed to validate GPU/PyTorch runtime", help="Issue title")
+    parser.add_argument(
+        "--stage", default="installer-runtime-verification", help="Short failure stage label"
+    )
+    parser.add_argument(
+        "--title", default="Installer failed to validate GPU/PyTorch runtime", help="Issue title"
+    )
     parser.add_argument(
         "--body-out",
         default="logs/diagnostics/install-support-report.md",

--- a/scripts/sam2_smoke.py
+++ b/scripts/sam2_smoke.py
@@ -47,7 +47,8 @@ def _resolve_frames_dir(clip_root: Path) -> Path:
 
 def _input_files(frames_dir: Path) -> list[str]:
     files = sorted(
-        name for name in os.listdir(frames_dir)
+        name
+        for name in os.listdir(frames_dir)
         if name.lower().endswith((".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff"))
     )
     if not files:
@@ -212,9 +213,15 @@ def run_smoke(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Quick SAM2 smoke test on the first N frames of a clip")
-    parser.add_argument("clip_root", help="Path to the clip root containing Frames/ and annotations.json")
-    parser.add_argument("--frames", type=int, default=5, help="Number of initial frames to test (default: 5)")
+    parser = argparse.ArgumentParser(
+        description="Quick SAM2 smoke test on the first N frames of a clip"
+    )
+    parser.add_argument(
+        "clip_root", help="Path to the clip root containing Frames/ and annotations.json"
+    )
+    parser.add_argument(
+        "--frames", type=int, default=5, help="Number of initial frames to test (default: 5)"
+    )
     parser.add_argument(
         "--sam2-model",
         choices=sorted(SAM2_MODEL_IDS.keys()),

--- a/scripts/setup_models.py
+++ b/scripts/setup_models.py
@@ -41,12 +41,14 @@ def _data_root() -> Path:
         return _SCRIPT_ROOT
     try:
         from backend.project import get_data_dir
+
         return Path(get_data_dir())
     except ImportError:
         pass
     # Standalone fallback (script run outside frozen app)
     try:
         from PySide6.QtCore import QSettings
+
         saved = QSettings().value("app/install_path", "", type=str)
         if saved and os.path.isdir(saved):
             return Path(saved)
@@ -231,7 +233,7 @@ def download_corridorkey_mlx() -> bool:
     dest = local_dir / cfg["filename"]
 
     if dest.is_file():
-        print(f"  [OK] MLX checkpoint already installed")
+        print("  [OK] MLX checkpoint already installed")
         return True
 
     if not check_disk_space(cfg["size_bytes"], local_dir):
@@ -244,6 +246,7 @@ def download_corridorkey_mlx() -> bool:
     print(f"  Downloading MLX checkpoint ({cfg['size_human']})...")
     tmp_dest = dest.with_suffix(".safetensors.tmp")
     try:
+
         def _progress(block_num, block_size, total_size):
             downloaded = block_num * block_size
             if total_size > 0:
@@ -261,12 +264,12 @@ def download_corridorkey_mlx() -> bool:
             expected_hash = sha256_resp.read().decode().strip().split()[0]
             actual_hash = hashlib.sha256(tmp_dest.read_bytes()).hexdigest()
             if actual_hash != expected_hash:
-                print(f"  [ERROR] SHA256 mismatch!")
+                print("  [ERROR] SHA256 mismatch!")
                 print(f"  Expected: {expected_hash}")
                 print(f"  Got:      {actual_hash}")
                 tmp_dest.unlink(missing_ok=True)
                 return False
-            print(f"  [OK] SHA256 verified")
+            print("  [OK] SHA256 verified")
         except Exception as e:
             print(f"  [WARN] Could not verify SHA256: {e}")
             print("  Proceeding anyway (file downloaded successfully)")
@@ -318,7 +321,7 @@ def download_repo(name: str) -> bool:
         base_dir = local_dir / base["subfolder"]
         base_check = base.get("check_file")
         if base_check and (local_dir / base_check).is_file():
-            print(f"  [OK] Base model already downloaded")
+            print("  [OK] Base model already downloaded")
         else:
             print(f"  Downloading base model ({base['repo_id']})...")
             print("  This may take a while. Downloads resume if interrupted.")
@@ -346,7 +349,7 @@ def download_repo(name: str) -> bool:
             videomama_dir = local_dir / "VideoMaMa"
             if unet_dir.is_dir() and not videomama_dir.is_dir():
                 unet_dir.rename(videomama_dir)
-                print(f"  Renamed unet/ -> VideoMaMa/")
+                print("  Renamed unet/ -> VideoMaMa/")
         print(f"  Saved to: {local_dir}")
         return True
     except Exception as e:
@@ -408,7 +411,7 @@ def download_matanyone2() -> bool:
     dest = local_dir / cfg["filename"]
 
     if dest.is_file():
-        print(f"  [OK] MatAnyone2 checkpoint already installed")
+        print("  [OK] MatAnyone2 checkpoint already installed")
         return True
 
     if not check_disk_space(cfg["size_bytes"], local_dir):
@@ -421,6 +424,7 @@ def download_matanyone2() -> bool:
     print(f"  Downloading MatAnyone2 checkpoint ({cfg['size_human']})...")
     tmp_dest = dest.with_suffix(".pth.tmp")
     try:
+
         def _progress(block_num, block_size, total_size):
             downloaded = block_num * block_size
             if total_size > 0:
@@ -464,14 +468,22 @@ def check_all():
     ma2_installed = is_matanyone2_installed()
     ma2_mark = "[OK]" if ma2_installed else "[--]"
     ma2_status = "INSTALLED" if ma2_installed else "NOT INSTALLED"
-    print(f"  {ma2_mark} matanyone2   {MATANYONE2_CHECKPOINT['size_human']:>8s}  {ma2_status} (optional)")
+    print(
+        f"  {ma2_mark} matanyone2   {MATANYONE2_CHECKPOINT['size_human']:>8s}  {ma2_status} (optional)"
+    )
 
     # MLX checkpoint (Apple Silicon only, but show status on all platforms)
     mlx_installed = is_mlx_installed()
     mlx_mark = "[OK]" if mlx_installed else "[--]"
     mlx_status = "INSTALLED" if mlx_installed else "NOT INSTALLED"
-    mlx_note = " (Apple Silicon)" if sys.platform == "darwin" and platform.machine() == "arm64" else " (Apple Silicon only)"
-    print(f"  {mlx_mark} corridorkey-mlx {MLX_CHECKPOINT['size_human']:>8s}  {mlx_status}{mlx_note}")
+    mlx_note = (
+        " (Apple Silicon)"
+        if sys.platform == "darwin" and platform.machine() == "arm64"
+        else " (Apple Silicon only)"
+    )
+    print(
+        f"  {mlx_mark} corridorkey-mlx {MLX_CHECKPOINT['size_human']:>8s}  {mlx_status}{mlx_note}"
+    )
 
     tracker_installed = tracker_dependency_installed()
     tracker_mark = "[OK]" if tracker_installed else "[--]"
@@ -491,8 +503,16 @@ def check_all():
 
 def main():
     parser = argparse.ArgumentParser(description="Download model weights for EZ-CorridorKey")
-    parser.add_argument("--corridorkey", action="store_true", help="Download CorridorKey checkpoint (383MB, required)")
-    parser.add_argument("--corridorkey-mlx", action="store_true", help="Download MLX checkpoint for Apple Silicon (380MB)")
+    parser.add_argument(
+        "--corridorkey",
+        action="store_true",
+        help="Download CorridorKey checkpoint (383MB, required)",
+    )
+    parser.add_argument(
+        "--corridorkey-mlx",
+        action="store_true",
+        help="Download MLX checkpoint for Apple Silicon (380MB)",
+    )
     parser.add_argument(
         "--sam2",
         nargs="?",
@@ -501,21 +521,46 @@ def main():
         help="Download SAM2 checkpoint(s): small, base-plus, large, or all (default: base-plus)",
     )
     parser.add_argument("--gvm", action="store_true", help="Download GVM weights (~6GB, optional)")
-    parser.add_argument("--videomama", action="store_true", help="Download VideoMaMa weights (~37GB, optional)")
-    parser.add_argument("--matanyone2", action="store_true", help="Download MatAnyone2 weights (~141MB, optional)")
+    parser.add_argument(
+        "--videomama", action="store_true", help="Download VideoMaMa weights (~37GB, optional)"
+    )
+    parser.add_argument(
+        "--matanyone2", action="store_true", help="Download MatAnyone2 weights (~141MB, optional)"
+    )
     parser.add_argument("--all", action="store_true", help="Download all models")
     parser.add_argument("--check", action="store_true", help="Check installation status")
     args = parser.parse_args()
 
-    mlx_flag = getattr(args, 'corridorkey_mlx', False)
+    mlx_flag = getattr(args, "corridorkey_mlx", False)
 
     # Default to --check if no flags
-    if not any([args.corridorkey, mlx_flag, args.sam2, args.gvm, args.videomama, args.matanyone2, args.all, args.check]):
+    if not any(
+        [
+            args.corridorkey,
+            mlx_flag,
+            args.sam2,
+            args.gvm,
+            args.videomama,
+            args.matanyone2,
+            args.all,
+            args.check,
+        ]
+    ):
         args.check = True
 
     if args.check:
         check_all()
-        if not any([args.corridorkey, mlx_flag, args.sam2, args.gvm, args.videomama, args.matanyone2, args.all]):
+        if not any(
+            [
+                args.corridorkey,
+                mlx_flag,
+                args.sam2,
+                args.gvm,
+                args.videomama,
+                args.matanyone2,
+                args.all,
+            ]
+        ):
             return
 
     targets = []
@@ -549,7 +594,9 @@ def main():
     if not targets and not sam2_targets and not download_mlx and not download_ma2:
         return
 
-    total_targets = len(targets) + len(sam2_targets) + (1 if download_mlx else 0) + (1 if download_ma2 else 0)
+    total_targets = (
+        len(targets) + len(sam2_targets) + (1 if download_mlx else 0) + (1 if download_ma2 else 0)
+    )
     print(f"\nDownloading {total_targets} model(s)...\n")
     results = {}
     for name in targets:

--- a/scripts/verify_torch_runtime.py
+++ b/scripts/verify_torch_runtime.py
@@ -4,6 +4,7 @@ This runs inside the freshly created virtual environment at install time so the
 installer can fail fast with actionable diagnostics instead of reporting a
 "successful" install that only works on CPU.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -139,7 +140,10 @@ def evaluate_runtime(info: RuntimeInfo, expect_gpu: str = "auto") -> tuple[bool,
                 "Torch reports a CUDA build, but torch.cuda.is_available() is false. "
                 "Check that the NVIDIA driver is working and that the installed torch build matches the system.",
             )
-        return True, f"CUDA verified: torch {info.torch_version} with CUDA {info.torch_cuda_version}."
+        return (
+            True,
+            f"CUDA verified: torch {info.torch_version} with CUDA {info.torch_cuda_version}.",
+        )
 
     if info.platform.lower().startswith("macos") or sys.platform == "darwin":
         if info.mps_available:
@@ -158,7 +162,9 @@ def write_log(path: str | None, payload: dict[str, object]) -> None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Verify the installed torch runtime for CorridorKey")
+    parser = argparse.ArgumentParser(
+        description="Verify the installed torch runtime for CorridorKey"
+    )
     parser.add_argument("--log", default="", help="Optional JSON log path")
     parser.add_argument(
         "--expect-gpu",

--- a/scripts/windows/pyi_rth_cv2.py
+++ b/scripts/windows/pyi_rth_cv2.py
@@ -7,6 +7,7 @@
    ships a bootstrap __init__.py that calls importlib.import_module("cv2")
    which in a frozen build finds itself again → infinite recursion.
 """
+
 import importlib.util
 import os
 import sys
@@ -27,9 +28,7 @@ def _preload_cv2_native():
                 break
         else:
             continue
-        spec = importlib.util.spec_from_file_location(
-            "cv2", pyd, submodule_search_locations=[]
-        )
+        spec = importlib.util.spec_from_file_location("cv2", pyd, submodule_search_locations=[])
         if spec and spec.loader:
             mod = importlib.util.module_from_spec(spec)
             sys.modules["cv2"] = mod

--- a/scripts/windows/pyi_rth_triton.py
+++ b/scripts/windows/pyi_rth_triton.py
@@ -13,13 +13,14 @@ Result: Triton compiles everything on first launch using the bundled TCC
 compiler, then caches in ~/.triton/cache/ for instant subsequent starts.
 Works on any NVIDIA GPU — no CUDA Toolkit required on the end-user machine.
 """
+
 import logging
 import os
 import sys
 
-_log = logging.getLogger('pyi_rth_triton')
+_log = logging.getLogger("pyi_rth_triton")
 
-if getattr(sys, 'frozen', False):
+if getattr(sys, "frozen", False):
     _meipass = sys._MEIPASS
     _log.info("Triton frozen-build hook: _MEIPASS = %s", _meipass)
 
@@ -27,9 +28,9 @@ if getattr(sys, 'frozen', False):
     # triton.runtime.build.get_cc() checks CC env var first.
     # TCC is bundled with triton-windows at triton/runtime/tcc/tcc.exe
     # and ships with cuda.def + python311.def for linking.
-    _tcc = os.path.join(_meipass, 'triton', 'runtime', 'tcc', 'tcc.exe')
+    _tcc = os.path.join(_meipass, "triton", "runtime", "tcc", "tcc.exe")
     if os.path.exists(_tcc):
-        os.environ.setdefault('CC', _tcc)
+        os.environ.setdefault("CC", _tcc)
         _log.info("CC -> %s", _tcc)
     else:
         _log.warning("TCC not found at %s", _tcc)
@@ -38,12 +39,12 @@ if getattr(sys, 'frozen', False):
     # triton.windows_utils.find_cuda() checks CUDA_PATH env var first.
     # check_and_find_cuda() expects: bin/ptxas.exe, include/cuda.h,
     # lib/x64/cuda.lib — all present in the bundled nvidia backend.
-    _cuda = os.path.join(_meipass, 'triton', 'backends', 'nvidia')
+    _cuda = os.path.join(_meipass, "triton", "backends", "nvidia")
     if os.path.isdir(_cuda):
-        os.environ.setdefault('CUDA_PATH', _cuda)
+        os.environ.setdefault("CUDA_PATH", _cuda)
         _log.info("CUDA_PATH -> %s", _cuda)
         # Verify expected files exist
-        for _check in ['bin/ptxas.exe', 'include/cuda.h', 'lib/x64/cuda.lib']:
+        for _check in ["bin/ptxas.exe", "include/cuda.h", "lib/x64/cuda.lib"]:
             _p = os.path.join(_cuda, _check)
             _log.info("  %s: %s", _check, "OK" if os.path.exists(_p) else "MISSING")
     else:
@@ -53,16 +54,16 @@ if getattr(sys, 'frozen', False):
     # _MEIPASS is read-only (installer) or cluttered (portable).
     # Compiled modules go to the user's home — persists across updates,
     # shared between installer and portable builds on the same machine.
-    _cache = os.path.join(os.path.expanduser('~'), '.triton', 'cache')
+    _cache = os.path.join(os.path.expanduser("~"), ".triton", "cache")
     os.makedirs(_cache, exist_ok=True)
-    os.environ.setdefault('TRITON_CACHE_DIR', _cache)
+    os.environ.setdefault("TRITON_CACHE_DIR", _cache)
     _log.info("TRITON_CACHE_DIR -> %s", _cache)
 
     # ── 4. Python include headers (Python.h) ───────────────────────────
     # triton.runtime.build._build() uses sysconfig.get_paths()["include"]
     # to find Python.h.  No env-var override exists, so we patch sysconfig.
     # Only the "include" key is changed; all other paths are untouched.
-    _py_inc = os.path.join(_meipass, 'python_include')
+    _py_inc = os.path.join(_meipass, "python_include")
     if os.path.isdir(_py_inc):
         import sysconfig as _sysconfig
 
@@ -70,7 +71,7 @@ if getattr(sys, 'frozen', False):
 
         def _frozen_get_paths(scheme=None, vars=None, expand=True):
             paths = _orig_get_paths(scheme, vars, expand)
-            paths['include'] = _py_inc
+            paths["include"] = _py_inc
             return paths
 
         _sysconfig.get_paths = _frozen_get_paths
@@ -87,16 +88,18 @@ if getattr(sys, 'frozen', False):
             from importlib.metadata import entry_points as _ep
         else:
             from importlib_metadata import entry_points as _ep
-        _triton_eps = _ep().select(group='triton.backends')
+        _triton_eps = _ep().select(group="triton.backends")
         _names = [e.name for e in _triton_eps]
-        if 'nvidia' not in _names:
-            _log.warning("triton.backends entry points missing nvidia (found: %s), patching", _names)
+        if "nvidia" not in _names:
+            _log.warning(
+                "triton.backends entry points missing nvidia (found: %s), patching", _names
+            )
             # Monkey-patch _discover_backends after triton is imported
-            os.environ['_TRITON_PATCH_BACKENDS'] = '1'
+            os.environ["_TRITON_PATCH_BACKENDS"] = "1"
         else:
             _log.info("triton.backends entry points OK: %s", _names)
     except Exception as _e:
         _log.warning("Entry points check failed: %s, will patch backends", _e)
-        os.environ['_TRITON_PATCH_BACKENDS'] = '1'
+        os.environ["_TRITON_PATCH_BACKENDS"] = "1"
 
     _log.info("Triton frozen-build hook complete")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared fixtures for ez-CorridorKey backend tests."""
+
 import os
 import tempfile
 
@@ -129,12 +130,16 @@ def tmp_project_dir(sample_frame, sample_mask):
 
         # project.json
         import json
+
         with open(os.path.join(project_root, "project.json"), "w") as f:
-            json.dump({
-                "version": 1,
-                "display_name": "Test Project",
-                "source": {"filename": "test_video.mp4"},
-            }, f)
+            json.dump(
+                {
+                    "version": 1,
+                    "display_name": "Test Project",
+                    "source": {"filename": "test_video.mp4"},
+                },
+                f,
+            )
 
         yield project_root
 
@@ -179,16 +184,23 @@ def tmp_v2_project_dir(sample_frame, sample_mask):
             cv2.imwrite(os.path.join(alpha_dir, f"_alphaHint_{i:06d}.png"), mask_u8)
 
         import json
+
         with open(os.path.join(project_root, "project.json"), "w") as f:
-            json.dump({
-                "version": 2,
-                "display_name": "Test Project",
-                "clips": ["test_clip"],
-            }, f)
+            json.dump(
+                {
+                    "version": 2,
+                    "display_name": "Test Project",
+                    "clips": ["test_clip"],
+                },
+                f,
+            )
 
         with open(os.path.join(clip_dir, "clip.json"), "w") as f:
-            json.dump({
-                "source": {"filename": "test_video.mp4", "copied": True},
-            }, f)
+            json.dump(
+                {
+                    "source": {"filename": "test_video.mp4", "copied": True},
+                },
+                f,
+            )
 
         yield project_root

--- a/tests/test_backend_output_contract.py
+++ b/tests/test_backend_output_contract.py
@@ -36,7 +36,9 @@ def test_wrap_mlx_output_returns_straight_linear_processed_rgba():
     expected_alpha = raw["alpha"].astype(np.float32)[:, :, np.newaxis] / 255.0
 
     # Output is premultiplied RGBA, so RGB values are scaled by alpha
-    np.testing.assert_allclose(wrapped["processed"][:, :, :3], expected_rgb * expected_alpha, atol=1e-6)
+    np.testing.assert_allclose(
+        wrapped["processed"][:, :, :3], expected_rgb * expected_alpha, atol=1e-6
+    )
     np.testing.assert_allclose(wrapped["processed"][:, :, 3:], expected_alpha, atol=1e-6)
 
 
@@ -60,7 +62,9 @@ def test_wrap_mlx_output_matches_source_luminance_within_clamp():
     src_luma = float(np.sum(source * weights, axis=-1).mean())
     out_luma = float(np.sum(wrapped["processed"][:, :, :3] * weights, axis=-1).mean())
 
-    assert out_luma > float(np.sum(cu.srgb_to_linear(raw["fg"].astype(np.float32) / 255.0) * weights, axis=-1).mean())
+    assert out_luma > float(
+        np.sum(cu.srgb_to_linear(raw["fg"].astype(np.float32) / 255.0) * weights, axis=-1).mean()
+    )
     assert out_luma <= src_luma * 1.15
 
 
@@ -196,10 +200,13 @@ def test_try_mlx_float_outputs_handles_resize_path(monkeypatch):
     assert result["alpha"].shape == (2, 2, 1)
     assert result["fg"].shape == (2, 2, 3)
 
-    expected_rgb = np.asarray(
-        Image.fromarray(image_u8, mode="RGB").resize((1, 1), Image.Resampling.BICUBIC),
-        dtype=np.float32,
-    ) / 255.0
+    expected_rgb = (
+        np.asarray(
+            Image.fromarray(image_u8, mode="RGB").resize((1, 1), Image.Resampling.BICUBIC),
+            dtype=np.float32,
+        )
+        / 255.0
+    )
     expected_mask = (
         np.asarray(
             Image.fromarray(mask_u8, mode="L").resize((1, 1), Image.Resampling.BICUBIC),
@@ -250,7 +257,9 @@ def test_restore_opaque_source_detail_prefers_source_on_low_spill_edge_pixels():
     )
 
     np.testing.assert_allclose(restored[2, 1], source_lin[2, 1], atol=1e-6)
-    assert np.linalg.norm(restored[2, 3] - source_lin[2, 3]) < np.linalg.norm(restored[2, 3] - image_lin[2, 3])
+    assert np.linalg.norm(restored[2, 3] - source_lin[2, 3]) < np.linalg.norm(
+        restored[2, 3] - image_lin[2, 3]
+    )
 
 
 def test_restore_opaque_source_detail_keeps_model_control_on_green_spill_edge_pixels():
@@ -265,4 +274,6 @@ def test_restore_opaque_source_detail_keeps_model_control_on_green_spill_edge_pi
         source_lin, source_srgb, image_lin, alpha, edge_band_radius=1, edge_band_softness=1
     )
 
-    assert np.linalg.norm(restored[2, 3] - image_lin[2, 3]) < np.linalg.norm(restored[2, 3] - source_lin[2, 3])
+    assert np.linalg.norm(restored[2, 3] - image_lin[2, 3]) < np.linalg.norm(
+        restored[2, 3] - source_lin[2, 3]
+    )

--- a/tests/test_clip_state.py
+++ b/tests/test_clip_state.py
@@ -1,4 +1,5 @@
 """Tests for backend.clip_state module — state machine transitions."""
+
 import json
 import os
 import tempfile
@@ -18,6 +19,7 @@ from backend.errors import InvalidStateTransitionError, ClipScanError
 
 
 # --- ClipState transitions ---
+
 
 class TestClipStateTransitions:
     def _make_clip(self, state: ClipState = ClipState.RAW) -> ClipEntry:
@@ -149,6 +151,7 @@ class TestPipelineRouteClassification:
 
 # --- ClipEntry asset scanning ---
 
+
 class TestClipEntryFindAssets:
     def test_finds_input_sequence(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -164,7 +167,7 @@ class TestClipEntryFindAssets:
             clip.find_assets()
 
             assert clip.input_asset is not None
-            assert clip.input_asset.asset_type == 'sequence'
+            assert clip.input_asset.asset_type == "sequence"
             assert clip.input_asset.frame_count == 5
             assert clip.state == ClipState.RAW
 
@@ -284,9 +287,13 @@ class TestClipEntryFindAssets:
             shot_dir = os.path.join(tmpdir, "shot1")
             frames_dir = os.path.join(shot_dir, "Frames")
             os.makedirs(frames_dir)
-            with open(os.path.join(frames_dir, "frame_000000.exr"), "w", encoding="utf-8") as handle:
+            with open(
+                os.path.join(frames_dir, "frame_000000.exr"), "w", encoding="utf-8"
+            ) as handle:
                 handle.write("dummy")
-            with open(os.path.join(shot_dir, ".video_metadata.json"), "w", encoding="utf-8") as handle:
+            with open(
+                os.path.join(shot_dir, ".video_metadata.json"), "w", encoding="utf-8"
+            ) as handle:
                 handle.write("{}")
 
             clip = ClipEntry(name="shot1", root_path=shot_dir)
@@ -302,7 +309,9 @@ class TestClipEntryFindAssets:
             shot_dir = os.path.join(tmpdir, "shot1")
             frames_dir = os.path.join(shot_dir, "Frames")
             os.makedirs(frames_dir)
-            with open(os.path.join(frames_dir, "frame_000000.exr"), "w", encoding="utf-8") as handle:
+            with open(
+                os.path.join(frames_dir, "frame_000000.exr"), "w", encoding="utf-8"
+            ) as handle:
                 handle.write("dummy")
 
             clip = ClipEntry(name="shot1", root_path=shot_dir)
@@ -318,9 +327,13 @@ class TestClipEntryFindAssets:
             shot_dir = os.path.join(tmpdir, "shot1")
             frames_dir = os.path.join(shot_dir, "Frames")
             os.makedirs(frames_dir)
-            with open(os.path.join(frames_dir, "frame_000000.exr"), "w", encoding="utf-8") as handle:
+            with open(
+                os.path.join(frames_dir, "frame_000000.exr"), "w", encoding="utf-8"
+            ) as handle:
                 handle.write("dummy")
-            with open(os.path.join(shot_dir, ".video_metadata.json"), "w", encoding="utf-8") as handle:
+            with open(
+                os.path.join(shot_dir, ".video_metadata.json"), "w", encoding="utf-8"
+            ) as handle:
                 json.dump({"source_probe": {"color_transfer": "linear"}}, handle)
 
             clip = ClipEntry(name="shot1", root_path=shot_dir)
@@ -372,6 +385,7 @@ class TestClipEntryFindAssets:
 
             # Write project.json with display_name
             import json
+
             with open(os.path.join(shot_dir, "project.json"), "w") as f:
                 json.dump({"display_name": "My Custom Name"}, f)
 
@@ -382,6 +396,7 @@ class TestClipEntryFindAssets:
 
 
 # --- scan_clips_dir ---
+
 
 class TestScanClipsDir:
     def test_scans_multiple_clips(self):
@@ -509,6 +524,7 @@ class TestScanClipsDir:
 
 # --- scan_project_clips ---
 
+
 class TestScanProjectClips:
     def test_scans_v2_project(self):
         """scan_project_clips finds clips inside clips/ subdir."""
@@ -585,9 +601,12 @@ class TestScanProjectClips:
                 f.write("dummy")
 
             with open(os.path.join(clip_dir, "clip.json"), "w") as f:
-                json.dump({
-                    "in_out_range": {"in_point": 5, "out_point": 20},
-                }, f)
+                json.dump(
+                    {
+                        "in_out_range": {"in_point": 5, "out_point": 20},
+                    },
+                    f,
+                )
 
             clips = scan_project_clips(tmpdir)
             assert len(clips) == 1

--- a/tests/test_dialog_sizes.py
+++ b/tests/test_dialog_sizes.py
@@ -2,8 +2,14 @@
 
 import sys
 from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QPushButton, QVBoxLayout, QWidget, QMessageBox,
-    QDialogButtonBox, QScrollArea,
+    QApplication,
+    QMainWindow,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    QMessageBox,
+    QDialogButtonBox,
+    QScrollArea,
 )
 from PySide6.QtCore import QObject, QEvent
 
@@ -23,6 +29,7 @@ class _MessageBoxFilter(QObject):
 
 def load_theme(app):
     import pathlib
+
     theme_dir = str(pathlib.Path(THEME_PATH).parent.resolve()).replace("\\", "/")
     raw = pathlib.Path(THEME_PATH).read_text(encoding="utf-8")
     app.setStyleSheet(raw.replace("{{THEME_DIR}}", theme_dir))
@@ -34,16 +41,24 @@ DIALOGS = [
     # main_window.py:496 — cancel extraction/GVM
     ("question", "Cancel", "Cancel extraction?", QMessageBox.Yes | QMessageBox.No),
     # main_window.py:630
-    ("critical", "Force Stop Failed", "Could not restart inference engine:\nPermission denied", None),
+    (
+        "critical",
+        "Force Stop Failed",
+        "Could not restart inference engine:\nPermission denied",
+        None,
+    ),
     # main_window.py:687
     ("information", "No Annotations", "Paint green (1) and red (2) strokes on frames first.", None),
     # main_window.py:728
-    ("question", "Replace Existing Alpha?",
-     "This clip already has an AlphaHint (from GVM or a previous run).\n\n"
-     "To use your annotations with VideoMaMa, the existing AlphaHint must\n"
-     "be removed so it can be regenerated.\n\n"
-     "Remove existing AlphaHint and proceed?",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Replace Existing Alpha?",
+        "This clip already has an AlphaHint (from GVM or a previous run).\n\n"
+        "To use your annotations with VideoMaMa, the existing AlphaHint must\n"
+        "be removed so it can be regenerated.\n\n"
+        "Remove existing AlphaHint and proceed?",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # main_window.py:773
     ("information", "Masks Exported", "Exported 120 mask frames to AlphaHint/", None),
     # main_window.py:790 — custom 3-button
@@ -55,32 +70,60 @@ DIALOGS = [
     # main_window.py:1289
     ("information", "No Media", "No video files or image sequences found in that folder.", None),
     # main_window.py:1340
-    ("information", "Already Imported", 'All selected videos are already in the project ("clip1", "clip2").', None),
+    (
+        "information",
+        "Already Imported",
+        'All selected videos are already in the project ("clip1", "clip2").',
+        None,
+    ),
     # main_window.py:1374
-    ("information", "No Images",
-     "No image files found in that folder.\n\n"
-     "Supported formats: PNG, JPG, TIFF, EXR, BMP", None),
+    (
+        "information",
+        "No Images",
+        "No image files found in that folder.\n\nSupported formats: PNG, JPG, TIFF, EXR, BMP",
+        None,
+    ),
     # main_window.py:1385
-    ("information", "Already Imported", 'This sequence is already in the project as "Woman_Jumps".', None),
+    (
+        "information",
+        "Already Imported",
+        'This sequence is already in the project as "Woman_Jumps".',
+        None,
+    ),
     # main_window.py:1405
-    ("warning", "Duplicate Filenames",
-     "Found files with the same name but different extensions:\n"
-     "frame_001.png, frame_001.jpg\n\n"
-     "Only the first match per stem will be used.", None),
+    (
+        "warning",
+        "Duplicate Filenames",
+        "Found files with the same name but different extensions:\n"
+        "frame_001.png, frame_001.jpg\n\n"
+        "Only the first match per stem will be used.",
+        None,
+    ),
     # main_window.py:1464 — custom 3-button
-    ("custom_import", "Import Image Frames",
-     "You selected 24 images from a folder containing 120.\n\n"
-     "Import just the selected files, or the full sequence?", None),
+    (
+        "custom_import",
+        "Import Image Frames",
+        "You selected 24 images from a folder containing 120.\n\n"
+        "Import just the selected files, or the full sequence?",
+        None,
+    ),
     # main_window.py:1562
     ("information", "No Media", "No video files or image sequences found in that folder.", None),
     # main_window.py:1741
-    ("warning", "Not Ready",
-     "Clip 'Woman_Jumps' is in EXTRACTING state.\n"
-     "Wait for extraction to finish, or use a READY clip.", None),
+    (
+        "warning",
+        "Not Ready",
+        "Clip 'Woman_Jumps' is in EXTRACTING state.\n"
+        "Wait for extraction to finish, or use a READY clip.",
+        None,
+    ),
     # main_window.py:1753 — custom 3-button
-    ("custom_incomplete", "Incomplete Alpha",
-     "Only 24 of 120 alpha hint frames found.\n\n"
-     "Process with available frames, or re-run GVM?", None),
+    (
+        "custom_incomplete",
+        "Incomplete Alpha",
+        "Only 24 of 120 alpha hint frames found.\n\nProcess with available frames, or re-run GVM?",
+        None,
+    ),
     # main_window.py:1799
     ("information", "Duplicate", "'Woman_Jumps_For_Joy' is already queued.", None),
     # main_window.py:1826
@@ -90,40 +133,62 @@ DIALOGS = [
     # main_window.py:1901
     ("information", "Nothing to Process", "No selected clips are in a processable state.", None),
     # main_window.py:2011
-    ("question", "Replace Alpha Hints?",
-     "Clip 'Woman_Jumps' already has alpha hint images.\n\n"
-     "Replace them with new ones?",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Replace Alpha Hints?",
+        "Clip 'Woman_Jumps' already has alpha hint images.\n\nReplace them with new ones?",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # main_window.py:2045
-    ("warning", "No Images",
-     "No image files found in the selected folder.\n"
-     "Supported: PNG, JPG, TIFF, EXR, BMP", None),
+    (
+        "warning",
+        "No Images",
+        "No image files found in the selected folder.\nSupported: PNG, JPG, TIFF, EXR, BMP",
+        None,
+    ),
     # main_window.py:2058
-    ("warning", "Frame Count Mismatch",
-     "Clip 'Woman_Jumps' has 120 input frames but you "
-     "selected 96 alpha images.\n\n"
-     "Continue anyway?",
-     QMessageBox.Ok | QMessageBox.Cancel),
+    (
+        "warning",
+        "Frame Count Mismatch",
+        "Clip 'Woman_Jumps' has 120 input frames but you "
+        "selected 96 alpha images.\n\n"
+        "Continue anyway?",
+        QMessageBox.Ok | QMessageBox.Cancel,
+    ),
     # main_window.py:2074
-    ("question", "Import Alpha",
-     "Import 120 alpha hint images?\n(24 frames will have no alpha hint)",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Import Alpha",
+        "Import 120 alpha hint images?\n(24 frames will have no alpha hint)",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # main_window.py:2132 — custom 3-button
-    ("custom_partial", "Partial Alpha Found",
-     "Found 24 of 120 alpha frames from a previous run.\n\n"
-     "Resume from where it left off, or regenerate all?", None),
+    (
+        "custom_partial",
+        "Partial Alpha Found",
+        "Found 24 of 120 alpha frames from a previous run.\n\n"
+        "Resume from where it left off, or regenerate all?",
+        None,
+    ),
     # main_window.py:2209
-    ("question", "Force Stop",
-     "The current GPU step has not returned to Python.\n\n"
-     "Force-kill the inference engine process?\n"
-     "This will lose any in-progress frame.",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Force Stop",
+        "The current GPU step has not returned to Python.\n\n"
+        "Force-kill the inference engine process?\n"
+        "This will lose any in-progress frame.",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # main_window.py:2223
     ("question", "Cancel", "Cancel processing?", QMessageBox.Yes | QMessageBox.No),
     # main_window.py:2437
-    ("critical", "Processing Error",
-     "Clip: Woman_Jumps_For_Joy\n\n"
-     "FileNotFoundError: [Errno 2] No such file or directory: triton kernel cache", None),
+    (
+        "critical",
+        "Processing Error",
+        "Clip: Woman_Jumps_For_Joy\n\n"
+        "FileNotFoundError: [Errno 2] No such file or directory: triton kernel cache",
+        None,
+    ),
     # main_window.py:2633
     ("information", "No Clip", "Select a clip first.", None),
     # main_window.py:2638
@@ -131,9 +196,12 @@ DIALOGS = [
     # main_window.py:2655
     ("warning", "No Output", "No output frames found to export.", None),
     # main_window.py:2661
-    ("critical", "FFmpeg Not Found",
-     "FFmpeg is required for video export.\n"
-     "Install it and make sure it's on your PATH.", None),
+    (
+        "critical",
+        "FFmpeg Not Found",
+        "FFmpeg is required for video export.\nInstall it and make sure it's on your PATH.",
+        None,
+    ),
     # main_window.py:2704
     ("information", "Export Complete", "Video exported:\nC:\\Users\\Johan\\output\\clip.mp4", None),
     # main_window.py:2712
@@ -141,45 +209,60 @@ DIALOGS = [
     # main_window.py:2840
     ("information", "No Folder", "Open a clips folder first.", None),
     # main_window.py:3061
-    ("question", "Update EZ-CorridorKey",
-     "This will save your session, close the app, and run the updater.\n"
-     "Continue?",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Update EZ-CorridorKey",
+        "This will save your session, close the app, and run the updater.\nContinue?",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # io_tray_panel.py:493
     ("information", "No Markers", "No clips have in/out markers set.", None),
     # io_tray_panel.py:501
-    ("question", "Reset In/Out Markers",
-     "This will clear in/out markers on 5 clips.\n\n"
-     "Continue?",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Reset In/Out Markers",
+        "This will clear in/out markers on 5 clips.\n\nContinue?",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # io_tray_panel.py:512
-    ("warning", "Confirm Reset",
-     "Are you sure? This cannot be undone.\n\n"
-     "5 clips will have their in/out markers removed.",
-     QMessageBox.Ok | QMessageBox.Cancel),
+    (
+        "warning",
+        "Confirm Reset",
+        "Are you sure? This cannot be undone.\n\n5 clips will have their in/out markers removed.",
+        QMessageBox.Ok | QMessageBox.Cancel,
+    ),
     # io_tray_panel.py:773
-    ("question", "Clear Outputs",
-     "Remove all output files for 3 clip(s)?\nClip1, Clip2, Clip3\n\n"
-     "This cannot be undone.",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Clear Outputs",
+        "Remove all output files for 3 clip(s)?\nClip1, Clip2, Clip3\n\nThis cannot be undone.",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # io_tray_panel.py:815 — custom with detailed text
-    ("custom_remove", "Remove Clips",
-     "Remove 3 clips from the project?", None),
+    ("custom_remove", "Remove Clips", "Remove 3 clips from the project?", None),
     # hotkeys_dialog.py:93
-    ("warning", "Shortcut Conflict",
-     '"Ctrl+S" is already assigned to:\nSave Session\n\n'
-     "Reassign it?",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "warning",
+        "Shortcut Conflict",
+        '"Ctrl+S" is already assigned to:\nSave Session\n\nReassign it?',
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # hotkeys_dialog.py:309
-    ("question", "Reset All Shortcuts", "Reset all shortcuts to their default values?",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "question",
+        "Reset All Shortcuts",
+        "Reset all shortcuts to their default values?",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # recent_projects_panel.py:237 — custom 3-button
-    ("custom_remove_project", "Remove Project",
-     'Remove "My Project" from recent projects?', None),
+    ("custom_remove_project", "Remove Project", 'Remove "My Project" from recent projects?', None),
     # recent_projects_panel.py:259
-    ("warning", "Confirm Delete",
-     "Permanently delete this project folder?\n\nC:\\Users\\Johan\\clips",
-     QMessageBox.Yes | QMessageBox.No),
+    (
+        "warning",
+        "Confirm Delete",
+        "Permanently delete this project folder?\n\nC:\\Users\\Johan\\clips",
+        QMessageBox.Yes | QMessageBox.No,
+    ),
     # recent_projects_panel.py:282
     ("warning", "Delete Failed", "Could not delete project:\nPermission denied", None),
 ]
@@ -199,13 +282,15 @@ class DialogTester(QMainWindow):
         layout = QVBoxLayout(inner)
 
         for dlg in DIALOGS:
-            label = f"{dlg[0].upper()}: {dlg[1]} - \"{dlg[2][:60]}...\""
+            label = f'{dlg[0].upper()}: {dlg[1]} - "{dlg[2][:60]}..."'
             btn = QPushButton(label)
             btn.clicked.connect(lambda checked, d=dlg: self._show(d))
             layout.addWidget(btn)
 
         show_all = QPushButton(">>> SHOW ALL ONE BY ONE <<<")
-        show_all.setStyleSheet("background: #FFF203; color: #000; font-weight: bold; padding: 10px;")
+        show_all.setStyleSheet(
+            "background: #FFF203; color: #000; font-weight: bold; padding: 10px;"
+        )
         show_all.clicked.connect(self._show_all)
         layout.addWidget(show_all)
 
@@ -218,18 +303,20 @@ class DialogTester(QMainWindow):
         kind, title, text, buttons = dlg
 
         if kind == "question":
-            box = QMessageBox(QMessageBox.Question, title, text,
-                              buttons or (QMessageBox.Yes | QMessageBox.No), self)
+            box = QMessageBox(
+                QMessageBox.Question,
+                title,
+                text,
+                buttons or (QMessageBox.Yes | QMessageBox.No),
+                self,
+            )
             box.setDefaultButton(QMessageBox.No)
         elif kind == "critical":
-            box = QMessageBox(QMessageBox.Critical, title, text,
-                              QMessageBox.Ok, self)
+            box = QMessageBox(QMessageBox.Critical, title, text, QMessageBox.Ok, self)
         elif kind == "information":
-            box = QMessageBox(QMessageBox.Information, title, text,
-                              QMessageBox.Ok, self)
+            box = QMessageBox(QMessageBox.Information, title, text, QMessageBox.Ok, self)
         elif kind == "warning":
-            box = QMessageBox(QMessageBox.Warning, title, text,
-                              buttons or QMessageBox.Ok, self)
+            box = QMessageBox(QMessageBox.Warning, title, text, buttons or QMessageBox.Ok, self)
         elif kind == "custom_clear":
             box = QMessageBox(self)
             box.setIcon(QMessageBox.Question)

--- a/tests/test_display_transform.py
+++ b/tests/test_display_transform.py
@@ -1,6 +1,6 @@
 """Tests for display transform — EXR preview conversion for various channel layouts."""
+
 import os
-import tempfile
 from unittest.mock import patch
 import pytest
 import numpy as np
@@ -13,9 +13,15 @@ pyside6 = pytest.importorskip("PySide6", reason="PySide6 not installed")
 from PySide6.QtGui import QImage
 
 from ui.preview.display_transform import (
-    decode_frame, clear_cache, _cache_key, _transform_matte,
-    _transform_linear_rgb, _transform_processed_rgba, _numpy_to_qimage,
-    processed_rgba_to_qimage, decode_video_frame,
+    decode_frame,
+    clear_cache,
+    _cache_key,
+    _transform_matte,
+    _transform_linear_rgb,
+    _transform_processed_rgba,
+    _numpy_to_qimage,
+    processed_rgba_to_qimage,
+    decode_video_frame,
 )
 from ui.preview.frame_index import ViewMode
 
@@ -95,7 +101,7 @@ class TestTransformProcessedRGBA:
         """Codex test: 4-channel straight RGBA (Processed output)."""
         bgra = np.zeros((10, 10, 4), dtype=np.float32)
         bgra[:, :, :3] = 0.25
-        bgra[:, :, 3] = 0.5   # alpha
+        bgra[:, :, 3] = 0.5  # alpha
         qimg = _transform_processed_rgba(bgra)
         assert isinstance(qimg, QImage)
 
@@ -134,7 +140,9 @@ class TestTransformProcessedRGBA:
 class TestDecodeFrame:
     def test_cache_key_distinguishes_input_exr_color_truth(self):
         assert _cache_key("/tmp/test.exr", ViewMode.INPUT, False) != _cache_key(
-            "/tmp/test.exr", ViewMode.INPUT, True,
+            "/tmp/test.exr",
+            ViewMode.INPUT,
+            True,
         )
 
     def test_decode_png(self, tmp_path):

--- a/tests/test_ffmpeg_tools.py
+++ b/tests/test_ffmpeg_tools.py
@@ -1,8 +1,8 @@
 """Tests for backend.ffmpeg_tools probe and EXR filter selection."""
+
 import io
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 import backend.ffmpeg_tools as ffmpeg_tools
@@ -46,7 +46,10 @@ class TestProbeVideo:
             _probe.subprocess,
             "run",
             lambda *args, **kwargs: subprocess.CompletedProcess(
-                args[0], 0, stdout=payload, stderr="",
+                args[0],
+                0,
+                stdout=payload,
+                stderr="",
             ),
         )
 
@@ -67,57 +70,54 @@ class TestBuildExrVf:
         assert vf == "format=gbrpf32le"
 
     def test_yuv_input_with_missing_transfer_uses_explicit_scale(self):
-        vf = ffmpeg_tools.build_exr_vf({
-            "pix_fmt": "yuv422p10le",
-            "width": 1920,
-            "height": 1080,
-            "color_space": "bt709",
-            "color_primaries": "bt709",
-            "color_transfer": "",
-            "color_range": "",
-            "bits_per_raw_sample": 10,
-        })
-
-        assert (
-            vf ==
-            "scale=in_color_matrix=bt709:in_range=tv,format=gbrpf32le"
+        vf = ffmpeg_tools.build_exr_vf(
+            {
+                "pix_fmt": "yuv422p10le",
+                "width": 1920,
+                "height": 1080,
+                "color_space": "bt709",
+                "color_primaries": "bt709",
+                "color_transfer": "",
+                "color_range": "",
+                "bits_per_raw_sample": 10,
+            }
         )
+
+        assert vf == "scale=in_color_matrix=bt709:in_range=tv,format=gbrpf32le"
 
     def test_complete_yuv_metadata_is_preserved(self):
-        vf = ffmpeg_tools.build_exr_vf({
-            "pix_fmt": "yuv420p10le",
-            "width": 3840,
-            "height": 2160,
-            "color_space": "bt2020nc",
-            "color_primaries": "bt2020",
-            "color_transfer": "smpte2084",
-            "color_range": "tv",
-            "bits_per_raw_sample": 10,
-        })
-
-        assert (
-            vf ==
-            "scale=in_color_matrix=bt2020nc:in_range=tv,format=gbrpf32le"
+        vf = ffmpeg_tools.build_exr_vf(
+            {
+                "pix_fmt": "yuv420p10le",
+                "width": 3840,
+                "height": 2160,
+                "color_space": "bt2020nc",
+                "color_primaries": "bt2020",
+                "color_transfer": "smpte2084",
+                "color_range": "tv",
+                "bits_per_raw_sample": 10,
+            }
         )
 
+        assert vf == "scale=in_color_matrix=bt2020nc:in_range=tv,format=gbrpf32le"
+
     def test_sd_missing_transfer_uses_sd_fallback(self):
-        vf = ffmpeg_tools.build_exr_vf({
-            "pix_fmt": "yuv420p",
-            "width": 720,
-            "height": 576,
-            "color_space": "bt470bg",
-            "color_primaries": "bt470bg",
-            "color_transfer": "",
-            "color_range": "tv",
-            "bits_per_raw_sample": 8,
-        })
+        vf = ffmpeg_tools.build_exr_vf(
+            {
+                "pix_fmt": "yuv420p",
+                "width": 720,
+                "height": 576,
+                "color_space": "bt470bg",
+                "color_primaries": "bt470bg",
+                "color_transfer": "",
+                "color_range": "tv",
+                "bits_per_raw_sample": 8,
+            }
+        )
 
         # bt470bg is remapped: matrix->bt601
         # (FFmpeg's scale filter doesn't accept 'bt470bg' as in_color_matrix)
-        assert (
-            vf ==
-            "scale=in_color_matrix=bt601:in_range=tv,format=gbrpf32le"
-        )
+        assert vf == "scale=in_color_matrix=bt601:in_range=tv,format=gbrpf32le"
 
 
 class TestExtractFrames:
@@ -157,20 +157,24 @@ class TestExtractFrames:
         )
         monkeypatch.setattr(_extraction, "detect_hwaccel", lambda ffmpeg=None: [])
         monkeypatch.setattr(_extraction, "_recompress_to_dwab", lambda *args, **kwargs: None)
-        monkeypatch.setattr(_extraction, "probe_video", lambda path: {
-            "fps": 25.0,
-            "width": 1920,
-            "height": 1080,
-            "frame_count": 10,
-            "codec": "prores",
-            "duration": 0.4,
-            "pix_fmt": "yuv422p10le",
-            "color_space": "bt709",
-            "color_primaries": "bt709",
-            "color_transfer": "",
-            "color_range": "",
-            "bits_per_raw_sample": 10,
-        })
+        monkeypatch.setattr(
+            _extraction,
+            "probe_video",
+            lambda path: {
+                "fps": 25.0,
+                "width": 1920,
+                "height": 1080,
+                "frame_count": 10,
+                "codec": "prores",
+                "duration": 0.4,
+                "pix_fmt": "yuv422p10le",
+                "color_space": "bt709",
+                "color_primaries": "bt709",
+                "color_transfer": "",
+                "color_range": "",
+                "bits_per_raw_sample": 10,
+            },
+        )
         monkeypatch.setattr(_extraction.subprocess, "Popen", fake_popen)
 
         out_dir = tmp_path / "frames"
@@ -196,9 +200,7 @@ class TestVideoMetadata:
             "frame_count": 100,
             "codec": "prores",
             "duration": 4.0,
-            "exr_vf": (
-                "scale=in_color_matrix=bt709:in_range=tv,format=gbrpf32le"
-            ),
+            "exr_vf": ("scale=in_color_matrix=bt709:in_range=tv,format=gbrpf32le"),
             "source_probe": {
                 "frame_count": 100,
                 "pix_fmt": "yuv422p10le",
@@ -257,9 +259,7 @@ class TestValidateFFmpegInstall:
 
         def fake_run(cmd, **kwargs):
             program = Path(cmd[0]).name
-            first_line = (
-                f"{program} version 7.1.1-essentials_build-www.gyan.dev"
-            )
+            first_line = f"{program} version 7.1.1-essentials_build-www.gyan.dev"
             return subprocess.CompletedProcess(cmd, 0, stdout=f"{first_line}\n", stderr="")
 
         monkeypatch.setattr(_discovery.subprocess, "run", fake_run)

--- a/tests/test_frame_index.py
+++ b/tests/test_frame_index.py
@@ -1,8 +1,7 @@
 """Tests for FrameIndex — stem-based cross-mode navigation."""
+
 import os
-import tempfile
-import pytest
-from ui.preview.frame_index import FrameIndex, ViewMode, build_frame_index
+from ui.preview.frame_index import ViewMode, build_frame_index
 
 
 class TestFrameIndex:
@@ -28,26 +27,32 @@ class TestFrameIndex:
             os.makedirs(dir_path, exist_ok=True)
             ext = ".png" if mode == ViewMode.COMP else ".exr"
             for stem in stems:
-                open(os.path.join(dir_path, f"{stem}{ext}"), 'w').close()
+                open(os.path.join(dir_path, f"{stem}{ext}"), "w").close()
 
         return clip_root
 
     def test_basic_index(self, tmp_path):
-        clip_root = self._make_clip_dir(tmp_path, {
-            ViewMode.INPUT: ["frame_001", "frame_002", "frame_003"],
-            ViewMode.COMP: ["frame_001", "frame_002", "frame_003"],
-        })
+        clip_root = self._make_clip_dir(
+            tmp_path,
+            {
+                ViewMode.INPUT: ["frame_001", "frame_002", "frame_003"],
+                ViewMode.COMP: ["frame_001", "frame_002", "frame_003"],
+            },
+        )
         idx = build_frame_index(clip_root)
         assert idx.frame_count == 3
         assert idx.stems == ["frame_001", "frame_002", "frame_003"]
 
     def test_cross_mode_holes(self, tmp_path):
         """Codex test: stem-based sync when one mode has missing frames."""
-        clip_root = self._make_clip_dir(tmp_path, {
-            ViewMode.INPUT: ["frame_001", "frame_002", "frame_003"],
-            ViewMode.COMP: ["frame_001", "frame_003"],  # frame_002 missing
-            ViewMode.FG: ["frame_001", "frame_002"],     # frame_003 missing
-        })
+        clip_root = self._make_clip_dir(
+            tmp_path,
+            {
+                ViewMode.INPUT: ["frame_001", "frame_002", "frame_003"],
+                ViewMode.COMP: ["frame_001", "frame_003"],  # frame_002 missing
+                ViewMode.FG: ["frame_001", "frame_002"],  # frame_003 missing
+            },
+        )
         idx = build_frame_index(clip_root)
         # All stems should be present in the timeline
         assert idx.frame_count == 3
@@ -58,27 +63,33 @@ class TestFrameIndex:
         assert idx.has_frame(ViewMode.INPUT, 1)  # frame_002
         assert idx.has_frame(ViewMode.INPUT, 2)  # frame_003
 
-        assert idx.has_frame(ViewMode.COMP, 0)   # frame_001 ✓
-        assert not idx.has_frame(ViewMode.COMP, 1) # frame_002 ✗
-        assert idx.has_frame(ViewMode.COMP, 2)   # frame_003 ✓
+        assert idx.has_frame(ViewMode.COMP, 0)  # frame_001 ✓
+        assert not idx.has_frame(ViewMode.COMP, 1)  # frame_002 ✗
+        assert idx.has_frame(ViewMode.COMP, 2)  # frame_003 ✓
 
-        assert idx.has_frame(ViewMode.FG, 0)      # frame_001 ✓
-        assert idx.has_frame(ViewMode.FG, 1)      # frame_002 ✓
+        assert idx.has_frame(ViewMode.FG, 0)  # frame_001 ✓
+        assert idx.has_frame(ViewMode.FG, 1)  # frame_002 ✓
         assert not idx.has_frame(ViewMode.FG, 2)  # frame_003 ✗
 
     def test_natural_sort_order(self, tmp_path):
         """Verify natural sort in stem timeline."""
-        clip_root = self._make_clip_dir(tmp_path, {
-            ViewMode.INPUT: ["frame_1", "frame_10", "frame_2"],
-        })
+        clip_root = self._make_clip_dir(
+            tmp_path,
+            {
+                ViewMode.INPUT: ["frame_1", "frame_10", "frame_2"],
+            },
+        )
         idx = build_frame_index(clip_root)
         assert idx.stems == ["frame_1", "frame_2", "frame_10"]
 
     def test_available_modes(self, tmp_path):
-        clip_root = self._make_clip_dir(tmp_path, {
-            ViewMode.INPUT: ["frame_001"],
-            ViewMode.COMP: ["frame_001"],
-        })
+        clip_root = self._make_clip_dir(
+            tmp_path,
+            {
+                ViewMode.INPUT: ["frame_001"],
+                ViewMode.COMP: ["frame_001"],
+            },
+        )
         idx = build_frame_index(clip_root)
         modes = idx.available_modes()
         assert ViewMode.INPUT in modes
@@ -86,9 +97,12 @@ class TestFrameIndex:
         assert ViewMode.FG not in modes
 
     def test_get_path(self, tmp_path):
-        clip_root = self._make_clip_dir(tmp_path, {
-            ViewMode.INPUT: ["frame_001"],
-        })
+        clip_root = self._make_clip_dir(
+            tmp_path,
+            {
+                ViewMode.INPUT: ["frame_001"],
+            },
+        )
         idx = build_frame_index(clip_root)
         path = idx.get_path(ViewMode.INPUT, 0)
         assert path is not None
@@ -102,9 +116,12 @@ class TestFrameIndex:
         assert idx.stems == []
 
     def test_out_of_range(self, tmp_path):
-        clip_root = self._make_clip_dir(tmp_path, {
-            ViewMode.INPUT: ["frame_001"],
-        })
+        clip_root = self._make_clip_dir(
+            tmp_path,
+            {
+                ViewMode.INPUT: ["frame_001"],
+            },
+        )
         idx = build_frame_index(clip_root)
         assert not idx.has_frame(ViewMode.INPUT, -1)
         assert not idx.has_frame(ViewMode.INPUT, 1)

--- a/tests/test_frame_io.py
+++ b/tests/test_frame_io.py
@@ -1,4 +1,5 @@
 """Tests for backend.frame_io colour handling and EXR ingest."""
+
 import os
 
 import numpy as np

--- a/tests/test_inference_engine_init.py
+++ b/tests/test_inference_engine_init.py
@@ -79,7 +79,6 @@ class TestCorridorKeyEngineInit:
         monkeypatch.setattr(CorridorKeyEngine, "_load_model", lambda self: object())
 
         probe_called_with = []
-        original_get_vram = CorridorKeyEngine._get_vram_gb
 
         @staticmethod
         def _tracking_probe() -> float:

--- a/tests/test_invalid_format.py
+++ b/tests/test_invalid_format.py
@@ -8,10 +8,10 @@ Key design facts documented by these tests:
 - OutputConfig accepts arbitrary format strings; no validation is enforced at
   construction time.  Callers are responsible for passing valid values.
 """
+
 from unittest.mock import patch
 
 import numpy as np
-import pytest
 
 from backend.service import CorridorKeyService, OutputConfig
 
@@ -19,6 +19,7 @@ from backend.service import CorridorKeyService, OutputConfig
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _float32_frame(h: int = 4, w: int = 4, c: int = 3) -> np.ndarray:
     """Return a small float32 array whose values span [0, 1]."""
@@ -33,6 +34,7 @@ def _make_service() -> CorridorKeyService:
 # ---------------------------------------------------------------------------
 # TestWriteImageFormats
 # ---------------------------------------------------------------------------
+
 
 class TestWriteImageFormats:
     """Unit tests for _write_image format-routing logic."""
@@ -101,9 +103,7 @@ class TestWriteImageFormats:
 
         for path, info in captured_calls.items():
             # PNG branch: no extra flags passed
-            assert info["extra_args"] == (), (
-                f"Unknown format at {path} must not forward EXR flags"
-            )
+            assert info["extra_args"] == (), f"Unknown format at {path} must not forward EXR flags"
             # PNG branch: array must be uint8
             assert info["arr"].dtype == np.uint8, (
                 f"Unknown format at {path} must produce uint8 output"
@@ -151,6 +151,7 @@ class TestWriteImageFormats:
 # ---------------------------------------------------------------------------
 # TestOutputConfigNonStandardFormats
 # ---------------------------------------------------------------------------
+
 
 class TestOutputConfigNonStandardFormats:
     """Verify OutputConfig accepts arbitrary format strings without error."""

--- a/tests/test_job_queue_full.py
+++ b/tests/test_job_queue_full.py
@@ -4,6 +4,7 @@ Covers: lifecycle, failure, cancellation, mark_cancelled, callbacks,
 callback safety, deduplication, find_job_by_id, properties, clear_history,
 and GPUJob internals.
 """
+
 import pytest
 
 from backend.job_queue import GPUJob, GPUJobQueue, JobType, JobStatus
@@ -13,6 +14,7 @@ from backend.errors import JobCancelledError
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_queue() -> GPUJobQueue:
     return GPUJobQueue()
@@ -29,6 +31,7 @@ def _gvm(clip: str = "clip1") -> GPUJob:
 # ---------------------------------------------------------------------------
 # TestJobLifecycle
 # ---------------------------------------------------------------------------
+
 
 class TestJobLifecycle:
     def test_submit_puts_job_in_queue_with_queued_status(self):
@@ -120,6 +123,7 @@ class TestJobLifecycle:
 # TestJobFailure
 # ---------------------------------------------------------------------------
 
+
 class TestJobFailure:
     def test_fail_job_sets_failed_status(self):
         q = _make_queue()
@@ -158,6 +162,7 @@ class TestJobFailure:
 # TestJobCancellation
 # ---------------------------------------------------------------------------
 
+
 class TestJobCancellation:
     def test_cancel_queued_job_removes_from_queue(self):
         q = _make_queue()
@@ -182,7 +187,7 @@ class TestJobCancellation:
         q.start_job(job)
         q.cancel_job(job)
         assert job.status == JobStatus.RUNNING  # still running
-        assert job.is_cancelled is True          # flag set
+        assert job.is_cancelled is True  # flag set
 
     def test_cancel_running_job_stays_as_current(self):
         """cancel_job does NOT clear _current_job — worker must call mark_cancelled."""
@@ -240,6 +245,7 @@ class TestJobCancellation:
 # TestMarkCancelled
 # ---------------------------------------------------------------------------
 
+
 class TestMarkCancelled:
     def test_mark_cancelled_sets_status(self):
         q = _make_queue()
@@ -284,6 +290,7 @@ class TestMarkCancelled:
 # ---------------------------------------------------------------------------
 # TestCallbacks
 # ---------------------------------------------------------------------------
+
 
 class TestCallbacks:
     def test_on_completion_called_after_complete_job(self):
@@ -355,9 +362,11 @@ class TestCallbacks:
 # TestCallbackSafety
 # ---------------------------------------------------------------------------
 
+
 class TestCallbackSafety:
     def test_on_completion_exception_does_not_corrupt_history(self):
         """If on_completion raises, the job must still be in history as COMPLETED."""
+
         def boom(clip):
             raise RuntimeError("cb blew up")
 
@@ -378,6 +387,7 @@ class TestCallbackSafety:
 
     def test_on_error_exception_does_not_corrupt_history(self):
         """If on_error raises, the job must still be in history as FAILED."""
+
         def boom(clip, err):
             raise RuntimeError("cb blew up")
 
@@ -400,6 +410,7 @@ class TestCallbackSafety:
 # ---------------------------------------------------------------------------
 # TestDeduplication
 # ---------------------------------------------------------------------------
+
 
 class TestDeduplication:
     def test_same_clip_same_type_queued_twice_rejected(self):
@@ -447,6 +458,7 @@ class TestDeduplication:
 # TestFindJob
 # ---------------------------------------------------------------------------
 
+
 class TestFindJob:
     def test_find_job_in_queue(self):
         q = _make_queue()
@@ -480,6 +492,7 @@ class TestFindJob:
 # ---------------------------------------------------------------------------
 # TestProperties
 # ---------------------------------------------------------------------------
+
 
 class TestProperties:
     def test_has_pending_true_when_queue_has_jobs(self):
@@ -561,6 +574,7 @@ class TestProperties:
 # TestClearHistory
 # ---------------------------------------------------------------------------
 
+
 class TestClearHistory:
     def test_clear_history_empties_history(self):
         q = _make_queue()
@@ -596,6 +610,7 @@ class TestClearHistory:
 # ---------------------------------------------------------------------------
 # TestGPUJob
 # ---------------------------------------------------------------------------
+
 
 class TestGPUJob:
     def test_request_cancel_sets_flag(self):

--- a/tests/test_job_queue_phase4.py
+++ b/tests/test_job_queue_phase4.py
@@ -1,5 +1,5 @@
 """Tests for Phase 4 job queue enhancements — PREVIEW_REPROCESS replacement semantics."""
-import pytest
+
 from backend.job_queue import GPUJob, GPUJobQueue, JobType, JobStatus
 
 

--- a/tests/test_main_window_color_space.py
+++ b/tests/test_main_window_color_space.py
@@ -159,6 +159,7 @@ def test_selecting_another_clip_remembers_previous_clip_color_space_override():
     # Mock _clip_model with a clips list for index tracking
     class _DummyClipModel:
         clips = [previous, selected]
+
     window._clip_model = _DummyClipModel()
 
     MainWindow._on_clip_selected(window, selected)

--- a/tests/test_natural_sort.py
+++ b/tests/test_natural_sort.py
@@ -1,48 +1,48 @@
 """Tests for natural sort key — handles mixed stems, non-zero-padded numbers."""
-import pytest
-from backend.natural_sort import natural_sort_key, natsorted
+
+from backend.natural_sort import natsorted
 
 
 class TestNaturalSortKey:
     def test_numeric_ordering(self):
-        result = natsorted(['frame_1', 'frame_10', 'frame_2'])
-        assert result == ['frame_1', 'frame_2', 'frame_10']
+        result = natsorted(["frame_1", "frame_10", "frame_2"])
+        assert result == ["frame_1", "frame_2", "frame_10"]
 
     def test_zero_padded(self):
-        result = natsorted(['shot_0001.exr', 'shot_0010.exr', 'shot_0002.exr'])
-        assert result == ['shot_0001.exr', 'shot_0002.exr', 'shot_0010.exr']
+        result = natsorted(["shot_0001.exr", "shot_0010.exr", "shot_0002.exr"])
+        assert result == ["shot_0001.exr", "shot_0002.exr", "shot_0010.exr"]
 
     def test_mixed_stems(self):
         """Codex test case: mixed stem formats."""
-        result = natsorted(['frame_1', 'frame_2', 'frame_10', 'shot_v2_001'])
-        assert result == ['frame_1', 'frame_2', 'frame_10', 'shot_v2_001']
+        result = natsorted(["frame_1", "frame_2", "frame_10", "shot_v2_001"])
+        assert result == ["frame_1", "frame_2", "frame_10", "shot_v2_001"]
 
     def test_case_insensitive(self):
-        result = natsorted(['Frame_1', 'frame_10', 'FRAME_2'])
-        assert result == ['Frame_1', 'FRAME_2', 'frame_10']
+        result = natsorted(["Frame_1", "frame_10", "FRAME_2"])
+        assert result == ["Frame_1", "FRAME_2", "frame_10"]
 
     def test_empty_list(self):
         assert natsorted([]) == []
 
     def test_single_element(self):
-        assert natsorted(['file']) == ['file']
+        assert natsorted(["file"]) == ["file"]
 
     def test_pure_numbers(self):
-        result = natsorted(['3', '1', '20', '2'])
-        assert result == ['1', '2', '3', '20']
+        result = natsorted(["3", "1", "20", "2"])
+        assert result == ["1", "2", "3", "20"]
 
     def test_complex_stems(self):
         """VFX naming: plate_v2_fg_0001.exr"""
         files = [
-            'plate_v2_fg_0001.exr',
-            'plate_v2_fg_0010.exr',
-            'plate_v2_fg_0002.exr',
-            'plate_v1_fg_0001.exr',
+            "plate_v2_fg_0001.exr",
+            "plate_v2_fg_0010.exr",
+            "plate_v2_fg_0002.exr",
+            "plate_v1_fg_0001.exr",
         ]
         result = natsorted(files)
         assert result == [
-            'plate_v1_fg_0001.exr',
-            'plate_v2_fg_0001.exr',
-            'plate_v2_fg_0002.exr',
-            'plate_v2_fg_0010.exr',
+            "plate_v1_fg_0001.exr",
+            "plate_v2_fg_0001.exr",
+            "plate_v2_fg_0002.exr",
+            "plate_v2_fg_0010.exr",
         ]

--- a/tests/test_output_config.py
+++ b/tests/test_output_config.py
@@ -1,7 +1,7 @@
 """Tests for OutputConfig, InferenceParams serialization, and manifest-based resume."""
+
 import os
 import json
-import pytest
 
 from backend.service import InferenceParams, OutputConfig
 
@@ -71,7 +71,9 @@ class TestOutputConfig:
         assert restored.processed_enabled is False
 
     def test_enabled_outputs(self):
-        cfg = OutputConfig(fg_enabled=True, matte_enabled=True, comp_enabled=False, processed_enabled=False)
+        cfg = OutputConfig(
+            fg_enabled=True, matte_enabled=True, comp_enabled=False, processed_enabled=False
+        )
         assert cfg.enabled_outputs == ["fg", "matte"]
 
     def test_all_enabled(self):
@@ -88,7 +90,7 @@ class TestOutputConfig:
 class TestManifestResume:
     def test_completed_stems_uses_manifest(self, tmp_path):
         """When manifest exists, resume checks only enabled outputs."""
-        from backend.clip_state import ClipEntry, ClipState
+        from backend.clip_state import ClipEntry
 
         clip = ClipEntry(name="TestClip", root_path=str(tmp_path))
         out = os.path.join(str(tmp_path), "Output")
@@ -104,12 +106,12 @@ class TestManifestResume:
             "formats": {"fg": "exr", "comp": "png"},
             "params": {},
         }
-        with open(os.path.join(out, ".corridorkey_manifest.json"), 'w') as f:
+        with open(os.path.join(out, ".corridorkey_manifest.json"), "w") as f:
             json.dump(manifest, f)
 
         # Create matching stems
-        open(os.path.join(fg_dir, "frame_001.exr"), 'w').close()
-        open(os.path.join(comp_dir, "frame_001.png"), 'w').close()
+        open(os.path.join(fg_dir, "frame_001.exr"), "w").close()
+        open(os.path.join(comp_dir, "frame_001.png"), "w").close()
 
         stems = clip.completed_stems()
         assert "frame_001" in stems
@@ -125,9 +127,9 @@ class TestManifestResume:
         os.makedirs(fg_dir)
         os.makedirs(matte_dir)
 
-        open(os.path.join(fg_dir, "frame_001.exr"), 'w').close()
-        open(os.path.join(matte_dir, "frame_001.exr"), 'w').close()
-        open(os.path.join(fg_dir, "frame_002.exr"), 'w').close()
+        open(os.path.join(fg_dir, "frame_001.exr"), "w").close()
+        open(os.path.join(matte_dir, "frame_001.exr"), "w").close()
+        open(os.path.join(fg_dir, "frame_002.exr"), "w").close()
         # frame_002 missing from matte — not complete
 
         stems = clip.completed_stems()
@@ -145,8 +147,8 @@ class TestManifestResume:
         os.makedirs(matte_dir)
 
         for stem in ["frame_001", "frame_002", "frame_003"]:
-            open(os.path.join(fg_dir, f"{stem}.exr"), 'w').close()
-            open(os.path.join(matte_dir, f"{stem}.exr"), 'w').close()
+            open(os.path.join(fg_dir, f"{stem}.exr"), "w").close()
+            open(os.path.join(matte_dir, f"{stem}.exr"), "w").close()
 
         assert clip.completed_frame_count() == 3
         assert len(clip.completed_stems()) == 3

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,10 +1,9 @@
 """Tests for backend.project module — project folder creation and metadata."""
-import json
+
 import os
 import tempfile
 from unittest.mock import patch
 
-import pytest
 
 from backend.project import (
     sanitize_stem,
@@ -139,6 +138,7 @@ class TestInOutRangeStorage:
     def test_save_load_with_clip_json(self):
         """In/out range saved to clip.json when clip.json exists."""
         from backend.clip_state import InOutRange
+
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create a clip.json first
             write_clip_json(tmpdir, {"source": {"filename": "test.mp4"}})
@@ -157,6 +157,7 @@ class TestInOutRangeStorage:
     def test_save_load_with_project_json_v1(self):
         """In/out range falls back to project.json for v1 projects."""
         from backend.clip_state import InOutRange
+
         with tempfile.TemporaryDirectory() as tmpdir:
             # v1: only project.json, no clip.json
             write_project_json(tmpdir, {"version": 1})
@@ -170,6 +171,7 @@ class TestInOutRangeStorage:
 
     def test_clear_in_out_range(self):
         from backend.clip_state import InOutRange
+
         with tempfile.TemporaryDirectory() as tmpdir:
             write_clip_json(tmpdir, {"source": {"filename": "test.mp4"}})
             save_in_out_range(tmpdir, InOutRange(in_point=0, out_point=10))
@@ -306,7 +308,8 @@ class TestCreateProject:
 
             with patch("backend.project.projects_root", return_value=tmpdir):
                 project_dir = create_project(
-                    videos, display_name="My Cool Project",
+                    videos,
+                    display_name="My Cool Project",
                 )
 
             # Folder name uses sanitized display_name
@@ -400,10 +403,13 @@ class TestRemovedClips:
             # Need at least one image file for find_assets()
             with open(os.path.join(frames, "frame_001.png"), "wb") as f:
                 f.write(b"\x89PNG" + b"\x00" * 100)
-        write_project_json(tmpdir, {
-            "version": 2,
-            "clips": ["clip_a", "clip_b", "clip_c"],
-        })
+        write_project_json(
+            tmpdir,
+            {
+                "version": 2,
+                "clips": ["clip_a", "clip_b", "clip_c"],
+            },
+        )
         return tmpdir
 
     def test_get_removed_clips_empty_default(self):
@@ -447,18 +453,28 @@ class TestRemovedClips:
     def test_clear_removed_clip(self):
         """clear_removed_clip restores a clip."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            write_project_json(tmpdir, {
-                "version": 2, "clips": ["a"], "removed_clips": ["a", "b"],
-            })
+            write_project_json(
+                tmpdir,
+                {
+                    "version": 2,
+                    "clips": ["a"],
+                    "removed_clips": ["a", "b"],
+                },
+            )
             clear_removed_clip(tmpdir, "a")
             assert get_removed_clips(tmpdir) == {"b"}
 
     def test_clear_nonexistent_noop(self):
         """Clearing a clip that isn't removed is a no-op."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            write_project_json(tmpdir, {
-                "version": 2, "clips": ["a"], "removed_clips": ["x"],
-            })
+            write_project_json(
+                tmpdir,
+                {
+                    "version": 2,
+                    "clips": ["a"],
+                    "removed_clips": ["x"],
+                },
+            )
             clear_removed_clip(tmpdir, "a")
             assert get_removed_clips(tmpdir) == {"x"}
 

--- a/tests/test_rocm_setup.py
+++ b/tests/test_rocm_setup.py
@@ -1,0 +1,114 @@
+"""Tests for ROCm helper and startup path (mocked; no AMD GPU required)."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_device_utils_and_main_loggers() -> None:
+    """Avoid handler leakage across tests (stderr handlers, etc.)."""
+    import device_utils as du
+    import main
+
+    du.logger.handlers.clear()
+    du.logger.setLevel(logging.NOTSET)
+    du.logger.propagate = True
+    logging.getLogger(main.__name__).handlers.clear()
+    yield
+    du.logger.handlers.clear()
+    logging.getLogger(main.__name__).handlers.clear()
+
+
+@pytest.mark.rocm
+def test_setup_rocm_env_no_hip_no_env_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    import torch
+
+    with patch.object(torch.version, "hip", None):
+        from device_utils import setup_rocm_env
+
+        setup_rocm_env()
+    assert "HSA_OVERRIDE_GFX_VERSION" not in os.environ
+
+
+@pytest.mark.rocm
+def test_setup_rocm_env_with_hip_sets_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    import torch
+
+    with patch.object(torch.version, "hip", "6.0"):
+        with patch.object(torch.cuda, "is_available", return_value=True):
+            with patch.object(torch.cuda, "get_device_name", return_value="AMD test"):
+                from device_utils import setup_rocm_env
+
+                setup_rocm_env()
+    assert os.environ.get("HSA_OVERRIDE_GFX_VERSION") == "10.3.0"
+
+
+@pytest.mark.rocm
+def test_setup_rocm_env_hip_preserves_existing_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "11.0.0")
+    import torch
+
+    with patch.object(torch.version, "hip", "6.0"):
+        with patch.object(torch.cuda, "is_available", return_value=False):
+            from device_utils import setup_rocm_env
+
+            setup_rocm_env()
+    assert os.environ["HSA_OVERRIDE_GFX_VERSION"] == "11.0.0"
+
+
+@pytest.mark.rocm
+def test_try_setup_rocm_env_import_error_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "device_utils":
+            raise ImportError("simulated missing module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    import main
+
+    main._try_setup_rocm_env()
+
+
+@pytest.mark.rocm
+def test_try_setup_rocm_env_inner_failure_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import main
+
+    with caplog.at_level(logging.DEBUG, logger="main"):
+        with patch("device_utils.setup_rocm_env", side_effect=RuntimeError("boom")):
+            main._try_setup_rocm_env()
+    assert any("ROCm environment setup skipped" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.rocm
+def test_setup_rocm_env_hip_writes_to_stderr(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    import torch
+
+    import device_utils as du
+
+    du.logger.handlers.clear()
+    with patch.object(torch.version, "hip", "6.0"):
+        with patch.object(torch.cuda, "is_available", return_value=True):
+            with patch.object(torch.cuda, "get_device_name", return_value="AMD test"):
+                du.setup_rocm_env()
+    err = capsys.readouterr().err
+    assert "ROCm:" in err

--- a/tests/test_run_update_xplat.py
+++ b/tests/test_run_update_xplat.py
@@ -4,10 +4,10 @@ Verifies that the subprocess call in _run_update uses platform-appropriate
 flags (CREATE_NEW_CONSOLE on Windows, start_new_session on Unix) and
 does not raise AttributeError on any platform.
 """
+
 import os
 import subprocess
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -17,6 +17,7 @@ def _build_run_update_logic():
 
     Returns a callable(root_dir) that performs the Popen call.
     """
+
     def launch_updater(root):
         if os.name == "nt":
             bat = os.path.join(root, "3-update.bat")
@@ -30,6 +31,7 @@ def _build_run_update_logic():
                 [sh, "--relaunch"],
                 start_new_session=True,
             )
+
     return launch_updater
 
 
@@ -120,7 +122,9 @@ class TestRunUpdateCrossPlatform:
         """Verify _run_update has the os.name guard (in settings mixin)."""
         src_path = os.path.join(
             os.path.dirname(os.path.dirname(__file__)),
-            "ui", "main_window_mixins", "settings_mixin.py",
+            "ui",
+            "main_window_mixins",
+            "settings_mixin.py",
         )
         with open(src_path, "r", encoding="utf-8") as f:
             source = f.read()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,11 +5,12 @@ Mocking strategy (Codex-informed hybrid):
 - unittest.mock.patch for GPU/model/error injection
 - Behavioral tests for GPU lock (not structural)
 """
+
 import json
 import os
 import tempfile
 import types
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import cv2
 import numpy as np
@@ -20,7 +21,6 @@ from backend.service import (
     CorridorKeyService,
     InferenceParams,
     OutputConfig,
-    FrameResult,
     _ActiveModel,
     _import_matanyone2_processor_class,
 )
@@ -192,7 +192,10 @@ class TestGetEnginePool:
         result = svc._get_engine_pool()
         assert result[0] is mock_engine
 
-    @patch("CorridorKeyModule.backend.create_engine", side_effect=FileNotFoundError("No .pth checkpoint found"))
+    @patch(
+        "CorridorKeyModule.backend.create_engine",
+        side_effect=FileNotFoundError("No .pth checkpoint found"),
+    )
     @patch("CorridorKeyModule.backend.resolve_backend", return_value="torch")
     def test_no_checkpoint_raises(self, _rb, _ce):
         svc = CorridorKeyService()
@@ -200,7 +203,9 @@ class TestGetEnginePool:
         with pytest.raises(FileNotFoundError, match="No .pth checkpoint"):
             svc._get_engine_pool()
 
-    @patch("CorridorKeyModule.backend.create_engine", side_effect=ValueError("Multiple checkpoints"))
+    @patch(
+        "CorridorKeyModule.backend.create_engine", side_effect=ValueError("Multiple checkpoints")
+    )
     @patch("CorridorKeyModule.backend.resolve_backend", return_value="torch")
     def test_multiple_checkpoints_raises(self, _rb, _ce):
         svc = CorridorKeyService()
@@ -244,7 +249,11 @@ class TestReadInputFrame:
         svc = CorridorKeyService()
         input_files = sample_clip.input_asset.get_frame_files()
         img, stem, is_linear = svc._read_input_frame(
-            sample_clip, 0, input_files, None, False,
+            sample_clip,
+            0,
+            input_files,
+            None,
+            False,
         )
         assert img is not None
         assert img.dtype == np.float32
@@ -271,14 +280,20 @@ class TestReadInputFrame:
                 handle.write("dummy")
 
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.RAW,
+                "test",
+                tmpdir,
+                state=ClipState.RAW,
                 input_asset=ClipAsset(frames_dir, "sequence"),
             )
 
             fake_img = np.zeros((2, 2, 3), dtype=np.float32)
             with patch("backend.service.read_image_frame", return_value=fake_img):
                 img, stem, is_linear = svc._read_input_frame(
-                    clip, 0, clip.input_asset.get_frame_files(), None, False,
+                    clip,
+                    0,
+                    clip.input_asset.get_frame_files(),
+                    None,
+                    False,
                 )
 
             assert img is fake_img
@@ -326,7 +341,9 @@ class TestReadAlphaFrame:
             alpha_files = clip.alpha_asset.get_frame_files()
             alpha_lookup = {os.path.splitext(f)[0]: f for f in alpha_files}
 
-            with patch("backend.service.read_mask_frame", return_value=np.ones((4, 4), dtype=np.float32)) as mock_read:
+            with patch(
+                "backend.service.read_mask_frame", return_value=np.ones((4, 4), dtype=np.float32)
+            ) as mock_read:
                 svc._read_alpha_frame(
                     clip,
                     0,
@@ -355,7 +372,9 @@ class TestReadAlphaFrame:
             )
             alpha_files = clip.alpha_asset.get_frame_files()
 
-            with patch("backend.service.read_mask_frame", return_value=np.ones((4, 4), dtype=np.float32)) as mock_read:
+            with patch(
+                "backend.service.read_mask_frame", return_value=np.ones((4, 4), dtype=np.float32)
+            ) as mock_read:
                 svc._read_alpha_frame(
                     clip,
                     0,
@@ -461,11 +480,14 @@ class TestWriteOutputs:
     def test_all_outputs_enabled(self, tmp_clip_dir):
         svc = CorridorKeyService()
         from backend.validators import ensure_output_dirs
+
         dirs = ensure_output_dirs(tmp_clip_dir)
         res = self._make_result_dict()
         cfg = OutputConfig(
-            fg_format="png", matte_format="png",
-            comp_format="png", processed_format="png",
+            fg_format="png",
+            matte_format="png",
+            comp_format="png",
+            processed_format="png",
         )
         svc._write_outputs(res, dirs, "frame_00000", "clip1", 0, cfg)
 
@@ -477,11 +499,14 @@ class TestWriteOutputs:
     def test_selective_disable(self, tmp_clip_dir):
         svc = CorridorKeyService()
         from backend.validators import ensure_output_dirs
+
         dirs = ensure_output_dirs(tmp_clip_dir)
         res = self._make_result_dict()
         cfg = OutputConfig(
-            fg_enabled=False, matte_enabled=True,
-            comp_enabled=False, processed_enabled=False,
+            fg_enabled=False,
+            matte_enabled=True,
+            comp_enabled=False,
+            processed_enabled=False,
             matte_format="png",
         )
         svc._write_outputs(res, dirs, "frame_00000", "clip1", 0, cfg)
@@ -494,6 +519,7 @@ class TestWriteOutputs:
         """If 'processed' not in result dict, skip gracefully."""
         svc = CorridorKeyService()
         from backend.validators import ensure_output_dirs
+
         dirs = ensure_output_dirs(tmp_clip_dir)
         res = {
             "fg": np.ones((4, 4, 3), dtype=np.float32),
@@ -502,9 +528,11 @@ class TestWriteOutputs:
             # 'processed' intentionally missing
         }
         cfg = OutputConfig(
-            fg_format="png", matte_format="png",
+            fg_format="png",
+            matte_format="png",
             comp_format="png",
-            processed_enabled=True, processed_format="png",
+            processed_enabled=True,
+            processed_format="png",
         )
         # Should not raise
         svc._write_outputs(res, dirs, "frame_00000", "clip1", 0, cfg)
@@ -624,8 +652,10 @@ class TestRunInference:
         svc, mock_engine = self._setup_service_with_mock_engine()
         params = InferenceParams()
         cfg = OutputConfig(
-            fg_format="png", matte_format="png",
-            comp_format="png", processed_format="png",
+            fg_format="png",
+            matte_format="png",
+            comp_format="png",
+            processed_format="png",
         )
         results = svc.run_inference(sample_clip, params, output_config=cfg)
         assert len(results) == 3  # 3 frames in fixture
@@ -638,9 +668,12 @@ class TestRunInference:
         input_files = sample_clip.input_asset.get_frame_files()
         first_stem = os.path.splitext(input_files[0])[0]
         results = svc.run_inference(
-            sample_clip, params, skip_stems={first_stem},
-            output_config=OutputConfig(fg_format="png", matte_format="png",
-                                       comp_format="png", processed_format="png"),
+            sample_clip,
+            params,
+            skip_stems={first_stem},
+            output_config=OutputConfig(
+                fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+            ),
         )
         # First frame skipped (resumed), 2 processed
         skipped = [r for r in results if r.warning and "resumed" in r.warning]
@@ -654,9 +687,14 @@ class TestRunInference:
         job.request_cancel()
 
         with pytest.raises(JobCancelledError):
-            svc.run_inference(sample_clip, params, job=job,
-                              output_config=OutputConfig(fg_format="png", matte_format="png",
-                                                          comp_format="png", processed_format="png"))
+            svc.run_inference(
+                sample_clip,
+                params,
+                job=job,
+                output_config=OutputConfig(
+                    fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+                ),
+            )
 
     def test_frame_read_error_continues(self, sample_clip, tmp_clip_dir):
         """FrameReadError on a frame → skip that frame, continue others."""
@@ -677,10 +715,12 @@ class TestRunInference:
 
         warnings = []
         results = svc.run_inference(
-            sample_clip, params,
+            sample_clip,
+            params,
             on_warning=lambda msg: warnings.append(msg),
-            output_config=OutputConfig(fg_format="png", matte_format="png",
-                                       comp_format="png", processed_format="png"),
+            output_config=OutputConfig(
+                fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+            ),
         )
         failed = [r for r in results if not r.success]
         assert len(failed) >= 1
@@ -694,20 +734,26 @@ class TestRunInference:
 
         # Should propagate — not caught by the per-frame handler
         with pytest.raises(RuntimeError, match="GPU OOM"):
-            svc.run_inference(sample_clip, params,
-                              output_config=OutputConfig(fg_format="png", matte_format="png",
-                                                          comp_format="png", processed_format="png"))
+            svc.run_inference(
+                sample_clip,
+                params,
+                output_config=OutputConfig(
+                    fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+                ),
+            )
 
     def test_progress_callback_cadence(self, sample_clip, tmp_clip_dir):
         """Codex: progress fires every 5th frame + final, not per-frame."""
         svc, _ = self._setup_service_with_mock_engine()
         params = InferenceParams()
         calls = []
-        results = svc.run_inference(
-            sample_clip, params,
+        svc.run_inference(
+            sample_clip,
+            params,
             on_progress=lambda name, cur, total, **kwargs: calls.append((cur, total)),
-            output_config=OutputConfig(fg_format="png", matte_format="png",
-                                       comp_format="png", processed_format="png"),
+            output_config=OutputConfig(
+                fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+            ),
         )
         # With 3 frames: fires at frame 0 (0%5==0) and final (3)
         assert len(calls) >= 2
@@ -718,9 +764,13 @@ class TestRunInference:
         svc, _ = self._setup_service_with_mock_engine()
         params = InferenceParams()
         assert sample_clip.state == ClipState.READY
-        svc.run_inference(sample_clip, params,
-                          output_config=OutputConfig(fg_format="png", matte_format="png",
-                                                      comp_format="png", processed_format="png"))
+        svc.run_inference(
+            sample_clip,
+            params,
+            output_config=OutputConfig(
+                fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+            ),
+        )
         assert sample_clip.state == ClipState.COMPLETE
 
     def test_zero_frame_clip_no_complete(self):
@@ -736,13 +786,19 @@ class TestRunInference:
             os.makedirs(alpha_dir)
 
             clip = ClipEntry(
-                name="empty", root_path=clip_root, state=ClipState.READY,
+                name="empty",
+                root_path=clip_root,
+                state=ClipState.READY,
                 input_asset=ClipAsset(input_dir, "sequence"),
                 alpha_asset=ClipAsset(alpha_dir, "sequence"),
             )
-            results = svc.run_inference(clip, params,
-                                        output_config=OutputConfig(fg_format="png", matte_format="png",
-                                                                    comp_format="png", processed_format="png"))
+            results = svc.run_inference(
+                clip,
+                params,
+                output_config=OutputConfig(
+                    fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+                ),
+            )
             # 0 frames processed, 0 total — current code does 0==0 → COMPLETE
             # This test documents the current behavior
             assert len(results) == 0
@@ -778,9 +834,14 @@ class TestRunInference:
 
         params = InferenceParams()
         with pytest.raises(JobCancelledError):
-            svc.run_inference(sample_clip, params, job=job,
-                              output_config=OutputConfig(fg_format="png", matte_format="png",
-                                                          comp_format="png", processed_format="png"))
+            svc.run_inference(
+                sample_clip,
+                params,
+                job=job,
+                output_config=OutputConfig(
+                    fg_format="png", matte_format="png", comp_format="png", processed_format="png"
+                ),
+            )
         # Test passed — if finally block didn't run, we'd leak captures
 
     def test_frame_range_uses_stem_matched_partial_alpha_sequence(self):
@@ -820,8 +881,9 @@ class TestRunInference:
                 read_mask_paths.append(os.path.basename(path))
                 return fake_mask
 
-            with patch("backend.service.read_image_frame", return_value=fake_img), patch(
-                "backend.service.read_mask_frame", side_effect=_record_mask
+            with (
+                patch("backend.service.read_image_frame", return_value=fake_img),
+                patch("backend.service.read_mask_frame", side_effect=_record_mask),
             ):
                 results = svc.run_inference(
                     clip,
@@ -898,9 +960,11 @@ class TestReprocessSingleFrame:
 
         fake_img = np.zeros((4, 4, 3), dtype=np.float32)
         fake_mask = np.ones((4, 4), dtype=np.float32)
-        with patch.object(svc, "_get_engine_pool", side_effect=_fake_get_engine_pool), patch(
-            "backend.service.read_image_frame", return_value=fake_img
-        ), patch("backend.service.read_mask_frame", return_value=fake_mask):
+        with (
+            patch.object(svc, "_get_engine_pool", side_effect=_fake_get_engine_pool),
+            patch("backend.service.read_image_frame", return_value=fake_img),
+            patch("backend.service.read_mask_frame", return_value=fake_mask),
+        ):
             result = svc.reprocess_single_frame(
                 sample_clip,
                 InferenceParams(),
@@ -946,8 +1010,9 @@ class TestReprocessSingleFrame:
 
             fake_img = np.zeros((4, 4, 3), dtype=np.float32)
             fake_mask = np.ones((4, 4), dtype=np.float32)
-            with patch("backend.service.read_image_frame", return_value=fake_img), patch(
-                "backend.service.read_mask_frame", return_value=fake_mask
+            with (
+                patch("backend.service.read_image_frame", return_value=fake_img),
+                patch("backend.service.read_mask_frame", return_value=fake_mask),
             ):
                 svc.reprocess_single_frame(
                     clip,
@@ -993,8 +1058,9 @@ class TestReprocessSingleFrame:
 
             fake_img = np.zeros((4, 4, 3), dtype=np.float32)
             fake_mask = np.ones((4, 4), dtype=np.float32)
-            with patch("backend.service.read_image_frame", return_value=fake_img), patch(
-                "backend.service.read_mask_frame", return_value=fake_mask
+            with (
+                patch("backend.service.read_image_frame", return_value=fake_img),
+                patch("backend.service.read_mask_frame", return_value=fake_mask),
             ):
                 svc.reprocess_single_frame(
                     clip,
@@ -1046,8 +1112,9 @@ class TestReprocessSingleFrame:
                 read_mask_paths.append(os.path.basename(path))
                 return fake_mask
 
-            with patch("backend.service.read_image_frame", return_value=fake_img), patch(
-                "backend.service.read_mask_frame", side_effect=_record_mask
+            with (
+                patch("backend.service.read_image_frame", return_value=fake_img),
+                patch("backend.service.read_mask_frame", side_effect=_record_mask),
             ):
                 result = svc.reprocess_single_frame(
                     clip,
@@ -1106,7 +1173,9 @@ class TestSam2PreviewInputColorSpace:
             frame_path = os.path.join(frames_dir, "frame_000000.exr")
             with open(frame_path, "w", encoding="utf-8") as handle:
                 handle.write("dummy")
-            with open(os.path.join(tmpdir, ".video_metadata.json"), "w", encoding="utf-8") as handle:
+            with open(
+                os.path.join(tmpdir, ".video_metadata.json"), "w", encoding="utf-8"
+            ) as handle:
                 json.dump({"codec": "prores"}, handle)
 
             clip = ClipEntry(
@@ -1122,13 +1191,16 @@ class TestSam2PreviewInputColorSpace:
                 negative_points=[],
             )
             fake_img = np.full((4, 4, 3), 0.5, dtype=np.float32)
-            with patch(
-                "backend.service.load_annotation_prompt_frames",
-                return_value=[prompt],
-            ), patch(
-                "backend.service.read_image_frame",
-                return_value=fake_img,
-            ) as mock_read:
+            with (
+                patch(
+                    "backend.service.load_annotation_prompt_frames",
+                    return_value=[prompt],
+                ),
+                patch(
+                    "backend.service.read_image_frame",
+                    return_value=fake_img,
+                ) as mock_read,
+            ):
                 result = svc.preview_sam2_prompt(clip, preferred_frame_index=0)
 
         assert result is not None
@@ -1161,13 +1233,16 @@ class TestSam2PreviewInputColorSpace:
                 negative_points=[],
             )
             fake_img = np.full((4, 4, 3), 0.5, dtype=np.float32)
-            with patch(
-                "backend.service.load_annotation_prompt_frames",
-                return_value=[prompt],
-            ), patch(
-                "backend.service.read_image_frame",
-                return_value=fake_img,
-            ) as mock_read:
+            with (
+                patch(
+                    "backend.service.load_annotation_prompt_frames",
+                    return_value=[prompt],
+                ),
+                patch(
+                    "backend.service.read_image_frame",
+                    return_value=fake_img,
+                ) as mock_read,
+            ):
                 result = svc.preview_sam2_prompt(
                     clip,
                     preferred_frame_index=0,
@@ -1203,7 +1278,7 @@ class TestRunGVM:
 
     def test_cancellation_before_gvm(self):
         svc = CorridorKeyService()
-        svc._device = 'cuda'  # skip GPU guard (we're testing cancellation)
+        svc._device = "cuda"  # skip GPU guard (we're testing cancellation)
         svc._active_model = _ActiveModel.GVM
         svc._gvm_processor = MagicMock()
 
@@ -1211,7 +1286,9 @@ class TestRunGVM:
             input_dir = os.path.join(tmpdir, "Input")
             os.makedirs(input_dir)
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.RAW,
+                "test",
+                tmpdir,
+                state=ClipState.RAW,
                 input_asset=ClipAsset(input_dir, "sequence"),
             )
             job = GPUJob(JobType.GVM_ALPHA, "test")

--- a/tests/test_service_concurrency.py
+++ b/tests/test_service_concurrency.py
@@ -3,15 +3,14 @@
 Uses threading.Barrier + time recording to prove process_frame calls
 don't overlap, without asserting Lock.acquire directly.
 """
+
 import threading
 import time
 from unittest.mock import MagicMock
 
 import numpy as np
-import pytest
 
-from backend.service import CorridorKeyService, InferenceParams, OutputConfig, _ActiveModel
-from backend.clip_state import ClipAsset, ClipEntry, ClipState
+from backend.service import CorridorKeyService, InferenceParams, _ActiveModel
 
 
 def _make_slow_engine(delay: float = 0.1):

--- a/tests/test_service_videomama_contract.py
+++ b/tests/test_service_videomama_contract.py
@@ -5,6 +5,7 @@ _load_mask_frames_for_videomama() returns uint8 grayscale [0,255] with
 binary threshold at 10. The inference module expects uint8 for PIL conversion.
 The output from run_inference is uint8 RGB [0,255] (PIL Image -> np.array).
 """
+
 import json
 import os
 import tempfile
@@ -21,7 +22,9 @@ from backend.job_queue import GPUJob, JobType
 
 
 def _write_mask_manifest(root: str, source: str = "sam2") -> None:
-    with open(os.path.join(root, ".corridorkey_mask_manifest.json"), "w", encoding="utf-8") as handle:
+    with open(
+        os.path.join(root, ".corridorkey_mask_manifest.json"), "w", encoding="utf-8"
+    ) as handle:
         json.dump({"source": source, "frame_stems": ["frame_00000"]}, handle)
 
 
@@ -117,7 +120,7 @@ class TestVideoMaMaOutputWrite:
         out_bgr = cv2.cvtColor(frame_u8, cv2.COLOR_RGB2BGR)
         assert out_bgr.dtype == np.uint8
         assert out_bgr[0, 0, 0] == 255  # R=255 -> B=255
-        assert out_bgr[0, 0, 1] == 64   # G=64 -> G=64
+        assert out_bgr[0, 0, 1] == 64  # G=64 -> G=64
         assert out_bgr[0, 0, 2] == 128  # B=128 -> R=128
 
     def test_float_output_produces_valid_png(self):
@@ -136,7 +139,7 @@ class TestVideoMaMaOutputWrite:
         frame = np.array([[[1.5, -0.1, 0.5]]], dtype=np.float32)
         out = (np.clip(frame, 0.0, 1.0) * 255.0).astype(np.uint8)
         assert out[0, 0, 0] == 255  # 1.5 clamped to 1.0
-        assert out[0, 0, 1] == 0    # -0.1 clamped to 0.0
+        assert out[0, 0, 1] == 0  # -0.1 clamped to 0.0
         assert 125 <= out[0, 0, 2] <= 130  # 0.5 → ~128
 
 
@@ -153,7 +156,9 @@ class TestVideoMaMaMissingAssets:
             input_dir = os.path.join(tmpdir, "Input")
             os.makedirs(input_dir)
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.MASKED,
+                "test",
+                tmpdir,
+                state=ClipState.MASKED,
                 input_asset=ClipAsset(input_dir, "sequence"),
             )
             with pytest.raises(CorridorKeyError, match="missing mask asset"):
@@ -164,7 +169,7 @@ class TestVideoMaMaCancellation:
     def test_cancel_between_chunks(self):
         """Cancel is checked between chunks — partial AlphaHint files may exist."""
         svc = CorridorKeyService()
-        svc._device = 'cuda'  # skip GPU guard (we're testing cancellation)
+        svc._device = "cuda"  # skip GPU guard (we're testing cancellation)
         svc._active_model = _ActiveModel.VIDEOMAMA
         svc._videomama_pipeline = MagicMock()
 
@@ -186,7 +191,9 @@ class TestVideoMaMaCancellation:
             _write_mask_manifest(tmpdir)
 
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.MASKED,
+                "test",
+                tmpdir,
+                state=ClipState.MASKED,
                 input_asset=ClipAsset(input_dir, "sequence"),
                 mask_asset=ClipAsset(mask_dir, "sequence"),
             )
@@ -205,10 +212,13 @@ class TestVideoMaMaCancellation:
 
             mock_module = MagicMock()
             mock_module.run_inference = mock_run_inference
-            with patch.dict("sys.modules", {
-                "VideoMaMaInferenceModule": MagicMock(),
-                "VideoMaMaInferenceModule.inference": mock_module,
-            }):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "VideoMaMaInferenceModule": MagicMock(),
+                    "VideoMaMaInferenceModule.inference": mock_module,
+                },
+            ):
                 with pytest.raises(JobCancelledError):
                     svc.run_videomama(clip, job=job)
 
@@ -216,7 +226,9 @@ class TestVideoMaMaCancellation:
 class DummySAM2Tracker:
     model_id = "facebook/sam2.1-hiera-small"
 
-    def track_video(self, frames, prompt_frames, on_progress=None, on_status=None, check_cancel=None):
+    def track_video(
+        self, frames, prompt_frames, on_progress=None, on_status=None, check_cancel=None
+    ):
         assert len(prompt_frames) == 1
         assert prompt_frames[0].frame_index == 0
         assert prompt_frames[0].mask is None
@@ -272,7 +284,9 @@ class TestSAM2Tracking:
                 )
 
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.RAW,
+                "test",
+                tmpdir,
+                state=ClipState.RAW,
                 input_asset=ClipAsset(input_dir, "sequence"),
             )
 
@@ -286,7 +300,9 @@ class TestSAM2Tracking:
             assert clip.state == ClipState.MASKED
             assert not os.path.isdir(alpha_dir)
 
-            with open(os.path.join(tmpdir, ".corridorkey_mask_manifest.json"), "r", encoding="utf-8") as handle:
+            with open(
+                os.path.join(tmpdir, ".corridorkey_mask_manifest.json"), "r", encoding="utf-8"
+            ) as handle:
                 manifest = json.load(handle)
             assert manifest["source"] == "sam2"
             assert manifest["frame_stems"] == ["frame_00000", "frame_00001"]
@@ -321,7 +337,9 @@ class TestSAM2Tracking:
                 )
 
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.RAW,
+                "test",
+                tmpdir,
+                state=ClipState.RAW,
                 input_asset=ClipAsset(input_dir, "sequence"),
             )
 
@@ -365,7 +383,9 @@ class TestSAM2Tracking:
                 )
 
             clip = ClipEntry(
-                "test", tmpdir, state=ClipState.RAW,
+                "test",
+                tmpdir,
+                state=ClipState.RAW,
                 input_asset=ClipAsset(input_dir, "sequence"),
             )
             warnings: list[str] = []

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,4 +1,5 @@
 """Tests for session save/load — JSON sidecar, versioning, forward compat."""
+
 import json
 import os
 import pytest
@@ -32,10 +33,10 @@ class TestSessionData:
             "split_view": False,
         }
         path = os.path.join(str(tmp_path), ".corridorkey_session.json")
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             json.dump(session, f)
 
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             loaded = json.load(f)
 
         assert loaded["version"] == 1
@@ -56,11 +57,11 @@ class TestSessionData:
     def test_corrupt_session_file(self, tmp_path):
         """Corrupt JSON should not crash."""
         path = os.path.join(str(tmp_path), ".corridorkey_session.json")
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             f.write("{invalid json")
 
         with pytest.raises(json.JSONDecodeError):
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 json.load(f)
 
     def test_atomic_write_pattern(self, tmp_path):
@@ -69,12 +70,12 @@ class TestSessionData:
         tmp_path_file = path + ".tmp"
 
         data = {"version": 1, "test": True}
-        with open(tmp_path_file, 'w') as f:
+        with open(tmp_path_file, "w") as f:
             json.dump(data, f)
         os.rename(tmp_path_file, path)
 
         assert os.path.isfile(path)
         assert not os.path.exists(tmp_path_file)
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             loaded = json.load(f)
         assert loaded["test"] is True

--- a/tests/test_thumbnail_worker.py
+++ b/tests/test_thumbnail_worker.py
@@ -1,5 +1,4 @@
 """Tests for thumbnail generation using the viewer decode path."""
-import os
 
 import pytest
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,5 @@
 """Tests for backend.validators module."""
+
 import os
 import tempfile
 
@@ -25,6 +26,7 @@ from backend.errors import (
 
 # --- validate_frame_counts ---
 
+
 class TestValidateFrameCounts:
     def test_matching_counts(self):
         assert validate_frame_counts("shot1", 100, 100) == 100
@@ -34,6 +36,7 @@ class TestValidateFrameCounts:
 
     def test_mismatch_non_strict_logs_warning(self, caplog):
         import logging
+
         with caplog.at_level(logging.WARNING):
             validate_frame_counts("shot1", 100, 80)
         assert "frame count mismatch" in caplog.text
@@ -46,6 +49,7 @@ class TestValidateFrameCounts:
 
 
 # --- normalize_mask_channels ---
+
 
 class TestNormalizeMaskChannels:
     def test_2d_passthrough(self):
@@ -91,18 +95,19 @@ class TestNormalizeMaskChannels:
 
 # --- normalize_mask_dtype ---
 
+
 class TestNormalizeMaskDtype:
     def test_uint8(self):
         mask = np.array([0, 128, 255], dtype=np.uint8)
         result = normalize_mask_dtype(mask)
         assert result.dtype == np.float32
-        np.testing.assert_allclose(result, [0.0, 128/255.0, 1.0], atol=1e-5)
+        np.testing.assert_allclose(result, [0.0, 128 / 255.0, 1.0], atol=1e-5)
 
     def test_uint16(self):
         mask = np.array([0, 32768, 65535], dtype=np.uint16)
         result = normalize_mask_dtype(mask)
         assert result.dtype == np.float32
-        np.testing.assert_allclose(result, [0.0, 32768/65535.0, 1.0], atol=1e-5)
+        np.testing.assert_allclose(result, [0.0, 32768 / 65535.0, 1.0], atol=1e-5)
 
     def test_float32_passthrough(self):
         mask = np.array([0.0, 0.5, 1.0], dtype=np.float32)
@@ -116,6 +121,7 @@ class TestNormalizeMaskDtype:
 
 
 # --- validate_frame_read ---
+
 
 class TestValidateFrameRead:
     def test_valid_frame(self):
@@ -132,6 +138,7 @@ class TestValidateFrameRead:
 
 # --- validate_write ---
 
+
 class TestValidateWrite:
     def test_success(self):
         validate_write(True, "shot1", 0, "/path/frame.exr")
@@ -144,15 +151,16 @@ class TestValidateWrite:
 
 # --- ensure_output_dirs ---
 
+
 class TestEnsureOutputDirs:
     def test_creates_dirs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             dirs = ensure_output_dirs(tmpdir)
-            assert os.path.isdir(dirs['root'])
-            assert os.path.isdir(dirs['fg'])
-            assert os.path.isdir(dirs['matte'])
-            assert os.path.isdir(dirs['comp'])
-            assert os.path.isdir(dirs['processed'])
+            assert os.path.isdir(dirs["root"])
+            assert os.path.isdir(dirs["fg"])
+            assert os.path.isdir(dirs["matte"])
+            assert os.path.isdir(dirs["comp"])
+            assert os.path.isdir(dirs["processed"])
 
     def test_idempotent(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -162,6 +170,7 @@ class TestEnsureOutputDirs:
 
 
 # --- read_mask_frame integration (regression for dtype→channel ordering bug) ---
+
 
 class TestReadMaskFrameNormalization:
     """Regression: read_mask_frame must normalize dtype BEFORE extracting channels.

--- a/tests/test_validators_edge.py
+++ b/tests/test_validators_edge.py
@@ -4,6 +4,7 @@ Covers dtype casting behaviour for non-standard integer types, boundary frame
 counts, unexpected array dimensions, empty/minimal frames, and directory
 creation idempotency.
 """
+
 import os
 import tempfile
 
@@ -23,6 +24,7 @@ from backend.errors import MaskChannelError
 # ---------------------------------------------------------------------------
 # normalize_mask_dtype — non-standard integer dtypes
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeMaskDtypeEdge:
     """normalize_mask_dtype falls through to the bare astype(float32) branch
@@ -66,6 +68,7 @@ class TestNormalizeMaskDtypeEdge:
 # validate_frame_counts — boundary counts
 # ---------------------------------------------------------------------------
 
+
 class TestValidateFrameCountsEdge:
     def test_both_zero_returns_zero(self):
         # min(0, 0) == 0; no mismatch, no warning.
@@ -83,6 +86,7 @@ class TestValidateFrameCountsEdge:
 # ---------------------------------------------------------------------------
 # normalize_mask_channels — unsupported dimensions
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeMaskChannelsEdge:
     def test_1d_raises_mask_channel_error(self):
@@ -105,6 +109,7 @@ class TestNormalizeMaskChannelsEdge:
 # validate_frame_read — empty and minimal valid arrays
 # ---------------------------------------------------------------------------
 
+
 class TestValidateFrameReadEdge:
     def test_empty_array_shape_passes(self):
         # An array with a zero dimension is NOT None — it passes validation.
@@ -121,6 +126,7 @@ class TestValidateFrameReadEdge:
 # ---------------------------------------------------------------------------
 # ensure_output_dirs — nested creation and idempotency
 # ---------------------------------------------------------------------------
+
 
 class TestEnsureOutputDirsEdge:
     def test_nested_creation_creates_all_subdirs(self):

--- a/tests/test_verify_torch_runtime.py
+++ b/tests/test_verify_torch_runtime.py
@@ -88,7 +88,9 @@ def test_collect_runtime_info_skips_torch_cuda_on_macos(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
     monkeypatch.delitem(sys.modules, "torchvision", raising=False)
-    monkeypatch.setattr(verify_torch_runtime.platform, "platform", lambda: "macOS-15.0-arm64-arm-64bit")
+    monkeypatch.setattr(
+        verify_torch_runtime.platform, "platform", lambda: "macOS-15.0-arm64-arm-64bit"
+    )
     monkeypatch.setattr(verify_torch_runtime, "find_nvidia_smi", lambda: "")
 
     info = verify_torch_runtime.collect_runtime_info()

--- a/ui/app.py
+++ b/ui/app.py
@@ -4,6 +4,7 @@ Fonts:
   - Gagarin: Logo / brand mark text (identity font)
   - Open Sans: All secondary / body UI text (default app font)
 """
+
 from __future__ import annotations
 
 import sys
@@ -13,7 +14,7 @@ import logging
 
 from PySide6.QtWidgets import QApplication, QMessageBox, QDialogButtonBox
 from PySide6.QtGui import QFontDatabase, QFont, QIcon
-from PySide6.QtCore import Qt, QObject, QEvent
+from PySide6.QtCore import QObject, QEvent
 
 from ui.theme import load_stylesheet
 
@@ -47,7 +48,8 @@ def _configure_runtime_backends() -> None:
     # so the first batch of frames ran without TF32 tensor-core acceleration.
     try:
         import torch
-        torch.set_float32_matmul_precision('high')
+
+        torch.set_float32_matmul_precision("high")
         torch.backends.cudnn.benchmark = False
         logger.info("CUDA globals: TF32 precision='high', cuDNN benchmark=off")
     except ImportError:
@@ -60,6 +62,7 @@ def _configure_runtime_backends() -> None:
     # Without this, Windows 11 aggressively throttles background processes,
     # starving our GPU worker thread of CPU time and stalling CUDA inference.
     try:
+
         class _POWER_THROTTLING_STATE(ctypes.Structure):
             _fields_ = [
                 ("Version", ctypes.c_ulong),
@@ -83,8 +86,7 @@ def _configure_runtime_backends() -> None:
         if ok:
             logger.info("Disabled Windows power throttling (EcoQoS)")
         else:
-            logger.debug("SetProcessInformation failed: %s",
-                         ctypes.get_last_error())
+            logger.debug("SetProcessInformation failed: %s", ctypes.get_last_error())
     except Exception as exc:
         logger.debug("Power throttling opt-out skipped: %s", exc)
 
@@ -96,8 +98,7 @@ def _configure_runtime_backends() -> None:
     try:
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
         ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000
-        if kernel32.SetPriorityClass(kernel32.GetCurrentProcess(),
-                                     ABOVE_NORMAL_PRIORITY_CLASS):
+        if kernel32.SetPriorityClass(kernel32.GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS):
             logger.info("Process priority set to ABOVE_NORMAL")
         else:
             logger.debug("SetPriorityClass failed: %s", ctypes.get_last_error())
@@ -106,6 +107,7 @@ def _configure_runtime_backends() -> None:
 
     try:
         import cv2
+
         cv2.setNumThreads(1)
     except Exception as exc:
         logger.debug(f"OpenCV thread tuning skipped: {exc}")
@@ -118,6 +120,7 @@ def _migrate_legacy_settings() -> None:
     New: HKCU\\Software\\EZSCAPE\\EZ-CorridorKey
     """
     from PySide6.QtCore import QSettings
+
     new = QSettings()  # Uses current org/app (EZSCAPE / EZ-CorridorKey)
     if new.value("_migrated_from_legacy", False, type=bool):
         return
@@ -152,7 +155,7 @@ def create_app(argv: list[str] | None = None) -> QApplication:
     _migrate_legacy_settings()
 
     # ── Font loading (frozen-build aware) ──
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         base = sys._MEIPASS
         fonts_dir = os.path.join(base, "ui", "theme", "fonts")
     else:
@@ -209,7 +212,11 @@ def create_app(argv: list[str] | None = None) -> QApplication:
 
     # Set app icon (window title bar + taskbar) — ICO preferred for window chrome
     # (corridorkey.svg is the brand logo used on the welcome screen, not the app icon)
-    theme_dir = os.path.join(base, "ui", "theme") if getattr(sys, 'frozen', False) else os.path.join(base, "theme")
+    theme_dir = (
+        os.path.join(base, "ui", "theme")
+        if getattr(sys, "frozen", False)
+        else os.path.join(base, "theme")
+    )
     ico_icon = os.path.join(theme_dir, "corridorkey.ico")
     png_icon = os.path.join(theme_dir, "corridorkey.png")
     if os.path.isfile(ico_icon):
@@ -219,6 +226,7 @@ def create_app(argv: list[str] | None = None) -> QApplication:
 
     # Install unified click sound — every QPushButton gets click sound automatically
     from ui.sounds.audio_manager import install_global_click_sound
+
     install_global_click_sound(app)
 
     # Center buttons on all QMessageBox dialogs globally

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -14,37 +14,40 @@ Layout:
     |  [progress]  frame counter  warnings  [RUN/STOP]     |
     +----------------------------------------------------------+
 """
+
 from __future__ import annotations
 
 import glob as glob_module
-import json
 import logging
 import os
-import re
 import shutil
-import sys
 
 import cv2
 import numpy as np
 from PySide6.QtWidgets import (
-    QMainWindow, QSplitter, QVBoxLayout, QWidget,
-    QLabel, QHBoxLayout, QMessageBox, QStackedWidget,
-    QProgressBar, QFileDialog, QInputDialog, QGraphicsOpacityEffect,
-    QPushButton,
+    QMainWindow,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+    QLabel,
+    QHBoxLayout,
+    QMessageBox,
+    QStackedWidget,
+    QProgressBar,
+    QGraphicsOpacityEffect,
 )
-from PySide6.QtCore import Qt, Slot, QTimer, QPropertyAnimation, QEasingCurve, QSettings, QThread, Signal
-from PySide6.QtGui import QKeySequence, QAction, QImage, QPainter
+from PySide6.QtCore import Qt, Slot, QTimer, QPropertyAnimation, QEasingCurve, QThread, Signal
+from PySide6.QtGui import QImage, QPainter
 
 from backend import (
-    CorridorKeyService, ClipAsset, ClipEntry, ClipState, InferenceParams,
-    InOutRange, OutputConfig, JobType,
-    PipelineRoute, classify_pipeline_route, mask_sequence_is_videomama_ready,
+    CorridorKeyService,
+    ClipEntry,
+    ClipState,
+    JobType,
 )
-from backend.project import VIDEO_FILE_FILTER, is_video_file
+from backend.project import is_video_file
 
 from ui.models.clip_model import ClipListModel
-from ui.preview.frame_index import ViewMode
-from ui.preview.display_transform import processed_rgba_to_qimage
 from ui.widgets.dual_viewer import DualViewerPanel
 from ui.widgets.parameter_panel import ParameterPanel
 from ui.widgets.status_bar import StatusBar
@@ -52,14 +55,9 @@ from ui.widgets.queue_panel import QueuePanel
 from ui.widgets.io_tray_panel import IOTrayPanel
 from ui.widgets.welcome_screen import WelcomeScreen
 from ui.widgets.preferences_dialog import (
-    PreferencesDialog, KEY_SHOW_TOOLTIPS, DEFAULT_SHOW_TOOLTIPS,
-    KEY_COPY_SOURCE, DEFAULT_COPY_SOURCE,
-    KEY_COPY_SEQUENCES, DEFAULT_COPY_SEQUENCES,
-    KEY_TRACKER_MODEL, DEFAULT_TRACKER_MODEL,
-    KEY_MODEL_RESOLUTION, DEFAULT_MODEL_RESOLUTION,
-    get_setting_bool, get_setting_str, get_setting_int,
+    get_setting_int,
 )
-from ui.workers.gpu_job_worker import GPUJobWorker, create_job_snapshot
+from ui.workers.gpu_job_worker import GPUJobWorker
 from ui.workers.gpu_monitor import GPUMonitor
 from ui.workers.thumbnail_worker import ThumbnailGenerator
 from ui.workers.extract_worker import ExtractWorker
@@ -67,21 +65,28 @@ from ui.recent_sessions import RecentSessionsStore
 from ui.shortcut_registry import ShortcutRegistry
 
 from ui.main_window_mixins import (
-    MenuMixin, ShortcutsMixin, ClipMixin, ImportMixin,
-    InferenceMixin, AlphaImportMixin, ModelRunMixin, CancelMixin,
-    WorkerMixin, AnnotationMixin,
-    ExportMixin, SessionMixin, SettingsMixin,
+    MenuMixin,
+    ShortcutsMixin,
+    ClipMixin,
+    ImportMixin,
+    InferenceMixin,
+    AlphaImportMixin,
+    ModelRunMixin,
+    CancelMixin,
+    WorkerMixin,
+    AnnotationMixin,
+    ExportMixin,
+    SessionMixin,
+    SettingsMixin,
 )
 
 logger = logging.getLogger(__name__)
 
 
-
 class _Toast(QLabel):
     """Non-blocking notification that auto-fades after a duration. Click to dismiss."""
 
-    def __init__(self, parent: QWidget, text: str, duration_ms: int = 4000,
-                 center: bool = False):
+    def __init__(self, parent: QWidget, text: str, duration_ms: int = 4000, center: bool = False):
         super().__init__(text, parent)
         self.setWordWrap(True)
         self.setAlignment(Qt.AlignCenter)
@@ -186,7 +191,7 @@ class _MuteOverlay(QLabel):
             "font-family: 'Open Sans'; font-size: 11px; font-weight: 600;"
         )
         # Position inside the brand bar (top strip, ~24px tall)
-        menu_h = parent.menuBar().height() if hasattr(parent, 'menuBar') else 22
+        menu_h = parent.menuBar().height() if hasattr(parent, "menuBar") else 22
         self.move((parent.width() - self._FIXED_W) // 2, menu_h + 2)
         self._opacity = QGraphicsOpacityEffect(self)
         self._opacity.setOpacity(1.0)
@@ -203,6 +208,7 @@ class _MuteOverlay(QLabel):
 
 class _UpdateChecker(QThread):
     """Background thread that checks GitHub for a newer version."""
+
     update_available = Signal(str)  # emits the remote version string
 
     def __init__(self, local_version: str):
@@ -212,10 +218,8 @@ class _UpdateChecker(QThread):
     def run(self):
         try:
             import urllib.request
-            url = (
-                "https://raw.githubusercontent.com/edenaion/EZ-CorridorKey"
-                "/main/pyproject.toml"
-            )
+
+            url = "https://raw.githubusercontent.com/edenaion/EZ-CorridorKey/main/pyproject.toml"
             req = urllib.request.Request(url, headers={"User-Agent": "CorridorKey"})
             with urllib.request.urlopen(req, timeout=10) as resp:
                 text = resp.read().decode("utf-8")
@@ -233,18 +237,27 @@ class _UpdateChecker(QThread):
         """Simple semver comparison: 1.4.0 > 1.3.1."""
         try:
             r = tuple(int(x) for x in remote.split("."))
-            l = tuple(int(x) for x in local.split("."))
-            return r > l
+            local_ver = tuple(int(x) for x in local.split("."))
+            return r > local_ver
         except (ValueError, AttributeError):
             return False
 
 
 class MainWindow(
     QMainWindow,
-    MenuMixin, ShortcutsMixin, ClipMixin, ImportMixin,
-    InferenceMixin, AlphaImportMixin, ModelRunMixin, CancelMixin,
-    WorkerMixin, AnnotationMixin,
-    ExportMixin, SessionMixin, SettingsMixin,
+    MenuMixin,
+    ShortcutsMixin,
+    ClipMixin,
+    ImportMixin,
+    InferenceMixin,
+    AlphaImportMixin,
+    ModelRunMixin,
+    CancelMixin,
+    WorkerMixin,
+    AnnotationMixin,
+    ExportMixin,
+    SessionMixin,
+    SettingsMixin,
 ):
     """CorridorKey main application window."""
 
@@ -252,7 +265,7 @@ class MainWindow(
 
     def _warn_mps_slow(self, feature_name: str) -> bool:
         """Show a one-time performance warning on MPS. Returns False if user cancels."""
-        if getattr(self._service, '_device', '') != 'mps':
+        if getattr(self._service, "_device", "") != "mps":
             return True
         if MainWindow._mps_warning_acknowledged:
             return True
@@ -273,8 +286,9 @@ class MainWindow(
             return True
         return False
 
-    def __init__(self, service: CorridorKeyService | None = None,
-                 store: RecentSessionsStore | None = None):
+    def __init__(
+        self, service: CorridorKeyService | None = None, store: RecentSessionsStore | None = None
+    ):
         super().__init__()
         self.setWindowTitle("EZ-CorridorKey")
         self.setMinimumSize(1100, 650)
@@ -294,7 +308,6 @@ class MainWindow(
             self._container_mode = False
             self.resize(1400, 800)
 
-
         self.setAcceptDrops(True)
 
         self._service = service or CorridorKeyService()
@@ -313,6 +326,7 @@ class MainWindow(
         self._pipeline_steps: dict[str, list[JobType]] = {}
         # Debug console — created eagerly so log handler captures from startup
         from ui.widgets.debug_console import DebugConsoleWidget
+
         self._debug_console = DebugConsoleWidget()
         self._prefs_dialog = None
 
@@ -348,8 +362,10 @@ class MainWindow(
 
         # Workers
         from ui.widgets.preferences_dialog import (
-            get_setting_int, KEY_PARALLEL_CLIPS, DEFAULT_PARALLEL_CLIPS,
+            KEY_PARALLEL_CLIPS,
+            DEFAULT_PARALLEL_CLIPS,
         )
+
         self._gpu_worker = GPUJobWorker(
             self._service,
             max_workers=get_setting_int(KEY_PARALLEL_CLIPS, DEFAULT_PARALLEL_CLIPS),
@@ -651,9 +667,7 @@ class MainWindow(
             input_path=clip.input_asset.path,
             asset_type=clip.input_asset.asset_type,
             input_exr_is_linear=(
-                clip.should_default_input_linear()
-                if input_is_linear is None
-                else input_is_linear
+                clip.should_default_input_linear() if input_is_linear is None else input_is_linear
             ),
         )
 
@@ -680,9 +694,7 @@ class MainWindow(
             return
 
         # Cache the gradient image, regenerate only on resize
-        if (self._bg_cache is None
-                or self._bg_cache.width() != w
-                or self._bg_cache.height() != h):
+        if self._bg_cache is None or self._bg_cache.width() != w or self._bg_cache.height() != h:
             self._bg_cache = self._render_dithered_gradient(w, h)
 
         painter = QPainter(self)
@@ -720,14 +732,13 @@ class MainWindow(
         qimg = QImage(img_u8.data, w, h, bytes_per_line, QImage.Format.Format_RGB888)
         return qimg.copy()  # deep copy so numpy buffer can be freed
 
-
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
         self._position_queue_panel()
 
     def _position_queue_panel(self) -> None:
         """Keep the floating queue panel sized to the viewer area height."""
-        if hasattr(self, '_workspace') and hasattr(self, '_queue_panel'):
+        if hasattr(self, "_workspace") and hasattr(self, "_queue_panel"):
             # Use the top section height (viewer+params) not the full workspace
             sizes = self._vsplitter.sizes()
             h = sizes[0] if sizes else self._workspace.height()
@@ -740,6 +751,7 @@ class MainWindow(
     def dragEnterEvent(self, event) -> None:
         if event.mimeData().hasUrls():
             from backend.project import is_video_file, is_image_file
+
             for url in event.mimeData().urls():
                 path = url.toLocalFile()
                 if os.path.isdir(path) or is_video_file(path) or is_image_file(path):
@@ -748,6 +760,7 @@ class MainWindow(
 
     def dropEvent(self, event) -> None:
         from backend.project import is_video_file, is_image_file, folder_has_image_sequence
+
         folders = []
         video_files = []
         image_files = []

--- a/ui/main_window_mixins/__init__.py
+++ b/ui/main_window_mixins/__init__.py
@@ -13,8 +13,17 @@ from .session_mixin import SessionMixin
 from .settings_mixin import SettingsMixin
 
 __all__ = [
-    "MenuMixin", "ShortcutsMixin", "ClipMixin", "ImportMixin",
-    "InferenceMixin", "AlphaImportMixin", "ModelRunMixin", "CancelMixin",
-    "WorkerMixin", "AnnotationMixin",
-    "ExportMixin", "SessionMixin", "SettingsMixin",
+    "MenuMixin",
+    "ShortcutsMixin",
+    "ClipMixin",
+    "ImportMixin",
+    "InferenceMixin",
+    "AlphaImportMixin",
+    "ModelRunMixin",
+    "CancelMixin",
+    "WorkerMixin",
+    "AnnotationMixin",
+    "ExportMixin",
+    "SessionMixin",
+    "SettingsMixin",
 ]

--- a/ui/main_window_mixins/alpha_import_mixin.py
+++ b/ui/main_window_mixins/alpha_import_mixin.py
@@ -24,7 +24,11 @@ class AlphaImportMixin:
         frames named to match input frame stems so index-based matching in
         the inference loop works correctly (frame 0 -> frame 0, etc.).
         """
-        from ui.main_window import _remove_alpha_hint_assets, _import_alpha_video_as_sequence, _Toast
+        from ui.main_window import (
+            _remove_alpha_hint_assets,
+            _import_alpha_video_as_sequence,
+            _Toast,
+        )
 
         clip = self._current_clip
         if clip is None or clip.state not in (ClipState.RAW, ClipState.MASKED, ClipState.READY):
@@ -35,16 +39,17 @@ class AlphaImportMixin:
         # If AlphaHint already exists, ask before replacing
         alpha_dir = os.path.join(clip.root_path, "AlphaHint")
         alpha_video_candidates = [
-            c for c in glob_module.glob(os.path.join(clip.root_path, "AlphaHint.*"))
+            c
+            for c in glob_module.glob(os.path.join(clip.root_path, "AlphaHint.*"))
             if os.path.isfile(c) and is_video_file(c)
         ]
-        has_existing_alpha = (
-            (os.path.isdir(alpha_dir) and os.listdir(alpha_dir))
-            or bool(alpha_video_candidates)
+        has_existing_alpha = (os.path.isdir(alpha_dir) and os.listdir(alpha_dir)) or bool(
+            alpha_video_candidates
         )
         if has_existing_alpha:
             result = QMessageBox.question(
-                self, "Replace Alpha Hints?",
+                self,
+                "Replace Alpha Hints?",
                 f"Clip '{clip.name}' already has alpha hint images.\n\n"
                 "Do you want to replace them with new ones?",
                 QMessageBox.Yes | QMessageBox.No,
@@ -66,7 +71,8 @@ class AlphaImportMixin:
         clicked = picker.clickedButton()
         if clicked == folder_btn:
             source_path = QFileDialog.getExistingDirectory(
-                self, "Select Alpha Hint Folder",
+                self,
+                "Select Alpha Hint Folder",
                 "",
                 QFileDialog.ShowDirsOnly,
             )
@@ -96,7 +102,8 @@ class AlphaImportMixin:
 
             if not src_files:
                 QMessageBox.warning(
-                    self, "No Images",
+                    self,
+                    "No Images",
                     "No image files found in the selected folder.\n"
                     "Expected grayscale images (white=foreground, black=background).",
                 )
@@ -108,7 +115,8 @@ class AlphaImportMixin:
             n_src = alpha_video.frame_count
             if n_src <= 0:
                 QMessageBox.warning(
-                    self, "Unreadable Video",
+                    self,
+                    "Unreadable Video",
                     "Could not read frame count from the selected alpha video.",
                 )
                 return
@@ -118,8 +126,7 @@ class AlphaImportMixin:
         def _natural_key(path: str):
             """Sort key that handles any zero-padding scheme correctly."""
             name = os.path.basename(path)
-            return [int(c) if c.isdigit() else c.lower()
-                    for c in re_module.split(r'(\d+)', name)]
+            return [int(c) if c.isdigit() else c.lower() for c in re_module.split(r"(\d+)", name)]
 
         src_files.sort(key=_natural_key)
 
@@ -129,7 +136,8 @@ class AlphaImportMixin:
 
         if n_src != n_input:
             result = QMessageBox.warning(
-                self, "Frame Count Mismatch",
+                self,
+                "Frame Count Mismatch",
                 f"Clip '{clip.name}' has {n_input} input frames but you "
                 f"selected {n_src} alpha hints.\n\n"
                 f"Each input frame needs a matching alpha hint.\n"
@@ -168,7 +176,9 @@ class AlphaImportMixin:
                     shutil.rmtree(alpha_dir, ignore_errors=True)
                 logger.info(
                     "Imported %d/%d alpha frames from video into %s",
-                    imported_count, n_paired, alpha_dir,
+                    imported_count,
+                    n_paired,
+                    alpha_dir,
                 )
             else:
                 os.makedirs(alpha_dir, exist_ok=True)
@@ -194,7 +204,9 @@ class AlphaImportMixin:
                     shutil.rmtree(alpha_dir, ignore_errors=True)
                 logger.info(
                     "Imported %d/%d alpha hints into %s (renamed to match input stems)",
-                    imported_count, n_paired, alpha_dir,
+                    imported_count,
+                    n_paired,
+                    alpha_dir,
                 )
         except OSError as exc:
             QMessageBox.critical(

--- a/ui/main_window_mixins/annotation_mixin.py
+++ b/ui/main_window_mixins/annotation_mixin.py
@@ -36,6 +36,7 @@ class AnnotationMixin:
     def _cycle_fg_color(self) -> None:
         """Hotkey C: cycle foreground annotation color (green/blue)."""
         from ui.widgets.annotation_overlay import cycle_fg_color
+
         name = cycle_fg_color()
         self._dual_viewer.input_viewer.update()
         self._show_toast(f"Foreground color: {name}")
@@ -84,7 +85,8 @@ class AnnotationMixin:
         model = iv.annotation_model
         if not model.has_annotations():
             QMessageBox.information(
-                self, "No Paint Strokes",
+                self,
+                "No Paint Strokes",
                 "Paint green (1) and red (2) strokes on frames first.",
             )
             return
@@ -92,7 +94,9 @@ class AnnotationMixin:
         if not self._warn_mps_slow("SAM2 Track Mask"):
             return
 
-        job = create_job_snapshot(clip, self._param_panel.get_params(), job_type=JobType.SAM2_PREVIEW)
+        job = create_job_snapshot(
+            clip, self._param_panel.get_params(), job_type=JobType.SAM2_PREVIEW
+        )
         job.params["_frame_index"] = max(0, self._dual_viewer.current_stem_index)
         if not self._service.job_queue.submit(job):
             return
@@ -107,7 +111,8 @@ class AnnotationMixin:
         alpha_dir = os.path.join(clip.root_path, "AlphaHint")
         if os.path.isdir(alpha_dir):
             reply = QMessageBox.question(
-                self, "Replace Existing Alpha?",
+                self,
+                "Replace Existing Alpha?",
                 "This clip already has an AlphaHint (from GVM or a previous run).\n\n"
                 "Tracking a new mask sequence will replace that alpha hint.\n\n"
                 "Remove existing AlphaHint and proceed?",
@@ -201,9 +206,7 @@ class AnnotationMixin:
         model = iv.annotation_model
         fi = iv._frame_index
         total = fi.frame_count if fi else 0
-        self._param_panel.set_annotation_info(
-            model.annotated_frame_count(), total
-        )
+        self._param_panel.set_annotation_info(model.annotated_frame_count(), total)
         # Push annotation coverage to the scrubber timeline
         if fi and total > 0:
             annotated = [model.has_annotations(i) for i in range(total)]

--- a/ui/main_window_mixins/cancel_mixin.py
+++ b/ui/main_window_mixins/cancel_mixin.py
@@ -50,8 +50,9 @@ class CancelMixin:
                 # Check if frames already exist -> RAW, else back to VIDEO
                 frames_dir = os.path.join(clip.root_path, "Frames")
                 input_dir = os.path.join(clip.root_path, "Input")
-                has_frames = (os.path.isdir(frames_dir) and os.listdir(frames_dir)) or \
-                             (os.path.isdir(input_dir) and os.listdir(input_dir))
+                has_frames = (os.path.isdir(frames_dir) and os.listdir(frames_dir)) or (
+                    os.path.isdir(input_dir) and os.listdir(input_dir)
+                )
                 new_state = ClipState.RAW if has_frames else ClipState.ERROR
                 self._clip_model.update_clip_state(clip.name, new_state)
         self._io_tray.refresh()
@@ -64,8 +65,7 @@ class CancelMixin:
 
         queue = self._service.job_queue
         current_job = queue.current_job
-        is_videomama = (queue.current_job
-                        and queue.current_job.job_type == JobType.VIDEOMAMA_ALPHA)
+        is_videomama = queue.current_job and queue.current_job.job_type == JobType.VIDEOMAMA_ALPHA
         self._cancel_requested_job_id = current_job.id if current_job is not None else None
         queue.cancel_all()
         self._pipeline_steps.clear()
@@ -85,9 +85,11 @@ class CancelMixin:
         self._queue_panel.refresh()
         logger.info("Processing cancelled by user")
         if is_videomama:
-            _Toast(self, "GPU is finishing the current chunk.\n"
-                         "VideoMaMa will stop after it completes.",
-                   center=True)
+            _Toast(
+                self,
+                "GPU is finishing the current chunk.\nVideoMaMa will stop after it completes.",
+                center=True,
+            )
 
     def _force_restart_app(self) -> None:
         """Hard-stop a blocked GPU phase by relaunching the app process."""
@@ -112,9 +114,8 @@ class CancelMixin:
 
         kwargs: dict = {"cwd": cwd}
         if os.name == "nt":
-            kwargs["creationflags"] = (
-                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-                | getattr(subprocess, "DETACHED_PROCESS", 0)
+            kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(
+                subprocess, "DETACHED_PROCESS", 0
             )
         else:
             kwargs["start_new_session"] = True
@@ -147,7 +148,8 @@ class CancelMixin:
 
         if self._force_stop_armed:
             reply = QMessageBox.question(
-                self, "Force Stop",
+                self,
+                "Force Stop",
                 "The current GPU step has not returned to Python.\n\n"
                 "Force Stop will auto-save the session and relaunch the app "
                 "to break the stuck job immediately.\n\n"
@@ -161,7 +163,8 @@ class CancelMixin:
             return
 
         reply = QMessageBox.question(
-            self, "Cancel",
+            self,
+            "Cancel",
             "Cancel processing?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
@@ -170,6 +173,7 @@ class CancelMixin:
             return
 
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.user_cancel()
         self._cancel_inference()
 

--- a/ui/main_window_mixins/clip_mixin.py
+++ b/ui/main_window_mixins/clip_mixin.py
@@ -66,8 +66,7 @@ class ClipMixin:
         if batch_count > 1:
             # Check if any clip needs alpha generation (pipeline mode)
             needs_pipeline = any(
-                classify_pipeline_route(c) not in (
-                    PipelineRoute.INFERENCE_ONLY, PipelineRoute.SKIP)
+                classify_pipeline_route(c) not in (PipelineRoute.INFERENCE_ONLY, PipelineRoute.SKIP)
                 for c in clips
             )
             self._status_bar.update_button_state(
@@ -82,7 +81,9 @@ class ClipMixin:
             self._refresh_button_state()
         else:
             self._status_bar.update_button_state(
-                can_run=False, has_partial=False, has_in_out=False,
+                can_run=False,
+                has_partial=False,
+                has_in_out=False,
             )
 
     # ── Clip Selection ──
@@ -140,7 +141,9 @@ class ClipMixin:
 
     @Slot(str)
     def _on_clips_dir_changed(
-        self, dir_path: str, *,
+        self,
+        dir_path: str,
+        *,
         skip_session_restore: bool = False,
         select_clip: str | None = None,
     ) -> None:
@@ -150,24 +153,26 @@ class ClipMixin:
         # Reset status bar state on project load (no active job)
         self._status_bar.set_running(False)
         self._status_bar.update_button_state(
-            can_run=False, has_partial=False, has_in_out=False,
+            can_run=False,
+            has_partial=False,
+            has_in_out=False,
         )
         # Ensure workspace is visible (may come from welcome screen or menu)
         self._switch_to_workspace()
         try:
             # Detect if this is the Projects root (no standalone videos there)
             from backend.project import projects_root as _projects_root, get_display_name
+
             is_projects = os.path.normcase(os.path.abspath(dir_path)) == os.path.normcase(
                 os.path.abspath(_projects_root())
             )
             clips = self._service.scan_clips(
-                dir_path, allow_standalone_videos=not is_projects,
+                dir_path,
+                allow_standalone_videos=not is_projects,
             )
-            if (
-                previous_clips_dir is None
-                or os.path.normcase(os.path.abspath(previous_clips_dir))
-                != os.path.normcase(os.path.abspath(dir_path))
-            ):
+            if previous_clips_dir is None or os.path.normcase(
+                os.path.abspath(previous_clips_dir)
+            ) != os.path.normcase(os.path.abspath(dir_path)):
                 self._clip_input_is_linear = {}
             else:
                 current_names = {clip.name for clip in clips}
@@ -201,7 +206,8 @@ class ClipMixin:
 
             # Register in recent sessions store — per-project, not per-clip
             if is_projects:
-                from backend.project import is_v2_project, get_clip_dirs
+                from backend.project import get_clip_dirs
+
                 # Group clips by their project container
                 registered: set[str] = set()
                 for clip in clips:
@@ -219,10 +225,13 @@ class ClipMixin:
                         proj_name = get_display_name(project_path)
                         clip_count = len(get_clip_dirs(project_path))
                         self._recent_store.add_or_update(
-                            project_path, proj_name, clip_count,
+                            project_path,
+                            proj_name,
+                            clip_count,
                         )
             else:
                 from backend.project import is_v2_project as _is_v2
+
                 if _is_v2(dir_path):
                     display_name = get_display_name(dir_path)
                 else:
@@ -239,6 +248,7 @@ class ClipMixin:
             logger.error(f"Failed to scan clips: {e}")
             from ui.sounds.audio_manager import UIAudio
             from PySide6.QtWidgets import QMessageBox
+
             UIAudio.error()
             QMessageBox.critical(self, "Scan Error", f"Failed to scan clips directory:\n{e}")
 

--- a/ui/main_window_mixins/export_mixin.py
+++ b/ui/main_window_mixins/export_mixin.py
@@ -58,7 +58,9 @@ class ExportMixin:
                 clip.input_asset.path = target
 
             self._extract_worker.submit(
-                clip.name, clip.input_asset.path, clip.root_path,
+                clip.name,
+                clip.input_asset.path,
+                clip.root_path,
             )
         self._status_bar.start_job_timer(label="Extracting")
         logger.info(f"Auto-extraction queued: {len(extracting)} clip(s)")
@@ -93,10 +95,11 @@ class ExportMixin:
                             os.makedirs(target, exist_ok=True)
                             logger.info(f"Cleared {subdir}/ for retry: {clip.name}")
                     clip.error_message = None
-                    self._clip_model.update_clip_state(
-                        clip.name, ClipState.EXTRACTING)
+                    self._clip_model.update_clip_state(clip.name, ClipState.EXTRACTING)
                 self._extract_worker.submit(
-                    clip.name, clip.input_asset.path, clip.root_path,
+                    clip.name,
+                    clip.input_asset.path,
+                    clip.root_path,
                 )
                 count += 1
         if count:
@@ -166,6 +169,7 @@ class ExportMixin:
         if not self._extract_worker.is_busy:
             self._status_bar.reset_progress()
             from ui.sounds.audio_manager import UIAudio
+
             UIAudio.frame_extract_done()
 
     @Slot(str, str)
@@ -185,13 +189,15 @@ class ExportMixin:
         if not self._extract_worker.is_busy:
             self._status_bar.reset_progress()
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.error()
         logger.error(f"Extraction failed for {clip_name}: {error_msg}")
 
     # ── Export Video ──
 
-    def _on_export_video(self, clip: ClipEntry | None = None,
-                         source_dir: str | None = None) -> None:
+    def _on_export_video(
+        self, clip: ClipEntry | None = None, source_dir: str | None = None
+    ) -> None:
         """Export output image sequence as video file.
 
         Args:
@@ -206,7 +212,8 @@ class ExportMixin:
 
         if clip.state != ClipState.COMPLETE:
             QMessageBox.warning(
-                self, "Not Complete",
+                self,
+                "Not Complete",
                 f"Clip '{clip.name}' must be COMPLETE to export video.",
             )
             return
@@ -227,11 +234,13 @@ class ExportMixin:
 
         # Read video metadata for fps
         from backend.ffmpeg_tools import read_video_metadata, stitch_video, require_ffmpeg_install
+
         try:
             require_ffmpeg_install(require_probe=True)
         except RuntimeError as exc:
             QMessageBox.critical(
-                self, "FFmpeg Unavailable",
+                self,
+                "FFmpeg Unavailable",
                 str(exc),
             )
             return
@@ -256,29 +265,39 @@ class ExportMixin:
             )
         else:
             default_name = f"{clip.name}_{subdir_name}_export.mp4"
-            file_filter = "MP4 Video (*.mp4);;MOV ProRes (*.mov);;WebM Video (*.webm);;All Files (*)"
+            file_filter = (
+                "MP4 Video (*.mp4);;MOV ProRes (*.mov);;WebM Video (*.webm);;All Files (*)"
+            )
 
         default_path = os.path.join(exports_dir, default_name)
         out_path, _ = QFileDialog.getSaveFileName(
-            self, "Export Video", default_path,
+            self,
+            "Export Video",
+            default_path,
             file_filter,
         )
         if not out_path:
             return
 
         # Determine frame pattern from actual files
-        frames = sorted([f for f in os.listdir(source_dir)
-                         if os.path.splitext(f)[1].lower()
-                         in ('.png', '.jpg', '.jpeg', '.exr', '.tif', '.tiff')])
+        frames = sorted(
+            [
+                f
+                for f in os.listdir(source_dir)
+                if os.path.splitext(f)[1].lower()
+                in (".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff")
+            ]
+        )
         if not frames:
             QMessageBox.warning(self, "No Frames", "No image frames found in output directory.")
             return
 
         # Detect pattern from first filename (e.g. frame_000000.png -> frame_%06d.png)
         import re
+
         first = frames[0]
         ext = os.path.splitext(first)[1]
-        m = re.match(r'^(.*?)(\d+)(\.\w+)$', first)
+        m = re.match(r"^(.*?)(\d+)(\.\w+)$", first)
         if m:
             prefix, digits, suffix = m.group(1), m.group(2), m.group(3)
             pattern = f"{prefix}%0{len(digits)}d{suffix}"
@@ -300,15 +319,18 @@ class ExportMixin:
             )
             self._status_bar.set_message("")
             QMessageBox.information(
-                self, "Export Complete",
+                self,
+                "Export Complete",
                 f"Video exported:\n{out_path}",
             )
         except Exception as e:
             self._status_bar.set_message("")
             from ui.sounds.audio_manager import UIAudio
+
             UIAudio.error()
             QMessageBox.critical(
-                self, "Export Failed",
+                self,
+                "Export Failed",
                 f"Failed to export video:\n{e}",
             )
 
@@ -321,7 +343,15 @@ class ExportMixin:
         Writes to each clip's _EXPORTS/ folder.
         """
         from backend.ffmpeg_tools import read_video_metadata, stitch_video, require_ffmpeg_install
-        from PySide6.QtWidgets import QDialog, QVBoxLayout, QDialogButtonBox, QTreeWidget, QTreeWidgetItem, QLabel, QComboBox
+        from PySide6.QtWidgets import (
+            QDialog,
+            QVBoxLayout,
+            QDialogButtonBox,
+            QTreeWidget,
+            QTreeWidgetItem,
+            QLabel,
+            QComboBox,
+        )
         import re
 
         try:
@@ -373,11 +403,14 @@ class ExportMixin:
                 node.setCheckState(0, Qt.Checked)
                 clip_nodes[clip.name] = node
 
-            frame_count = len([
-                f for f in os.listdir(src)
-                if os.path.splitext(f)[1].lower()
-                in ('.png', '.jpg', '.jpeg', '.exr', '.tif', '.tiff')
-            ])
+            frame_count = len(
+                [
+                    f
+                    for f in os.listdir(src)
+                    if os.path.splitext(f)[1].lower()
+                    in (".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff")
+                ]
+            )
             is_processed = subdir.lower() == "processed"
 
             child = QTreeWidgetItem(clip_nodes[clip.name], [subdir, "", str(frame_count)])
@@ -426,7 +459,11 @@ class ExportMixin:
 
         # ── Export with progress ──
         progress = QProgressDialog(
-            "Exporting videos...", "Cancel", 0, len(selected), self,
+            "Exporting videos...",
+            "Cancel",
+            0,
+            len(selected),
+            self,
         )
         progress.setWindowTitle("Batch Export")
         progress.setWindowModality(Qt.WindowModal)
@@ -444,15 +481,16 @@ class ExportMixin:
             fps = metadata.get("fps", 24.0) if metadata else 24.0
 
             frames = sorted(
-                f for f in os.listdir(src)
+                f
+                for f in os.listdir(src)
                 if os.path.splitext(f)[1].lower()
-                in ('.png', '.jpg', '.jpeg', '.exr', '.tif', '.tiff')
+                in (".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff")
             )
             if not frames:
                 continue
 
             first = frames[0]
-            m = re.match(r'^(.*?)(\d+)(\.\w+)$', first)
+            m = re.match(r"^(.*?)(\d+)(\.\w+)$", first)
             if m:
                 prefix, digits, suffix = m.group(1), m.group(2), m.group(3)
                 pattern = f"{prefix}%0{len(digits)}d{suffix}"
@@ -464,8 +502,11 @@ class ExportMixin:
 
             try:
                 stitch_video(
-                    in_dir=src, out_path=out_path, fps=fps,
-                    pattern=pattern, start_number=start_number,
+                    in_dir=src,
+                    out_path=out_path,
+                    fps=fps,
+                    pattern=pattern,
+                    start_number=start_number,
                 )
                 exported.append(f"{clip.name}/{subdir}")
             except Exception as e:
@@ -479,10 +520,12 @@ class ExportMixin:
             summary += f"\n\n{len(failed)} failed:\n" + "\n".join(failed[:5])
         if exported:
             from ui.sounds.audio_manager import UIAudio
+
             UIAudio.frame_extract_done()
             QMessageBox.information(self, "Batch Export Complete", summary)
         elif failed:
             from ui.sounds.audio_manager import UIAudio
+
             UIAudio.error()
             QMessageBox.warning(self, "Batch Export", summary)
 
@@ -538,8 +581,7 @@ class ExportMixin:
         # Re-resolve state: removing in/out may drop READY -> RAW
         # if alpha only partially covers the full clip
         self._current_clip._resolve_state()
-        self._clip_model.update_clip_state(
-            self._current_clip.name, self._current_clip.state)
+        self._clip_model.update_clip_state(self._current_clip.name, self._current_clip.state)
         self._io_tray.refresh()
         self._refresh_button_state()
 
@@ -555,8 +597,7 @@ class ExportMixin:
             # Re-resolve state: partial alpha + new in/out range may
             # promote RAW -> READY (v1.2.1 partial alpha logic)
             self._current_clip._resolve_state()
-            self._clip_model.update_clip_state(
-                self._current_clip.name, self._current_clip.state)
+            self._clip_model.update_clip_state(self._current_clip.name, self._current_clip.state)
             self._io_tray.refresh()
         self._refresh_button_state()
 

--- a/ui/main_window_mixins/import_mixin.py
+++ b/ui/main_window_mixins/import_mixin.py
@@ -9,8 +9,10 @@ from PySide6.QtCore import Slot
 
 from backend.project import VIDEO_FILE_FILTER
 from ui.widgets.preferences_dialog import (
-    KEY_COPY_SOURCE, DEFAULT_COPY_SOURCE,
-    KEY_COPY_SEQUENCES, DEFAULT_COPY_SEQUENCES,
+    KEY_COPY_SOURCE,
+    DEFAULT_COPY_SOURCE,
+    KEY_COPY_SEQUENCES,
+    DEFAULT_COPY_SEQUENCES,
     get_setting_bool,
 )
 
@@ -53,6 +55,7 @@ class ImportMixin:
     def _return_to_welcome(self) -> None:
         """Save session and return to the welcome screen."""
         from PySide6.QtCore import QTimer
+
         if self._clips_dir:
             try:
                 self._on_save_session()
@@ -111,7 +114,8 @@ class ImportMixin:
         display_name = None
         if len(video_paths) > 1:
             name, ok = QInputDialog.getText(
-                self, "Name Your Project",
+                self,
+                "Name Your Project",
                 "Give your project a name:",
             )
             if not ok:
@@ -120,7 +124,9 @@ class ImportMixin:
 
         # Create ONE project with all videos as clips
         project_dir = create_project(
-            video_paths, copy_source=copy_source, display_name=display_name,
+            video_paths,
+            copy_source=copy_source,
+            display_name=display_name,
         )
         logger.info(
             f"Created project with {len(video_paths)} clip(s): "
@@ -130,13 +136,17 @@ class ImportMixin:
         # Open the new project (not the Projects root — each project is isolated)
         self._switch_to_workspace()
         self._on_clips_dir_changed(
-            project_dir, skip_session_restore=True, select_clip=None,
+            project_dir,
+            skip_session_restore=True,
+            select_clip=None,
         )
 
     def _on_import_folder(self) -> None:
         """File -> Import Clips -> Import Folder — context-aware."""
         dir_path = QFileDialog.getExistingDirectory(
-            self, "Select Clips Directory", "",
+            self,
+            "Select Clips Directory",
+            "",
             QFileDialog.ShowDirsOnly,
         )
         if not dir_path:
@@ -151,7 +161,9 @@ class ImportMixin:
     def _on_import_videos(self) -> None:
         """File -> Import Clips -> Import Video(s) — context-aware."""
         paths, _ = QFileDialog.getOpenFileNames(
-            self, "Select Video Files", "",
+            self,
+            "Select Video Files",
+            "",
             VIDEO_FILE_FILTER,
         )
         if not paths:
@@ -166,7 +178,9 @@ class ImportMixin:
     def _on_import_image_sequence(self) -> None:
         """File -> Import Clips -> Import Image Sequence — context-aware."""
         dir_path = QFileDialog.getExistingDirectory(
-            self, "Select Image Sequence Folder", "",
+            self,
+            "Select Image Sequence Folder",
+            "",
             QFileDialog.ShowDirsOnly,
         )
         if not dir_path:
@@ -176,7 +190,8 @@ class ImportMixin:
         if not self._clips_dir:
             folder_name = os.path.basename(dir_path.rstrip("/\\"))
             name, ok = QInputDialog.getText(
-                self, "Name Your Project",
+                self,
+                "Name Your Project",
                 "Give your project a name:",
                 text=folder_name,
             )
@@ -188,19 +203,22 @@ class ImportMixin:
     def _add_folder_to_project(self, dir_path: str) -> None:
         """Import all videos and image sequences from a folder into the current project."""
         from backend.project import (
-            is_video_file, add_clips_to_project,
-            folder_has_image_sequence, add_sequences_to_project,
+            is_video_file,
+            add_clips_to_project,
+            folder_has_image_sequence,
+            add_sequences_to_project,
         )
+
         videos = [
-            os.path.join(dir_path, f) for f in os.listdir(dir_path)
+            os.path.join(dir_path, f)
+            for f in os.listdir(dir_path)
             if is_video_file(os.path.join(dir_path, f))
         ]
         is_seq = folder_has_image_sequence(dir_path)
 
         if not videos and not is_seq:
             QMessageBox.information(
-                self, "No Media",
-                "No video files or image sequences found in that folder."
+                self, "No Media", "No video files or image sequences found in that folder."
             )
             return
 
@@ -212,18 +230,24 @@ class ImportMixin:
         if is_seq:
             copy_seq = get_setting_bool(KEY_COPY_SEQUENCES, DEFAULT_COPY_SEQUENCES)
             add_sequences_to_project(
-                self._clips_dir, [dir_path], copy_source=copy_seq,
+                self._clips_dir,
+                [dir_path],
+                copy_source=copy_seq,
             )
-            logger.info(f"Added image sequence from folder to project")
+            logger.info("Added image sequence from folder to project")
 
         self._on_clips_dir_changed(self._clips_dir, skip_session_restore=True)
 
     def _add_videos_to_project(self, file_paths: list) -> None:
         """Import selected video files into the current project."""
         from backend.project import (
-            is_video_file, add_clips_to_project, find_clip_by_source,
-            find_removed_clip_by_source, clear_removed_clip,
+            is_video_file,
+            add_clips_to_project,
+            find_clip_by_source,
+            find_removed_clip_by_source,
+            clear_removed_clip,
         )
+
         videos = [f for f in file_paths if is_video_file(f)]
         if not videos:
             return
@@ -250,8 +274,9 @@ class ImportMixin:
         if skipped and not new_videos and not restored:
             names = ", ".join(f'"{s}"' for s in skipped[:3])
             QMessageBox.information(
-                self, "Already Imported",
-                f"All selected videos are already in the project ({names})."
+                self,
+                "Already Imported",
+                f"All selected videos are already in the project ({names}).",
             )
             return
 
@@ -273,20 +298,26 @@ class ImportMixin:
 
     @Slot(str)
     def _on_sequence_folder_imported(
-        self, folder_path: str, display_name: str | None = None,
+        self,
+        folder_path: str,
+        display_name: str | None = None,
     ) -> None:
         """Handle image sequence folder from +ADD menu or drag-drop."""
         from backend.project import (
-            folder_has_image_sequence, validate_sequence_stems,
-            count_sequence_frames, add_sequences_to_project,
-            create_project_from_media, find_clip_by_source,
+            folder_has_image_sequence,
+            validate_sequence_stems,
+            count_sequence_frames,
+            add_sequences_to_project,
+            create_project_from_media,
+            find_clip_by_source,
         )
 
         if not folder_has_image_sequence(folder_path):
             QMessageBox.information(
-                self, "No Images",
+                self,
+                "No Images",
                 "No image files found in that folder.\n\n"
-                "Supported formats: PNG, JPG, EXR, TIF, TIFF, BMP, DPX"
+                "Supported formats: PNG, JPG, EXR, TIF, TIFF, BMP, DPX",
             )
             return
 
@@ -295,12 +326,14 @@ class ImportMixin:
             existing = find_clip_by_source(self._clips_dir, folder_path)
             if existing:
                 QMessageBox.information(
-                    self, "Already Imported",
-                    f"This sequence is already in the project as \"{existing}\"."
+                    self,
+                    "Already Imported",
+                    f'This sequence is already in the project as "{existing}".',
                 )
                 return
             # Restore if it was previously removed
             from backend.project import find_removed_clip_by_source, clear_removed_clip
+
             removed_folder = find_removed_clip_by_source(self._clips_dir, folder_path)
             if removed_folder:
                 clear_removed_clip(self._clips_dir, removed_folder)
@@ -315,11 +348,12 @@ class ImportMixin:
             if len(dupes) > 5:
                 sample += f" ... ({len(dupes)} total)"
             QMessageBox.warning(
-                self, "Duplicate Filenames",
+                self,
+                "Duplicate Filenames",
                 f"Found files with the same name but different extensions:\n"
                 f"{sample}\n\n"
                 f"This would cause output file conflicts. Please use one format "
-                f"per sequence folder."
+                f"per sequence folder.",
             )
             return
 
@@ -330,7 +364,9 @@ class ImportMixin:
 
         if self._clips_dir:
             add_sequences_to_project(
-                self._clips_dir, [folder_path], copy_source=copy_seq,
+                self._clips_dir,
+                [folder_path],
+                copy_source=copy_seq,
             )
             logger.info(f"Added image sequence to project: {folder_path}")
             self._on_clips_dir_changed(self._clips_dir, skip_session_restore=True)
@@ -360,7 +396,8 @@ class ImportMixin:
         if not self._clips_dir:
             folder_name = os.path.basename(parent_folder.rstrip("/\\"))
             name, ok = QInputDialog.getText(
-                self, "Name Your Project",
+                self,
+                "Name Your Project",
                 "Give your project a name:",
                 text=folder_name,
             )
@@ -371,6 +408,7 @@ class ImportMixin:
         if n < 5:
             # Show popup: "Just these N frames" or "Scan folder for full sequence?"
             from backend.project import count_sequence_frames
+
             folder_count = count_sequence_frames(parent_folder)
 
             msg = QMessageBox(self)
@@ -382,10 +420,12 @@ class ImportMixin:
             msg.setInformativeText("How would you like to import?")
 
             btn_just_these = msg.addButton(
-                f"Copy Just These {n}", QMessageBox.AcceptRole,
+                f"Copy Just These {n}",
+                QMessageBox.AcceptRole,
             )
             btn_full_seq = msg.addButton(
-                "Import Full Sequence", QMessageBox.ActionRole,
+                "Import Full Sequence",
+                QMessageBox.ActionRole,
             )
             msg.addButton(QMessageBox.Cancel)
             msg.setDefaultButton(btn_full_seq)
@@ -394,26 +434,33 @@ class ImportMixin:
             clicked = msg.clickedButton()
             if clicked == btn_just_these:
                 self._import_specific_frames(
-                    parent_folder, file_paths, display_name=display_name,
+                    parent_folder,
+                    file_paths,
+                    display_name=display_name,
                 )
             elif clicked == btn_full_seq:
                 self._on_sequence_folder_imported(
-                    parent_folder, display_name=display_name,
+                    parent_folder,
+                    display_name=display_name,
                 )
             # else: Cancel — do nothing
         else:
             # >= 5 files: auto-detect as full sequence from parent folder
             self._on_sequence_folder_imported(
-                parent_folder, display_name=display_name,
+                parent_folder,
+                display_name=display_name,
             )
 
     def _import_specific_frames(
-        self, source_folder: str, file_paths: list[str],
+        self,
+        source_folder: str,
+        file_paths: list[str],
         display_name: str | None = None,
     ) -> None:
         """Import specific frames (always copies into Frames/)."""
         from backend.project import (
-            create_clip_from_sequence, projects_root,
+            create_clip_from_sequence,
+            projects_root,
             write_project_json,
         )
 
@@ -423,14 +470,17 @@ class ImportMixin:
             clips_dir = os.path.join(self._clips_dir, "clips")
             os.makedirs(clips_dir, exist_ok=True)
             create_clip_from_sequence(
-                clips_dir, source_folder,
-                copy_source=True, specific_files=filenames,
+                clips_dir,
+                source_folder,
+                copy_source=True,
+                specific_files=filenames,
             )
             logger.info(f"Imported {len(filenames)} specific frame(s)")
             self._on_clips_dir_changed(self._clips_dir, skip_session_restore=True)
         else:
             # No project open — create one manually with specific files
             from datetime import datetime
+
             proj_name = display_name or os.path.basename(source_folder.rstrip("/\\"))
             name_stem = re.sub(r"[^\w\-]", "_", proj_name)
             name_stem = re.sub(r"_+", "_", name_stem).strip("_")[:60]
@@ -439,15 +489,20 @@ class ImportMixin:
             clips_dir = os.path.join(project_dir, "clips")
             os.makedirs(clips_dir, exist_ok=True)
             clip_name = create_clip_from_sequence(
-                clips_dir, source_folder,
-                copy_source=True, specific_files=filenames,
+                clips_dir,
+                source_folder,
+                copy_source=True,
+                specific_files=filenames,
             )
-            write_project_json(project_dir, {
-                "version": 2,
-                "created": datetime.now().isoformat(),
-                "display_name": proj_name,
-                "clips": [clip_name],
-            })
+            write_project_json(
+                project_dir,
+                {
+                    "version": 2,
+                    "created": datetime.now().isoformat(),
+                    "display_name": proj_name,
+                    "clips": [clip_name],
+                },
+            )
             logger.info(f"Created project with {len(filenames)} specific frame(s)")
             self._switch_to_workspace()
             self._on_clips_dir_changed(project_dir, skip_session_restore=True)
@@ -459,11 +514,15 @@ class ImportMixin:
         named after the folder, and opens it.
         """
         from backend.project import (
-            is_video_file, create_project, folder_has_image_sequence,
+            is_video_file,
+            create_project,
+            folder_has_image_sequence,
             create_project_from_media,
         )
+
         videos = sorted(
-            os.path.join(dir_path, f) for f in os.listdir(dir_path)
+            os.path.join(dir_path, f)
+            for f in os.listdir(dir_path)
             if is_video_file(os.path.join(dir_path, f))
         )
 
@@ -472,8 +531,7 @@ class ImportMixin:
 
         if not videos and not is_seq:
             QMessageBox.information(
-                self, "No Media",
-                "No video files or image sequences found in that folder."
+                self, "No Media", "No video files or image sequences found in that folder."
             )
             return
 
@@ -484,7 +542,9 @@ class ImportMixin:
         if videos and not is_seq:
             # Videos only — use existing path
             project_dir = create_project(
-                videos, copy_source=copy_video, display_name=folder_name,
+                videos,
+                copy_source=copy_video,
+                display_name=folder_name,
             )
         elif is_seq and not videos:
             # Image sequence only
@@ -504,8 +564,6 @@ class ImportMixin:
             )
 
         media_count = len(videos) + (1 if is_seq else 0)
-        logger.info(
-            f"Created project '{folder_name}' with {media_count} source(s) from folder"
-        )
+        logger.info(f"Created project '{folder_name}' with {media_count} source(s) from folder")
         self._switch_to_workspace()
         self._on_clips_dir_changed(project_dir, skip_session_restore=True)

--- a/ui/main_window_mixins/inference_mixin.py
+++ b/ui/main_window_mixins/inference_mixin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 
 import numpy as np
 from PySide6.QtWidgets import QMessageBox
@@ -9,8 +8,10 @@ from PySide6.QtCore import Slot, QThread
 from PySide6.QtGui import QImage
 
 from backend import (
-    ClipState, JobType,
-    PipelineRoute, classify_pipeline_route,
+    ClipState,
+    JobType,
+    PipelineRoute,
+    classify_pipeline_route,
 )
 from ui.preview.frame_index import ViewMode
 from ui.preview.display_transform import processed_rgba_to_qimage
@@ -26,9 +27,7 @@ class InferenceMixin:
     def _on_params_changed(self) -> None:
         """Handle parameter change — debounce before reprocess."""
         self._remember_current_clip_input_color_space()
-        self._dual_viewer.set_input_exr_is_linear(
-            self._param_panel.get_params().input_is_linear
-        )
+        self._dual_viewer.set_input_exr_is_linear(self._param_panel.get_params().input_is_linear)
         if self._current_clip is not None:
             self._refresh_input_thumbnail(
                 self._current_clip,
@@ -107,10 +106,12 @@ class InferenceMixin:
             if reply == QMessageBox.Yes:
                 self._submit_sam2_track_job(clip)
             else:
-                self._status_bar.set_message("Track preview ready. Refine paint strokes and run Track Mask again.")
+                self._status_bar.set_message(
+                    "Track preview ready. Refine paint strokes and run Track Mask again."
+                )
             return
 
-        if 'comp' not in result:
+        if "comp" not in result:
             return
 
         mode = self._dual_viewer.current_output_mode
@@ -121,24 +122,24 @@ class InferenceMixin:
             return
 
         # Pick the array that matches current view mode
-        if mode == ViewMode.MATTE and 'alpha' in result:
-            arr = result['alpha']
+        if mode == ViewMode.MATTE and "alpha" in result:
+            arr = result["alpha"]
             if arr.ndim == 3:
                 arr = arr[:, :, 0]
             # Matte display: clamp, light gamma lift, grayscale -> RGB
             display = np.power(np.clip(arr, 0.0, 1.0), 0.85)
             gray8 = (display * 255.0).astype(np.uint8)
             rgb = np.stack([gray8, gray8, gray8], axis=2)
-        elif mode == ViewMode.FG and 'fg' in result:
+        elif mode == ViewMode.FG and "fg" in result:
             # FG is already sRGB float [H,W,3]
-            rgb = (np.clip(result['fg'], 0.0, 1.0) * 255.0).astype(np.uint8)
-        elif mode == ViewMode.PROCESSED and 'processed' in result:
-            qimg = processed_rgba_to_qimage(result['processed'])
+            rgb = (np.clip(result["fg"], 0.0, 1.0) * 255.0).astype(np.uint8)
+        elif mode == ViewMode.PROCESSED and "processed" in result:
+            qimg = processed_rgba_to_qimage(result["processed"])
             self._dual_viewer.show_reprocess_preview(qimg)
             return
         else:
             # Default: COMP (also for INPUT/MASK/ALPHA which don't change on reprocess)
-            rgb = (np.clip(result['comp'], 0.0, 1.0) * 255.0).astype(np.uint8)
+            rgb = (np.clip(result["comp"], 0.0, 1.0) * 255.0).astype(np.uint8)
 
         h, w = rgb.shape[:2]
         qimg = QImage(rgb.data, w, h, w * 3, QImage.Format_RGB888).copy()
@@ -159,7 +160,8 @@ class InferenceMixin:
         clip = self._current_clip
         if clip.state not in (ClipState.READY, ClipState.COMPLETE):
             QMessageBox.warning(
-                self, "Not Ready",
+                self,
+                "Not Ready",
                 f"Clip '{clip.name}' is in {clip.state.value} state.\n"
                 "Only READY or COMPLETE clips can be processed.",
             )
@@ -191,7 +193,8 @@ class InferenceMixin:
                     if self._service.job_queue.submit(gvm_job):
                         clip.set_processing(True)
                         self._start_worker_if_needed(
-                            gvm_job.id, job_label="GVM Auto",
+                            gvm_job.id,
+                            job_label="GVM Auto",
                         )
                     return
                 elif clicked != btn_process:
@@ -254,7 +257,9 @@ class InferenceMixin:
         batch_count = self._io_tray.selected_count()
         if clip is None:
             self._status_bar.update_button_state(
-                can_run=False, has_partial=False, has_in_out=False,
+                can_run=False,
+                has_partial=False,
+                has_in_out=False,
             )
             return
         can_run = clip.state in (ClipState.READY, ClipState.COMPLETE)
@@ -319,8 +324,10 @@ class InferenceMixin:
 
         if not routes:
             from PySide6.QtWidgets import QMessageBox
+
             QMessageBox.information(
-                self, "Nothing to Process",
+                self,
+                "Nothing to Process",
                 "No selected clips are in a processable state.",
             )
             return

--- a/ui/main_window_mixins/menu_mixin.py
+++ b/ui/main_window_mixins/menu_mixin.py
@@ -76,6 +76,7 @@ class MenuMixin:
         corner_layout.addWidget(self._update_btn)
 
         from ui.widgets.volume_control import VolumeControl
+
         self._volume_control = VolumeControl(self._corner_widget)
         corner_layout.addWidget(self._volume_control)
 
@@ -83,4 +84,5 @@ class MenuMixin:
 
     def _menu_click_sound(self) -> None:
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.click()

--- a/ui/main_window_mixins/model_run_mixin.py
+++ b/ui/main_window_mixins/model_run_mixin.py
@@ -25,20 +25,17 @@ class ModelRunMixin:
         alpha_dir = os.path.join(self._current_clip.root_path, "AlphaHint")
         if not os.path.isdir(alpha_dir):
             return None
-        existing = [f for f in os.listdir(alpha_dir)
-                    if f.lower().endswith(('.png', '.jpg', '.jpeg'))]
+        existing = [
+            f for f in os.listdir(alpha_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))
+        ]
         if not existing:
             return None
-        total = (self._current_clip.input_asset.frame_count
-                 if self._current_clip.input_asset else 0)
+        total = self._current_clip.input_asset.frame_count if self._current_clip.input_asset else 0
         msg = QMessageBox(self)
         msg.setWindowTitle("Partial Alpha Found")
-        msg.setText(
-            f"Found {len(existing)}/{total} alpha frames from a previous run."
-        )
+        msg.setText(f"Found {len(existing)}/{total} alpha frames from a previous run.")
         msg.setInformativeText(
-            "Resume will skip completed frames.\n"
-            "Regenerate will redo all frames from scratch."
+            "Resume will skip completed frames.\nRegenerate will redo all frames from scratch."
         )
         resume_btn = msg.addButton("Resume", QMessageBox.AcceptRole)
         regen_btn = msg.addButton("Regenerate", QMessageBox.DestructiveRole)
@@ -55,7 +52,10 @@ class ModelRunMixin:
 
     def _on_run_gvm(self) -> None:
         """Run GVM alpha generation on the selected clip."""
-        if self._current_clip is None or self._current_clip.state not in (ClipState.RAW, ClipState.MASKED):
+        if self._current_clip is None or self._current_clip.state not in (
+            ClipState.RAW,
+            ClipState.MASKED,
+        ):
             return
 
         if not self._warn_mps_slow("GVM Auto Alpha"):
@@ -75,7 +75,10 @@ class ModelRunMixin:
     @Slot(str)
     def _on_run_birefnet(self, usage: str) -> None:
         """Run BiRefNet alpha generation on the selected clip."""
-        if self._current_clip is None or self._current_clip.state not in (ClipState.RAW, ClipState.MASKED):
+        if self._current_clip is None or self._current_clip.state not in (
+            ClipState.RAW,
+            ClipState.MASKED,
+        ):
             return
 
         result = self._confirm_partial_alpha()

--- a/ui/main_window_mixins/session_mixin.py
+++ b/ui/main_window_mixins/session_mixin.py
@@ -28,6 +28,7 @@ class SessionMixin:
         if not self._clips_dir:
             return None
         from backend.project import projects_root as _projects_root
+
         try:
             if os.path.normcase(os.path.abspath(self._clips_dir)) == os.path.normcase(
                 os.path.abspath(_projects_root())
@@ -50,8 +51,10 @@ class SessionMixin:
         # Window geometry
         geo = self.geometry()
         data["geometry"] = {
-            "x": geo.x(), "y": geo.y(),
-            "width": geo.width(), "height": geo.height(),
+            "x": geo.x(),
+            "y": geo.y(),
+            "width": geo.width(),
+            "height": geo.height(),
         }
 
         # Splitter sizes
@@ -164,9 +167,7 @@ class SessionMixin:
         if clip.name in self._clip_input_is_linear:
             return self._clip_input_is_linear[clip.name]
 
-        input_is_linear = bool(
-            clip.input_asset is not None and clip.should_default_input_linear()
-        )
+        input_is_linear = bool(clip.input_asset is not None and clip.should_default_input_linear())
         self._clip_input_is_linear[clip.name] = input_is_linear
         return input_is_linear
 
@@ -181,7 +182,7 @@ class SessionMixin:
         data = self._build_session_data()
         tmp_path = path + ".tmp"
         try:
-            with open(tmp_path, 'w') as f:
+            with open(tmp_path, "w") as f:
                 json.dump(data, f, indent=2)
             # Atomic rename (Windows: need to remove target first)
             if os.path.exists(path):
@@ -206,7 +207,7 @@ class SessionMixin:
             data = self._build_session_data()
             tmp_path = path + ".tmp"
             try:
-                with open(tmp_path, 'w') as f:
+                with open(tmp_path, "w") as f:
                     json.dump(data, f, indent=2)
                 if os.path.exists(path):
                     os.remove(path)
@@ -222,9 +223,12 @@ class SessionMixin:
     def _on_open_project(self) -> None:
         """Open a project folder via directory picker (Ctrl+O)."""
         from backend.project import projects_root
+
         start_dir = projects_root()
         folder = QFileDialog.getExistingDirectory(
-            self, "Open Project", start_dir,
+            self,
+            "Open Project",
+            start_dir,
         )
         if not folder:
             return
@@ -240,7 +244,7 @@ class SessionMixin:
     def _load_session_from(self, path: str) -> None:
         """Load session data from a file path."""
         try:
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 data = json.load(f)
             self._apply_session_data(data)
             logger.info(f"Session loaded: {path}")

--- a/ui/main_window_mixins/settings_mixin.py
+++ b/ui/main_window_mixins/settings_mixin.py
@@ -5,14 +5,20 @@ import os
 import re
 import sys
 
-from PySide6.QtWidgets import QWidget, QLabel, QMessageBox
+from PySide6.QtWidgets import QApplication, QLabel, QMessageBox, QWidget
 from PySide6.QtCore import Qt, Slot, QSettings
 
 from ui.widgets.preferences_dialog import (
-    PreferencesDialog, KEY_SHOW_TOOLTIPS, DEFAULT_SHOW_TOOLTIPS,
-    KEY_TRACKER_MODEL, DEFAULT_TRACKER_MODEL,
-    KEY_MODEL_RESOLUTION, DEFAULT_MODEL_RESOLUTION,
-    get_setting_bool, get_setting_str, get_setting_int,
+    PreferencesDialog,
+    KEY_SHOW_TOOLTIPS,
+    DEFAULT_SHOW_TOOLTIPS,
+    KEY_TRACKER_MODEL,
+    DEFAULT_TRACKER_MODEL,
+    KEY_MODEL_RESOLUTION,
+    DEFAULT_MODEL_RESOLUTION,
+    get_setting_bool,
+    get_setting_str,
+    get_setting_int,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,6 +49,7 @@ class SettingsMixin:
     def _run_startup_diagnostics(self, device: str) -> None:
         """Check environment for known issues and show a diagnostic dialog."""
         from ui.widgets.diagnostic_dialog import run_startup_diagnostics, StartupDiagnosticDialog
+
         issues = run_startup_diagnostics(device)
         if issues:
             dlg = StartupDiagnosticDialog(issues, parent=self)
@@ -67,6 +74,7 @@ class SettingsMixin:
     def _show_hotkeys(self) -> None:
         """Open the Hotkeys configuration dialog and apply changes."""
         from ui.widgets.hotkeys_dialog import HotkeysDialog
+
         dlg = HotkeysDialog(self._shortcut_registry, self)
         if dlg.exec() == HotkeysDialog.Accepted:
             self._setup_shortcuts()
@@ -86,6 +94,7 @@ class SettingsMixin:
         """Apply UI sounds on/off and volume from saved preferences."""
         from ui.widgets.preferences_dialog import KEY_UI_SOUNDS, DEFAULT_UI_SOUNDS
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.set_muted(not get_setting_bool(KEY_UI_SOUNDS, DEFAULT_UI_SOUNDS))
         # Restore volume level
         vol = QSettings().value("ui/sounds_volume", 1.0, type=float)
@@ -106,8 +115,11 @@ class SettingsMixin:
     def _apply_parallel_clips_setting(self) -> None:
         """Apply saved parallel clips preference to the GPU worker."""
         from ui.widgets.preferences_dialog import (
-            get_setting_int as _get_int, KEY_PARALLEL_CLIPS, DEFAULT_PARALLEL_CLIPS,
+            get_setting_int as _get_int,
+            KEY_PARALLEL_CLIPS,
+            DEFAULT_PARALLEL_CLIPS,
         )
+
         n = _get_int(KEY_PARALLEL_CLIPS, DEFAULT_PARALLEL_CLIPS)
         self._gpu_worker.set_max_workers(n)
 
@@ -170,11 +182,14 @@ class SettingsMixin:
 
     def _get_local_version(self) -> str:
         import tomllib
+
         candidates = []
-        if getattr(sys, 'frozen', False):
+        if getattr(sys, "frozen", False):
             candidates.append(os.path.join(sys._MEIPASS, "pyproject.toml"))
         candidates.append(
-            os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "pyproject.toml")
+            os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "pyproject.toml"
+            )
         )
         for path in candidates:
             try:
@@ -213,6 +228,7 @@ class SettingsMixin:
 
     def _check_for_updates(self) -> None:
         from ui.main_window import _UpdateChecker
+
         self._update_thread = _UpdateChecker(self._get_local_version())
         self._update_thread.update_available.connect(self._on_update_available)
         self._update_thread.start()
@@ -230,6 +246,7 @@ class SettingsMixin:
 
     def _run_update(self) -> None:
         import sys as _sys
+
         if getattr(_sys, "frozen", False):
             self._run_frozen_update()
         else:
@@ -238,16 +255,19 @@ class SettingsMixin:
     def _run_script_update(self) -> None:
         """Update via 3-update.sh / 3-update.bat (CLI/dev installs)."""
         reply = QMessageBox.question(
-            self, "Update EZ-CorridorKey",
+            self,
+            "Update EZ-CorridorKey",
             "This will save your session, close the app, and run the updater.\n"
             "The app will relaunch automatically after updating.\n\n"
             "Continue?",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes,
         )
         if reply != QMessageBox.Yes:
             return
         self._auto_save_session()
         import subprocess
+
         root = os.path.dirname(os.path.dirname(__file__))
         if os.name == "nt":
             bat = os.path.join(root, "3-update.bat")
@@ -262,26 +282,29 @@ class SettingsMixin:
                 start_new_session=True,
             )
         from PySide6.QtWidgets import QApplication
+
         QApplication.instance().quit()
 
     def _run_frozen_update(self) -> None:
         """Update a frozen .app/.exe by downloading from GitHub Releases."""
         import sys as _sys
+
         reply = QMessageBox.question(
-            self, "Update EZ-CorridorKey",
+            self,
+            "Update EZ-CorridorKey",
             "This will download the latest version, replace the current app,\n"
             "and relaunch automatically.\n\n"
             "Your session will be saved. Continue?",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes,
         )
         if reply != QMessageBox.Yes:
             return
         self._auto_save_session()
 
         from PySide6.QtWidgets import QProgressDialog
-        progress = QProgressDialog(
-            "Downloading update...", "Cancel", 0, 100, self
-        )
+
+        progress = QProgressDialog("Downloading update...", "Cancel", 0, 100, self)
         progress.setWindowTitle("Updating EZ-CorridorKey")
         progress.setMinimumWidth(400)
         progress.setModal(True)
@@ -299,9 +322,10 @@ class SettingsMixin:
             # Determine asset name by platform
             if _sys.platform == "darwin":
                 QMessageBox.information(
-                    self, "Update",
+                    self,
+                    "Update",
                     "macOS auto-update is not yet supported.\n"
-                    "Please download the latest .pkg from Gumroad or GitHub."
+                    "Please download the latest .pkg from Gumroad or GitHub.",
                 )
                 progress.close()
                 return
@@ -310,21 +334,17 @@ class SettingsMixin:
                 asset_ext = "zip"
             else:
                 QMessageBox.warning(
-                    self, "Update",
+                    self,
+                    "Update",
                     "Automatic updates are not supported on this platform.\n"
-                    "Please download the latest release from GitHub."
+                    "Please download the latest release from GitHub.",
                 )
                 progress.close()
                 return
 
             # Fetch latest release info from GitHub API
-            api_url = (
-                "https://api.github.com/repos/edenaion/EZ-CorridorKey"
-                "/releases/latest"
-            )
-            req = urllib.request.Request(
-                api_url, headers={"User-Agent": "CorridorKey"}
-            )
+            api_url = "https://api.github.com/repos/edenaion/EZ-CorridorKey/releases/latest"
+            req = urllib.request.Request(api_url, headers={"User-Agent": "CorridorKey"})
             with urllib.request.urlopen(req, timeout=15) as resp:
                 release = json.loads(resp.read().decode("utf-8"))
 
@@ -342,10 +362,11 @@ class SettingsMixin:
 
             if not download_url:
                 QMessageBox.warning(
-                    self, "Update",
+                    self,
+                    "Update",
                     f"No {asset_name} found in the latest release.\n"
                     f"Release: {tag or 'unknown'}\n\n"
-                    "Please download manually from GitHub."
+                    "Please download manually from GitHub.",
                 )
                 progress.close()
                 return
@@ -362,15 +383,12 @@ class SettingsMixin:
                     progress.setValue(pct)
                     progress.setLabelText(
                         f"Downloading update... "
-                        f"{block_num * block_size // (1024*1024)}/"
-                        f"{total_size // (1024*1024)} MB"
+                        f"{block_num * block_size // (1024 * 1024)}/"
+                        f"{total_size // (1024 * 1024)} MB"
                     )
-                from PySide6.QtWidgets import QApplication
                 QApplication.processEvents()
 
-            urllib.request.urlretrieve(
-                download_url, str(zip_path), reporthook=_report
-            )
+            urllib.request.urlretrieve(download_url, str(zip_path), reporthook=_report)
 
             progress.setLabelText("Installing update...")
             progress.setValue(95)
@@ -428,8 +446,8 @@ class SettingsMixin:
                 current_dir = Path(_sys.executable).resolve().parent
                 swap_script = tmp_dir / "swap_update.bat"
                 swap_script.write_text(
-                    f'@echo off\n'
-                    f'timeout /t 2 /nobreak >nul\n'
+                    f"@echo off\n"
+                    f"timeout /t 2 /nobreak >nul\n"
                     f'xcopy /s /e /y "{new_exe_dir}\\*" "{current_dir}\\"\n'
                     f'start "" "{_sys.executable}"\n'
                     f'rmdir /s /q "{tmp_dir}"\n',
@@ -449,7 +467,8 @@ class SettingsMixin:
         except Exception as e:
             progress.close()
             QMessageBox.critical(
-                self, "Update Failed",
+                self,
+                "Update Failed",
                 f"Could not update automatically:\n\n{e}\n\n"
-                "Please download the latest release manually from GitHub."
+                "Please download the latest release manually from GitHub.",
             )

--- a/ui/main_window_mixins/shortcuts_mixin.py
+++ b/ui/main_window_mixins/shortcuts_mixin.py
@@ -22,6 +22,7 @@ class ShortcutsMixin:
         from ui.widgets.preferences_dialog import KEY_UI_SOUNDS
         from PySide6.QtCore import QSettings
         from ui.main_window import _MuteOverlay
+
         muted = not UIAudio.is_muted()
         UIAudio.set_muted(muted)
         QSettings().setValue(KEY_UI_SOUNDS, not muted)
@@ -29,7 +30,7 @@ class ShortcutsMixin:
         if hasattr(self, "_volume_control"):
             self._volume_control.sync_mute_state()
         # Show overlay top-right
-        icon = "\U0001F507" if muted else "\U0001F50A"  # muted vs speaker
+        icon = "\U0001f507" if muted else "\U0001f50a"  # muted vs speaker
         text = f"{icon}  Sound {'OFF' if muted else 'ON'}"
         overlay = _MuteOverlay(self, text)
         overlay.show()
@@ -77,7 +78,8 @@ class ShortcutsMixin:
             return
 
         reply = QMessageBox.question(
-            self, "Cancel",
+            self,
+            "Cancel",
             f"Cancel {process_name}?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
@@ -86,6 +88,7 @@ class ShortcutsMixin:
             return
 
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.user_cancel()
 
         if process_name == "frame extraction":

--- a/ui/main_window_mixins/worker_mixin.py
+++ b/ui/main_window_mixins/worker_mixin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 
 from PySide6.QtWidgets import QMessageBox
 from PySide6.QtCore import Slot
@@ -16,7 +15,9 @@ class WorkerMixin:
     """GPU worker signal handlers for MainWindow."""
 
     @Slot(str, str, int, int)
-    def _on_worker_progress(self, job_id: str, clip_name: str, current: int, total: int, fps: float = 0.0) -> None:
+    def _on_worker_progress(
+        self, job_id: str, clip_name: str, current: int, total: int, fps: float = 0.0
+    ) -> None:
         if self._cancel_requested_job_id == job_id:
             self._queue_panel.refresh()
             return
@@ -96,8 +97,12 @@ class WorkerMixin:
         # Map job type to correct next state.
         if job_type == JobType.SAM2_TRACK.value:
             target_state = ClipState.MASKED
-        elif job_type in (JobType.GVM_ALPHA.value, JobType.VIDEOMAMA_ALPHA.value,
-                          JobType.MATANYONE2_ALPHA.value, JobType.BIREFNET_ALPHA.value):
+        elif job_type in (
+            JobType.GVM_ALPHA.value,
+            JobType.VIDEOMAMA_ALPHA.value,
+            JobType.MATANYONE2_ALPHA.value,
+            JobType.BIREFNET_ALPHA.value,
+        ):
             target_state = ClipState.READY
         else:
             target_state = ClipState.COMPLETE
@@ -186,6 +191,7 @@ class WorkerMixin:
             self._status_bar.start_job_timer(label=next_label)
 
         from ui.sounds.audio_manager import UIAudio
+
         if target_state == ClipState.MASKED:
             UIAudio.mask_done()
             self._status_bar.set_message(f"Track Mask complete for {clip_name}")
@@ -201,7 +207,9 @@ class WorkerMixin:
             alpha_info = ""
             for c in self._clip_model.clips:
                 if c.name == clip_name and c.alpha_asset and c.input_asset:
-                    alpha_info = f" ({c.alpha_asset.frame_count}/{c.input_asset.frame_count} alpha frames)"
+                    alpha_info = (
+                        f" ({c.alpha_asset.frame_count}/{c.input_asset.frame_count} alpha frames)"
+                    )
                     break
             self._status_bar.set_message(
                 f"{type_label} complete for {clip_name}{alpha_info} -- Ready to Run Inference"
@@ -284,17 +292,21 @@ class WorkerMixin:
         self._queue_panel.refresh()
         logger.error(f"Worker error for {clip_name}: {error_msg}")
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.error()
 
         # Try to match a known error pattern for actionable diagnostics
         from ui.widgets.diagnostic_dialog import match_diagnostic, DiagnosticDialog
+
         diag = match_diagnostic(error_msg)
         if diag:
             dlg = DiagnosticDialog(
-                diag, error_msg,
+                diag,
+                error_msg,
                 gpu_info=self._service.get_vram_info(),
                 recent_errors=self._debug_console.recent_errors()
-                if hasattr(self, '_debug_console') else None,
+                if hasattr(self, "_debug_console")
+                else None,
                 parent=self,
             )
             dlg.exec()

--- a/ui/models/clip_model.py
+++ b/ui/models/clip_model.py
@@ -4,6 +4,7 @@ Provides the data layer for the clip browser list view. The model
 emits standard Qt signals when clips are added/removed/changed, so
 the view updates automatically.
 """
+
 from __future__ import annotations
 
 from collections import OrderedDict
@@ -70,7 +71,9 @@ class ClipListModel(QAbstractListModel):
         elif role == Qt.ToolTipRole:
             lines = [f"State: {clip.state.value}"]
             if clip.input_asset:
-                lines.append(f"Input: {clip.input_asset.frame_count} frames ({clip.input_asset.asset_type})")
+                lines.append(
+                    f"Input: {clip.input_asset.frame_count} frames ({clip.input_asset.asset_type})"
+                )
             if clip.alpha_asset:
                 lines.append(f"Alpha: {clip.alpha_asset.frame_count} frames")
             if clip.warnings:

--- a/ui/preview/async_decoder.py
+++ b/ui/preview/async_decoder.py
@@ -6,12 +6,13 @@ latest request is honored when rapid scrubbing generates many requests.
 Codex finding: synchronous decode freezes UI on scrub/mode change.
 Pattern: worker generates QImage, signals main thread, main thread paints.
 """
+
 from __future__ import annotations
 
 import logging
 import sys
 
-from PySide6.QtCore import QObject, QRunnable, Signal, Slot, QThreadPool
+from PySide6.QtCore import QObject, QRunnable, Signal, QThreadPool
 
 from .frame_index import ViewMode
 from .display_transform import decode_frame, decode_video_frame
@@ -21,16 +22,23 @@ logger = logging.getLogger(__name__)
 
 class _DecodeSignals(QObject):
     """Signals for the decode worker (QRunnable can't have signals directly)."""
+
     finished = Signal(int, str, object)  # stem_index, mode_value, QImage|None
 
 
 class _DecodeTask(QRunnable):
     """Decode a single frame in the thread pool."""
 
-    def __init__(self, request_id: int, path: str, mode: ViewMode,
-                 stem_index: int, video_path: str | None = None,
-                 video_frame_index: int = 0,
-                 input_exr_is_linear: bool = False):
+    def __init__(
+        self,
+        request_id: int,
+        path: str,
+        mode: ViewMode,
+        stem_index: int,
+        video_path: str | None = None,
+        video_frame_index: int = 0,
+        input_exr_is_linear: bool = False,
+    ):
         super().__init__()
         self.signals = _DecodeSignals()
         self._request_id = request_id
@@ -90,10 +98,15 @@ class AsyncDecoder(QObject):
         # before the callback fires. Keyed by request_id.
         self._pending_signals: dict[int, _DecodeSignals] = {}
 
-    def request_decode(self, path: str, mode: ViewMode, stem_index: int,
-                       video_path: str | None = None,
-                       video_frame_index: int = 0,
-                       input_exr_is_linear: bool = False) -> None:
+    def request_decode(
+        self,
+        path: str,
+        mode: ViewMode,
+        stem_index: int,
+        video_path: str | None = None,
+        video_frame_index: int = 0,
+        input_exr_is_linear: bool = False,
+    ) -> None:
         """Submit a decode request. Supersedes any pending request."""
         self._current_request_id += 1
         req_id = self._current_request_id
@@ -116,8 +129,9 @@ class AsyncDecoder(QObject):
         )
         self._pool.start(task)
 
-    def _on_decoded(self, request_id: int, stem_index: int,
-                    mode_value: str, qimage: object) -> None:
+    def _on_decoded(
+        self, request_id: int, stem_index: int, mode_value: str, qimage: object
+    ) -> None:
         """Handle decode completion — discard if stale."""
         # Release the signal reference
         self._pending_signals.pop(request_id, None)

--- a/ui/preview/display_transform.py
+++ b/ui/preview/display_transform.py
@@ -9,13 +9,13 @@ Codex critical finding: naive clip-to-8bit looks wrong for:
 - Processed (straight RGBA → composite with alpha for display)
 - Negative/HDR values (needs clamping before conversion)
 """
+
 from __future__ import annotations
 
 import os
 import logging
 import threading
 from collections import OrderedDict
-from functools import lru_cache
 
 import cv2
 import numpy as np
@@ -82,7 +82,7 @@ def _do_decode(path: str, mode: ViewMode, *, input_exr_is_linear: bool = False) 
     if not os.path.isfile(path):
         return None
 
-    is_exr = path.lower().endswith('.exr')
+    is_exr = path.lower().endswith(".exr")
 
     try:
         if is_exr:
@@ -142,12 +142,16 @@ def _decode_exr(path: str, mode: ViewMode, *, input_exr_is_linear: bool = False)
             else:
                 # Strip alpha, treat as RGB
                 return _transform_linear_rgb(
-                    img[:, :, :3], mode, input_exr_is_linear=input_exr_is_linear,
+                    img[:, :, :3],
+                    mode,
+                    input_exr_is_linear=input_exr_is_linear,
                 )
         else:
             # Unexpected channel count, take first 3
             return _transform_linear_rgb(
-                img[:, :, :3], mode, input_exr_is_linear=input_exr_is_linear,
+                img[:, :, :3],
+                mode,
+                input_exr_is_linear=input_exr_is_linear,
             )
     return None
 

--- a/ui/preview/frame_index.py
+++ b/ui/preview/frame_index.py
@@ -8,6 +8,7 @@ when some modes have holes.
 Codex critical finding: index-based navigation across directories with
 different file counts will misalign. Stem-based is the only correct approach.
 """
+
 from __future__ import annotations
 
 import os
@@ -20,6 +21,7 @@ from backend.project import is_image_file as _is_image
 
 class ViewMode(str, Enum):
     """Available preview modes. Each maps to a specific source directory."""
+
     INPUT = "Input"
     MASK = "Mask"
     ALPHA = "Alpha"
@@ -50,6 +52,7 @@ class FrameIndex:
         availability: Maps ViewMode → set of stems present in that mode.
         stem_files: Maps (ViewMode, stem) → full file path.
     """
+
     stems: list[str] = field(default_factory=list)
     availability: dict[ViewMode, set[str]] = field(default_factory=dict)
     stem_files: dict[tuple[ViewMode, str], str] = field(default_factory=dict)
@@ -116,15 +119,16 @@ def build_frame_index(
                     # Check Source/ first (new format), then Input.* (legacy)
                     source_dir = os.path.join(clip_root, "Source")
                     if os.path.isdir(source_dir):
-                        video_exts = ('.mp4', '.mov', '.avi', '.mkv', '.mxf', '.webm', '.m4v')
+                        video_exts = (".mp4", ".mov", ".avi", ".mkv", ".mxf", ".webm", ".m4v")
                         for f in os.listdir(source_dir):
                             if f.lower().endswith(video_exts):
                                 index.video_modes[mode] = os.path.join(source_dir, f)
                                 break
                     if mode not in index.video_modes:
                         import glob as glob_module
+
                         video_candidates = glob_module.glob(os.path.join(clip_root, "Input.*"))
-                        video_exts = ('.mp4', '.mov', '.avi', '.mkv')
+                        video_exts = (".mp4", ".mov", ".avi", ".mkv")
                         for vc in video_candidates:
                             if vc.lower().endswith(video_exts):
                                 index.video_modes[mode] = vc
@@ -167,6 +171,7 @@ def build_frame_index(
         vpath = index.video_modes[ViewMode.INPUT]
         try:
             import cv2
+
             cap = cv2.VideoCapture(vpath)
             if cap.isOpened():
                 count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))

--- a/ui/recent_sessions.py
+++ b/ui/recent_sessions.py
@@ -6,6 +6,7 @@ Tracks which workspaces the user has opened, persisted as JSON at
 
 Independent of per-workspace session sidecars (.corridorkey_session.json).
 """
+
 from __future__ import annotations
 
 import json
@@ -23,10 +24,10 @@ _FILENAME = "recent_sessions.json"
 def _config_dir() -> str:
     """Platform-appropriate config directory for app-level settings."""
     # Portable: config lives next to the exe
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         exe_dir = os.path.dirname(sys.executable)
-        if os.path.isfile(os.path.join(exe_dir, 'portable.txt')):
-            return os.path.join(exe_dir, 'config')
+        if os.path.isfile(os.path.join(exe_dir, "portable.txt")):
+            return os.path.join(exe_dir, "config")
     if os.name == "nt":
         base = os.environ.get("APPDATA", os.path.expanduser("~"))
         return os.path.join(base, "CorridorKey")
@@ -38,6 +39,7 @@ def _config_dir() -> str:
 @dataclass
 class RecentSession:
     """A recently-opened workspace."""
+
     workspace_path: str
     display_name: str
     last_opened: float
@@ -59,6 +61,7 @@ class RecentSessionsStore:
     Persisted as a JSON file in the app config directory.
     Thread-safe for single-threaded Qt main thread usage.
     """
+
     MAX_RECENT = 20
 
     def __init__(self, config_dir: str | None = None):
@@ -111,8 +114,12 @@ class RecentSessionsStore:
                     pass
 
     def add_or_update(
-        self, workspace_path: str, display_name: str, clip_count: int,
-        *, force: bool = False,
+        self,
+        workspace_path: str,
+        display_name: str,
+        clip_count: int,
+        *,
+        force: bool = False,
     ) -> None:
         """Add or update a workspace in the recents list.
 
@@ -126,14 +133,17 @@ class RecentSessionsStore:
         # Remove existing entry for this path
         self._sessions = [s for s in self._sessions if self._norm(s.workspace_path) != norm]
         # Add at front
-        self._sessions.insert(0, RecentSession(
-            workspace_path=workspace_path,
-            display_name=display_name,
-            last_opened=time.time(),
-            clip_count=clip_count,
-        ))
+        self._sessions.insert(
+            0,
+            RecentSession(
+                workspace_path=workspace_path,
+                display_name=display_name,
+                last_opened=time.time(),
+                clip_count=clip_count,
+            ),
+        )
         # Trim
-        self._sessions = self._sessions[:self.MAX_RECENT]
+        self._sessions = self._sessions[: self.MAX_RECENT]
         self._save()
 
     def remove(self, workspace_path: str) -> None:
@@ -159,5 +169,3 @@ class RecentSessionsStore:
             self._save()
             logger.info(f"Pruned {pruned} missing workspace(s) from recent sessions")
         return pruned
-
-

--- a/ui/shortcut_registry.py
+++ b/ui/shortcut_registry.py
@@ -3,6 +3,7 @@
 Stores default shortcuts, loads/saves user overrides via QSettings,
 creates QShortcut objects, and detects conflicts.
 """
+
 from __future__ import annotations
 
 import logging
@@ -20,11 +21,12 @@ _QSETTINGS_GROUP = "shortcuts"
 @dataclass
 class ShortcutDef:
     """One shortcut definition."""
-    action_id: str          # Unique internal ID, e.g. "run_inference"
-    display_name: str       # Human-readable label shown in the dialog
-    category: str           # Grouping: "Global", "Timeline", etc.
-    default_key: str        # Default key sequence string, e.g. "Ctrl+R"
-    callback_name: str      # Name of the method on MainWindow to call
+
+    action_id: str  # Unique internal ID, e.g. "run_inference"
+    display_name: str  # Human-readable label shown in the dialog
+    category: str  # Grouping: "Global", "Timeline", etc.
+    default_key: str  # Default key sequence string, e.g. "Ctrl+R"
+    callback_name: str  # Name of the method on MainWindow to call
     menu_action: bool = False  # True for shortcuts managed by QAction (menu bar)
     app_shortcut: bool = False  # True to use ApplicationShortcut context (fires globally)
 
@@ -32,38 +34,55 @@ class ShortcutDef:
 # Authoritative list — order here = display order in dialog
 SHORTCUT_DEFAULTS: list[ShortcutDef] = [
     # Global
-    ShortcutDef("escape",             "Stop / Cancel",                "Global",     "Esc",          "_on_escape"),
-    ShortcutDef("run_inference",      "Run Inference",                "Global",     "Ctrl+R",       "_on_run_inference"),
-    ShortcutDef("run_all",            "Run All Clips",                "Global",     "Ctrl+Shift+R", "_on_run_all_ready"),
-    ShortcutDef("save_session",       "Save Session",                 "Global",     "Ctrl+S",       "_on_save_session",    menu_action=True),
-    ShortcutDef("open_project",       "Open Project",                 "Global",     "Ctrl+O",       "_on_open_project",    menu_action=True),
-    ShortcutDef("toggle_mute",        "Toggle Mute",                  "Global",     "Ctrl+M",       "_toggle_mute"),
-    ShortcutDef("welcome_screen",     "Return to Home",               "Global",     "Home",         "_return_to_welcome"),
-    ShortcutDef("delete_clips",       "Remove Selected Clips",        "Global",     "Del",          "_on_delete_selected_clips"),
-    ShortcutDef("toggle_queue",       "Toggle Queue",                 "Global",     "Q",            "_toggle_queue_panel"),
-    ShortcutDef("debug_console",     "Debug Console",                "Global",     "F12",          "_toggle_debug_console", app_shortcut=True),
-    ShortcutDef("preferences",       "Preferences",                  "Global",     "Ctrl+,",       "_show_preferences",     menu_action=True),
+    ShortcutDef("escape", "Stop / Cancel", "Global", "Esc", "_on_escape"),
+    ShortcutDef("run_inference", "Run Inference", "Global", "Ctrl+R", "_on_run_inference"),
+    ShortcutDef("run_all", "Run All Clips", "Global", "Ctrl+Shift+R", "_on_run_all_ready"),
+    ShortcutDef(
+        "save_session", "Save Session", "Global", "Ctrl+S", "_on_save_session", menu_action=True
+    ),
+    ShortcutDef(
+        "open_project", "Open Project", "Global", "Ctrl+O", "_on_open_project", menu_action=True
+    ),
+    ShortcutDef("toggle_mute", "Toggle Mute", "Global", "Ctrl+M", "_toggle_mute"),
+    ShortcutDef("welcome_screen", "Return to Home", "Global", "Home", "_return_to_welcome"),
+    ShortcutDef(
+        "delete_clips", "Remove Selected Clips", "Global", "Del", "_on_delete_selected_clips"
+    ),
+    ShortcutDef("toggle_queue", "Toggle Queue", "Global", "Q", "_toggle_queue_panel"),
+    ShortcutDef(
+        "debug_console",
+        "Debug Console",
+        "Global",
+        "F12",
+        "_toggle_debug_console",
+        app_shortcut=True,
+    ),
+    ShortcutDef(
+        "preferences", "Preferences", "Global", "Ctrl+,", "_show_preferences", menu_action=True
+    ),
     # Timeline
-    ShortcutDef("set_in",             "Set In-Point",                 "Timeline",   "I",            "_set_in_point"),
-    ShortcutDef("set_out",            "Set Out-Point",                "Timeline",   "O",            "_set_out_point"),
-    ShortcutDef("clear_in_out",       "Clear In/Out",                 "Timeline",   "Alt+I",        "_clear_in_out"),
+    ShortcutDef("set_in", "Set In-Point", "Timeline", "I", "_set_in_point"),
+    ShortcutDef("set_out", "Set Out-Point", "Timeline", "O", "_set_out_point"),
+    ShortcutDef("clear_in_out", "Clear In/Out", "Timeline", "Alt+I", "_clear_in_out"),
     # Playback
-    ShortcutDef("play_pause",         "Play / Pause",                 "Playback",   "Space",        "_toggle_playback"),
+    ShortcutDef("play_pause", "Play / Pause", "Playback", "Space", "_toggle_playback"),
     # Paint
-    ShortcutDef("annotation_fg",      "Foreground Paint",             "Paint",      "1",            "_toggle_annotation_fg"),
-    ShortcutDef("annotation_bg",      "Background Paint (Red)",       "Paint",      "2",            "_toggle_annotation_bg"),
-    ShortcutDef("cycle_fg_color",     "Cycle Foreground Color",       "Paint",      "C",            "_cycle_fg_color"),
-    ShortcutDef("undo_annotation",    "Undo Paint Stroke",            "Paint",      "Ctrl+Z",       "_undo_annotation"),
-    ShortcutDef("clear_annotations",  "Clear Paint Strokes",          "Paint",      "Ctrl+C",       "_confirm_clear_annotations"),
+    ShortcutDef("annotation_fg", "Foreground Paint", "Paint", "1", "_toggle_annotation_fg"),
+    ShortcutDef("annotation_bg", "Background Paint (Red)", "Paint", "2", "_toggle_annotation_bg"),
+    ShortcutDef("cycle_fg_color", "Cycle Foreground Color", "Paint", "C", "_cycle_fg_color"),
+    ShortcutDef("undo_annotation", "Undo Paint Stroke", "Paint", "Ctrl+Z", "_undo_annotation"),
+    ShortcutDef(
+        "clear_annotations", "Clear Paint Strokes", "Paint", "Ctrl+C", "_confirm_clear_annotations"
+    ),
     # Viewer
-    ShortcutDef("toggle_ab_wipe",     "Toggle A/B Wipe",              "Viewer",     "A",            "_toggle_ab_wipe"),
-    ShortcutDef("view_input",         "View: INPUT",                  "Viewer",     "F1",           "_view_mode_input"),
-    ShortcutDef("view_mask",          "View: MASK",                   "Viewer",     "F2",           "_view_mode_mask"),
-    ShortcutDef("view_alpha",         "View: ALPHA",                  "Viewer",     "F3",           "_view_mode_alpha"),
-    ShortcutDef("view_fg",            "View: FG",                     "Viewer",     "F4",           "_view_mode_fg"),
-    ShortcutDef("view_matte",         "View: MATTE",                  "Viewer",     "F5",           "_view_mode_matte"),
-    ShortcutDef("view_comp",          "View: COMP",                   "Viewer",     "F6",           "_view_mode_comp"),
-    ShortcutDef("view_proc",          "View: PROC",                   "Viewer",     "F7",           "_view_mode_proc"),
+    ShortcutDef("toggle_ab_wipe", "Toggle A/B Wipe", "Viewer", "A", "_toggle_ab_wipe"),
+    ShortcutDef("view_input", "View: INPUT", "Viewer", "F1", "_view_mode_input"),
+    ShortcutDef("view_mask", "View: MASK", "Viewer", "F2", "_view_mode_mask"),
+    ShortcutDef("view_alpha", "View: ALPHA", "Viewer", "F3", "_view_mode_alpha"),
+    ShortcutDef("view_fg", "View: FG", "Viewer", "F4", "_view_mode_fg"),
+    ShortcutDef("view_matte", "View: MATTE", "Viewer", "F5", "_view_mode_matte"),
+    ShortcutDef("view_comp", "View: COMP", "Viewer", "F6", "_view_mode_comp"),
+    ShortcutDef("view_proc", "View: PROC", "Viewer", "F7", "_view_mode_proc"),
 ]
 
 # Category display order
@@ -119,8 +138,10 @@ class ShortcutRegistry:
 
     def is_default(self, action_id: str) -> bool:
         """True if the action uses its default key (no custom override)."""
-        return action_id not in self._overrides or \
-            self._overrides[action_id] == self._defs[action_id].default_key
+        return (
+            action_id not in self._overrides
+            or self._overrides[action_id] == self._defs[action_id].default_key
+        )
 
     def get_def(self, action_id: str) -> ShortcutDef | None:
         """Return the definition for an action."""

--- a/ui/sounds/audio_manager.py
+++ b/ui/sounds/audio_manager.py
@@ -99,7 +99,10 @@ class UIAudio:
 
     @classmethod
     def _play(
-        cls, sfx: QSoundEffect, variance: float = _VARIANCE, db_offset: float = 0.0,
+        cls,
+        sfx: QSoundEffect,
+        variance: float = _VARIANCE,
+        db_offset: float = 0.0,
         skip_debounce: bool = False,
     ) -> None:
         if cls._muted or cls._volume <= 0.0:

--- a/ui/theme/__init__.py
+++ b/ui/theme/__init__.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 # Frozen-build aware path resolution
-if getattr(sys, 'frozen', False):
+if getattr(sys, "frozen", False):
     THEME_DIR = os.path.join(sys._MEIPASS, "ui", "theme")
 else:
     THEME_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/ui/widgets/annotation_overlay.py
+++ b/ui/widgets/annotation_overlay.py
@@ -13,6 +13,7 @@ Brush size: Shift+left-drag up/down.
 Straight line: Alt+left-drag draws a straight line at current brush size.
 Undo: Ctrl+Z pops last stroke on the current frame.
 """
+
 from __future__ import annotations
 
 import json
@@ -31,12 +32,14 @@ logger = logging.getLogger(__name__)
 
 # ── Data Model ──────────────────────────────────────────────────────────────
 
+
 @dataclass
 class AnnotationStroke:
     """A single brush stroke in image-pixel coordinates."""
+
     points: list[tuple[float, float]] = field(default_factory=list)
-    brush_type: str = "fg"   # "fg" (foreground/keep) or "bg" (background/remove)
-    radius: float = 15.0     # brush radius in image pixels
+    brush_type: str = "fg"  # "fg" (foreground/keep) or "bg" (background/remove)
+    radius: float = 15.0  # brush radius in image pixels
 
 
 class AnnotationModel:
@@ -49,8 +52,9 @@ class AnnotationModel:
         self._current_stroke: AnnotationStroke | None = None
         self._current_frame: int = -1
 
-    def start_stroke(self, stem_idx: int, x: float, y: float,
-                     brush_type: str, radius: float) -> None:
+    def start_stroke(
+        self, stem_idx: int, x: float, y: float, brush_type: str, radius: float
+    ) -> None:
         """Begin a new stroke on the given frame."""
         self._current_stroke = AnnotationStroke(
             points=[(x, y)],
@@ -161,9 +165,9 @@ class AnnotationModel:
         except (json.JSONDecodeError, OSError, KeyError, TypeError) as e:
             logger.warning(f"Failed to load annotations: {e}")
 
-    def export_masks(self, clip_root: str, frame_stems: list[str],
-                     width: int, height: int,
-                     start_index: int = 0) -> str:
+    def export_masks(
+        self, clip_root: str, frame_stems: list[str], width: int, height: int, start_index: int = 0
+    ) -> str:
         """Rasterize annotations to binary mask PNGs for VideoMamaMaskHint.
 
         Args:
@@ -199,8 +203,7 @@ class AnnotationModel:
         return mask_dir
 
     @staticmethod
-    def _rasterize_strokes(strokes: list[AnnotationStroke],
-                           width: int, height: int) -> np.ndarray:
+    def _rasterize_strokes(strokes: list[AnnotationStroke], width: int, height: int) -> np.ndarray:
         """Render strokes into a binary mask (0=bg, 255=fg).
 
         Foreground strokes draw white, background strokes draw black.
@@ -220,10 +223,8 @@ class AnnotationModel:
             # Connect consecutive points with thick lines for smooth strokes
             if len(stroke.points) >= 2:
                 for i in range(len(stroke.points) - 1):
-                    p1 = (int(round(stroke.points[i][0])),
-                           int(round(stroke.points[i][1])))
-                    p2 = (int(round(stroke.points[i + 1][0])),
-                           int(round(stroke.points[i + 1][1])))
+                    p1 = (int(round(stroke.points[i][0])), int(round(stroke.points[i][1])))
+                    p2 = (int(round(stroke.points[i + 1][0])), int(round(stroke.points[i + 1][1])))
                     cv2.line(mask, p1, p2, color, radius * 2)
 
         return mask
@@ -234,18 +235,22 @@ class AnnotationModel:
 # Foreground color palette — cycle with C key
 FG_PALETTE = [
     {"name": "Green", "fill": QColor(44, 195, 80, 128), "cursor": QColor(44, 195, 80, 200)},
-    {"name": "Blue",  "fill": QColor(50, 140, 255, 128), "cursor": QColor(50, 140, 255, 200)},
+    {"name": "Blue", "fill": QColor(50, 140, 255, 128), "cursor": QColor(50, 140, 255, 200)},
 ]
 _fg_palette_idx = 0
+
 
 def get_fg_color() -> QColor:
     return FG_PALETTE[_fg_palette_idx]["fill"]
 
+
 def get_fg_cursor() -> QColor:
     return FG_PALETTE[_fg_palette_idx]["cursor"]
 
+
 def get_fg_name() -> str:
     return FG_PALETTE[_fg_palette_idx]["name"]
+
 
 def cycle_fg_color() -> str:
     """Advance to next foreground color. Returns the new color name."""
@@ -253,16 +258,23 @@ def cycle_fg_color() -> str:
     _fg_palette_idx = (_fg_palette_idx + 1) % len(FG_PALETTE)
     return FG_PALETTE[_fg_palette_idx]["name"]
 
-_BG_COLOR = QColor(209, 0, 0, 128)       # #D10000 at 50% opacity
+
+_BG_COLOR = QColor(209, 0, 0, 128)  # #D10000 at 50% opacity
 _BG_CURSOR = QColor(209, 0, 0, 200)
-_RESIZE_TEXT = QColor(255, 242, 3, 220)   # brand yellow for size text
+_RESIZE_TEXT = QColor(255, 242, 3, 220)  # brand yellow for size text
 
 
 # ── Rendering ───────────────────────────────────────────────────────────────
 
-def paint_annotations(painter: QPainter, strokes: list[AnnotationStroke],
-                      current_stroke: AnnotationStroke | None,
-                      image_rect: QRectF, img_w: int, img_h: int) -> None:
+
+def paint_annotations(
+    painter: QPainter,
+    strokes: list[AnnotationStroke],
+    current_stroke: AnnotationStroke | None,
+    image_rect: QRectF,
+    img_w: int,
+    img_h: int,
+) -> None:
     """Paint annotation strokes onto the viewport.
 
     Converts image-pixel coords to display coords via image_rect.
@@ -304,8 +316,9 @@ def paint_annotations(painter: QPainter, strokes: list[AnnotationStroke],
     painter.restore()
 
 
-def paint_brush_cursor(painter: QPainter, pos: QPointF,
-                       radius_display: float, brush_type: str) -> None:
+def paint_brush_cursor(
+    painter: QPainter, pos: QPointF, radius_display: float, brush_type: str
+) -> None:
     """Draw a circle outline at the cursor position showing brush size."""
     painter.save()
     painter.setRenderHint(QPainter.Antialiasing)
@@ -320,9 +333,9 @@ def paint_brush_cursor(painter: QPainter, pos: QPointF,
     painter.restore()
 
 
-def paint_resize_indicator(painter: QPainter, pos: QPointF,
-                           radius_display: float, radius_image: float,
-                           brush_type: str) -> None:
+def paint_resize_indicator(
+    painter: QPainter, pos: QPointF, radius_display: float, radius_image: float, brush_type: str
+) -> None:
     """Draw brush resize feedback: circle + size text."""
     paint_brush_cursor(painter, pos, radius_display, brush_type)
 

--- a/ui/widgets/debug_console.py
+++ b/ui/widgets/debug_console.py
@@ -3,6 +3,7 @@
 Shows real-time log output inside the app. Toggle with F12 or Help > Console.
 Captures all Python logging output via a custom handler attached to the root logger.
 """
+
 from __future__ import annotations
 
 import logging
@@ -10,7 +11,7 @@ import re
 from datetime import datetime
 
 from PySide6.QtCore import QObject, QSettings, Qt, Signal, Slot
-from PySide6.QtGui import QCursor, QFont, QKeySequence, QMouseEvent, QShortcut
+from PySide6.QtGui import QFont, QKeySequence, QMouseEvent, QShortcut
 from PySide6.QtWidgets import (
     QComboBox,
     QHBoxLayout,
@@ -36,6 +37,7 @@ _LEVEL_COLORS = {
 # ---------------------------------------------------------------------------
 # Qt-safe logging handler
 # ---------------------------------------------------------------------------
+
 
 class _QtLogHandler(logging.Handler, QObject):
     """Logging handler that emits a Qt signal for each log record.
@@ -78,6 +80,7 @@ class _QtLogHandler(logging.Handler, QObject):
 # Debug Console Widget
 # ---------------------------------------------------------------------------
 
+
 class DebugConsoleWidget(QWidget):
     """Floating debug console window with live log output."""
 
@@ -110,9 +113,7 @@ class DebugConsoleWidget(QWidget):
 
     def _build_ui(self) -> None:
         self.setMinimumSize(400, 200)
-        self.setStyleSheet(
-            "DebugConsoleWidget { background: #0E0D00; border: 1px solid #2A2910; }"
-        )
+        self.setStyleSheet("DebugConsoleWidget { background: #0E0D00; border: 1px solid #2A2910; }")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(1, 1, 1, 1)
@@ -128,8 +129,7 @@ class DebugConsoleWidget(QWidget):
 
         title_label = QLabel("CONSOLE")
         title_label.setStyleSheet(
-            "color: #FFF203; font-size: 11px; font-weight: 700;"
-            "letter-spacing: 3px; border: none;"
+            "color: #FFF203; font-size: 11px; font-weight: 700;letter-spacing: 3px; border: none;"
         )
         tb_layout.addWidget(title_label)
         tb_layout.addStretch()
@@ -212,7 +212,9 @@ class DebugConsoleWidget(QWidget):
         grip = QLabel("\u25e2")  # ◢
         grip.setFixedSize(14, 14)
         grip.setAlignment(Qt.AlignRight | Qt.AlignBottom)
-        grip.setStyleSheet("color: #454430; font-size: 12px; border: none; background: transparent;")
+        grip.setStyleSheet(
+            "color: #454430; font-size: 12px; border: none; background: transparent;"
+        )
         layout.addWidget(grip, 0, Qt.AlignRight)
 
     @staticmethod
@@ -253,7 +255,7 @@ class DebugConsoleWidget(QWidget):
         # Always buffer (trim newest-first; drop oldest beyond limit)
         self._log_buffer.insert(0, (html, levelno))
         if len(self._log_buffer) > _MAX_LINES:
-            self._log_buffer = self._log_buffer[:_MAX_LINES - 500]
+            self._log_buffer = self._log_buffer[: _MAX_LINES - 500]
 
         # Prepend so newest entries appear at the top
         if levelno >= self._min_level:
@@ -278,10 +280,11 @@ class DebugConsoleWidget(QWidget):
 
     # --- Backfill from session log file ----------------------------------
 
-    _LOG_RE = re.compile(
-        r"^[\d-]+\s+([\d:]+)\s+\[(\w+)\s*\]\s+([\w.]+):\s+(.*)$"
-    )
-    _LEVEL_MAP = {n: getattr(logging, n, logging.DEBUG) for n in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")}
+    _LOG_RE = re.compile(r"^[\d-]+\s+([\d:]+)\s+\[(\w+)\s*\]\s+([\w.]+):\s+(.*)$")
+    _LEVEL_MAP = {
+        n: getattr(logging, n, logging.DEBUG)
+        for n in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+    }
 
     def _backfill_session_log(self) -> None:
         """Read any lines already written to this session's log file."""
@@ -359,8 +362,10 @@ class DebugConsoleWidget(QWidget):
         if event.button() == Qt.LeftButton:
             pos = event.position().toPoint()
             # Check if near bottom-right corner for resize
-            if (self.width() - pos.x() < self._EDGE_MARGIN
-                    and self.height() - pos.y() < self._EDGE_MARGIN):
+            if (
+                self.width() - pos.x() < self._EDGE_MARGIN
+                and self.height() - pos.y() < self._EDGE_MARGIN
+            ):
                 self._resize_edge = True
                 self._drag_pos = event.globalPosition().toPoint()
             elif pos.y() < 28:  # Title bar drag
@@ -374,8 +379,10 @@ class DebugConsoleWidget(QWidget):
         if self._drag_pos is None:
             # Update cursor for resize hint
             pos = event.position().toPoint()
-            if (self.width() - pos.x() < self._EDGE_MARGIN
-                    and self.height() - pos.y() < self._EDGE_MARGIN):
+            if (
+                self.width() - pos.x() < self._EDGE_MARGIN
+                and self.height() - pos.y() < self._EDGE_MARGIN
+            ):
                 self.setCursor(Qt.SizeFDiagCursor)
             elif pos.y() < 28:
                 self.setCursor(Qt.OpenHandCursor)

--- a/ui/widgets/diagnostic_checks.py
+++ b/ui/widgets/diagnostic_checks.py
@@ -5,6 +5,7 @@ registry of known error patterns (``_DIAGNOSTICS``), and the
 ``run_startup_diagnostics`` routine.  The UI dialog classes that *display*
 these results live in ``diagnostic_dialog.py``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -16,9 +17,11 @@ logger = logging.getLogger(__name__)
 
 # ── Known error patterns ─────────────────────────────────────────────
 
+
 @dataclass
 class Diagnostic:
     """A single known-error diagnosis with user-facing fix steps."""
+
     id: str
     title: str
     pattern: re.Pattern[str]
@@ -46,8 +49,7 @@ _DIAGNOSTICS: list[Diagnostic] = [
         ),
         steps=[
             "Open a terminal in the EZ-CorridorKey folder.",
-            "Activate the virtual environment:\n"
-            "    .venv\\Scripts\\activate",
+            "Activate the virtual environment:\n    .venv\\Scripts\\activate",
             "Reinstall PyTorch with CUDA:\n"
             "    pip install torch torchvision --index-url\n"
             "    https://download.pytorch.org/whl/cu128",
@@ -72,10 +74,8 @@ _DIAGNOSTICS: list[Diagnostic] = [
             "checkpoints folder.  The model must be downloaded separately."
         ),
         steps=[
-            "Download CorridorKey.pth from the project release page\n"
-            "or the link in the README.",
-            "Place the file in:\n"
-            "    CorridorKeyModule/checkpoints/CorridorKey.pth",
+            "Download CorridorKey.pth from the project release page\nor the link in the README.",
+            "Place the file in:\n    CorridorKeyModule/checkpoints/CorridorKey.pth",
             "Restart EZ-CorridorKey.",
         ],
         tags=["checkpoint", "model", "pth"],
@@ -105,9 +105,7 @@ _DIAGNOSTICS: list[Diagnostic] = [
             "  Windows: re-run 1-install.bat.\n"
             "  macOS: brew install ffmpeg\n"
             "  Linux: install both ffmpeg and ffprobe from your package manager (version 7.0+).",
-            "Verify both commands work:\n"
-            "    ffmpeg -version\n"
-            "    ffprobe -version",
+            "Verify both commands work:\n    ffmpeg -version\n    ffprobe -version",
         ],
         tags=["ffmpeg", "ffprobe", "video", "version"],
     ),
@@ -151,10 +149,8 @@ _DIAGNOSTICS: list[Diagnostic] = [
         ),
         steps=[
             "Open a terminal in the EZ-CorridorKey folder.",
-            "Activate the virtual environment:\n"
-            "    .venv\\Scripts\\activate",
-            "Install triton-windows:\n"
-            "    pip install triton-windows",
+            "Activate the virtual environment:\n    .venv\\Scripts\\activate",
+            "Install triton-windows:\n    pip install triton-windows",
             "Restart EZ-CorridorKey.",
         ],
         tags=["triton", "compile"],
@@ -200,8 +196,7 @@ _DIAGNOSTICS: list[Diagnostic] = [
             "Open a terminal in the EZ-CorridorKey folder.",
             "Activate the virtual environment:\n"
             "    .venv\\Scripts\\activate  (or venv\\Scripts\\activate)",
-            "Uninstall the CPU-only build:\n"
-            "    pip uninstall torch torchvision -y",
+            "Uninstall the CPU-only build:\n    pip uninstall torch torchvision -y",
             "Reinstall with CUDA support:\n"
             "    pip install torch torchvision --index-url\n"
             "    https://download.pytorch.org/whl/cu128",
@@ -227,7 +222,7 @@ _DIAGNOSTICS: list[Diagnostic] = [
         ),
         steps=[
             "First, check if you have CPU-only PyTorch:\n"
-            "    python -c \"import torch; print(torch.__version__)\"",
+            '    python -c "import torch; print(torch.__version__)"',
             "If the version ends in '+cpu', reinstall with CUDA:\n"
             "    pip install torch torchvision --index-url\n"
             "    https://download.pytorch.org/whl/cu128",
@@ -252,10 +247,8 @@ _DIAGNOSTICS: list[Diagnostic] = [
             "They must be downloaded separately from the model files."
         ),
         steps=[
-            "Run the GVM weight downloader:\n"
-            "    python -m gvm_core.download",
-            "Or download manually from the README link and place\n"
-            "in gvm_core/weights/",
+            "Run the GVM weight downloader:\n    python -m gvm_core.download",
+            "Or download manually from the README link and place\nin gvm_core/weights/",
             "Restart EZ-CorridorKey.",
         ],
         tags=["gvm", "weights"],
@@ -301,10 +294,8 @@ _DIAGNOSTICS: list[Diagnostic] = [
             "Close other GPU-heavy applications (games, other AI tools,\n"
             "browser hardware acceleration).",
             "Try processing at a lower resolution first.",
-            "Set the environment variable for low-VRAM mode:\n"
-            "    set CORRIDORKEY_OPT_MODE=lowvram",
-            "If the problem persists, your GPU may not have enough\n"
-            "VRAM for this clip resolution.",
+            "Set the environment variable for low-VRAM mode:\n    set CORRIDORKEY_OPT_MODE=lowvram",
+            "If the problem persists, your GPU may not have enough\nVRAM for this clip resolution.",
         ],
         tags=["vram", "memory", "oom"],
     ),
@@ -321,9 +312,11 @@ def match_diagnostic(error_msg: str) -> Diagnostic | None:
 
 # ── Startup diagnostics ──────────────────────────────────────────────
 
+
 @dataclass
 class StartupIssue:
     """A non-fatal issue detected during application startup."""
+
     diagnostic: Diagnostic
     detail: str  # extra context (e.g. detected PyTorch version)
 
@@ -346,10 +339,12 @@ def run_startup_diagnostics(device: str) -> list[StartupIssue]:
     if device == "cpu":
         try:
             import torch
+
             if "+cpu" in torch.__version__:
                 has_nvidia = False
                 try:
                     import pynvml
+
                     pynvml.nvmlInit()
                     has_nvidia = pynvml.nvmlDeviceGetCount() > 0
                     pynvml.nvmlShutdown()
@@ -361,27 +356,33 @@ def run_startup_diagnostics(device: str) -> list[StartupIssue]:
                         None,
                     )
                     if diag:
-                        issues.append(StartupIssue(
-                            diag,
-                            f"PyTorch {torch.__version__} (CPU-only) with NVIDIA GPU detected",
-                        ))
+                        issues.append(
+                            StartupIssue(
+                                diag,
+                                f"PyTorch {torch.__version__} (CPU-only) with NVIDIA GPU detected",
+                            )
+                        )
         except ImportError:
             pass
 
     # 2. Python version outside supported range
     import sys
+
     vi = sys.version_info
     if vi.major != 3 or vi.minor < 10 or vi.minor > 13:
         diag = next((d for d in _DIAGNOSTICS if d.id == "python-version"), None)
         if diag:
-            issues.append(StartupIssue(
-                diag,
-                f"Detected Python {vi.major}.{vi.minor}.{vi.micro}",
-            ))
+            issues.append(
+                StartupIssue(
+                    diag,
+                    f"Detected Python {vi.major}.{vi.minor}.{vi.micro}",
+                )
+            )
 
     # 3. FFmpeg missing, too old, or invalid build
     try:
         from backend.ffmpeg_tools import validate_ffmpeg_install
+
         result = validate_ffmpeg_install()
         if not result.ok:
             # Pick the right diagnostic based on whether FFmpeg was found at all
@@ -401,6 +402,7 @@ def _get_torch_detail() -> str:
     """Build a one-line detail string about the PyTorch install."""
     try:
         import torch
+
         ver = torch.__version__
         cuda = torch.version.cuda or "none"
         return f"PyTorch {ver}, CUDA toolkit: {cuda}"

--- a/ui/widgets/diagnostic_dialog.py
+++ b/ui/widgets/diagnostic_dialog.py
@@ -5,6 +5,7 @@ presents the user with a clear explanation and step-by-step fix instructions
 instead of a raw traceback.  If none of the steps resolve the issue, the
 user can click through to file a GitHub issue with system info pre-filled.
 """
+
 from __future__ import annotations
 
 from PySide6.QtCore import Qt
@@ -28,6 +29,7 @@ from ui.widgets.diagnostic_checks import (  # noqa: F401
 
 
 # ── Dialog ────────────────────────────────────────────────────────────
+
 
 class DiagnosticDialog(QDialog):
     """Shows a known-error diagnosis with fix steps and a Report Issue fallback."""
@@ -58,9 +60,7 @@ class DiagnosticDialog(QDialog):
 
         # ── Title ──
         title_lbl = QLabel(diagnostic.title)
-        title_lbl.setStyleSheet(
-            "QLabel { font-size: 16px; font-weight: bold; color: #FFF203; }"
-        )
+        title_lbl.setStyleSheet("QLabel { font-size: 16px; font-weight: bold; color: #FFF203; }")
         root.addWidget(title_lbl)
 
         # ── Explanation ──
@@ -72,9 +72,7 @@ class DiagnosticDialog(QDialog):
         # ── Detail (optional runtime context) ──
         if detail:
             detail_lbl = QLabel(detail)
-            detail_lbl.setStyleSheet(
-                "QLabel { color: #999; font-style: italic; font-size: 12px; }"
-            )
+            detail_lbl.setStyleSheet("QLabel { color: #999; font-style: italic; font-size: 12px; }")
             root.addWidget(detail_lbl)
 
         # ── Steps (scrollable) ──
@@ -89,9 +87,7 @@ class DiagnosticDialog(QDialog):
         for i, step in enumerate(diagnostic.steps, 1):
             step_lbl = QLabel(f"{i}.  {step}")
             step_lbl.setWordWrap(True)
-            step_lbl.setTextInteractionFlags(
-                Qt.TextInteractionFlag.TextSelectableByMouse
-            )
+            step_lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
             step_lbl.setStyleSheet(
                 "QLabel { color: #E0E0E0; font-family: 'Consolas', monospace; "
                 "font-size: 12px; background: #1a1a1a; border-radius: 4px; "
@@ -106,12 +102,8 @@ class DiagnosticDialog(QDialog):
         # ── Error detail (collapsed) ──
         error_lbl = QLabel(f"Error: {error_msg}")
         error_lbl.setWordWrap(True)
-        error_lbl.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
-        error_lbl.setStyleSheet(
-            "QLabel { color: #888; font-size: 11px; padding: 4px; }"
-        )
+        error_lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        error_lbl.setStyleSheet("QLabel { color: #888; font-size: 11px; padding: 4px; }")
         root.addWidget(error_lbl)
 
         # ── Buttons ──
@@ -201,8 +193,7 @@ class StartupDiagnosticDialog(QDialog):
     def _build_issue_card(issue: StartupIssue) -> QWidget:
         card = QWidget()
         card.setStyleSheet(
-            "QWidget { background: #1a1a1a; border: 1px solid #333; "
-            "border-radius: 6px; }"
+            "QWidget { background: #1a1a1a; border: 1px solid #333; border-radius: 6px; }"
         )
         layout = QVBoxLayout(card)
         layout.setContentsMargins(12, 10, 12, 10)
@@ -226,19 +217,14 @@ class StartupDiagnosticDialog(QDialog):
         explain = QLabel(issue.diagnostic.explanation)
         explain.setWordWrap(True)
         explain.setStyleSheet(
-            "QLabel { color: #bbb; font-size: 12px; "
-            "background: transparent; border: none; }"
+            "QLabel { color: #bbb; font-size: 12px; background: transparent; border: none; }"
         )
         layout.addWidget(explain)
 
-        steps_text = "\n".join(
-            f"  {i}. {s}" for i, s in enumerate(issue.diagnostic.steps, 1)
-        )
+        steps_text = "\n".join(f"  {i}. {s}" for i, s in enumerate(issue.diagnostic.steps, 1))
         steps = QLabel(steps_text)
         steps.setWordWrap(True)
-        steps.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
+        steps.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         steps.setStyleSheet(
             "QLabel { color: #E0E0E0; font-family: 'Consolas', monospace; "
             "font-size: 11px; background: transparent; border: none; "

--- a/ui/widgets/dual_viewer.py
+++ b/ui/widgets/dual_viewer.py
@@ -6,10 +6,10 @@ at the bottom that keeps them in sync.
 
 When no output exists yet (clip not processed), both viewers show the input.
 """
+
 from __future__ import annotations
 
 import logging
-import os
 
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QSplitter, QLabel
 from PySide6.QtCore import Qt, Signal, Slot
@@ -68,6 +68,7 @@ class DualViewerPanel(QWidget):
         # A/B wipe overlay — sits ON TOP of the splitter, covers both viewer
         # canvases without touching the top bars.  Hidden until activated.
         from ui.widgets.split_view import SplitViewWidget
+
         self._wipe_overlay = SplitViewWidget(parent=self)
         self._wipe_overlay.set_wipe_mode(True)
         self._wipe_overlay.hide()

--- a/ui/widgets/frame_scrubber.py
+++ b/ui/widgets/frame_scrubber.py
@@ -6,6 +6,7 @@ after a debounce period (50ms) to coalesce rapid scrubbing events.
 Helper widgets (CoverageBar, MarkerOverlay, _FatSlider) live in
 ``ui.widgets.timeline_widgets`` to keep this module focused on FrameScrubber.
 """
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QPushButton, QToolTip
@@ -17,10 +18,10 @@ from ui.widgets.timeline_widgets import _FatSlider, CoverageBar, MarkerOverlay
 class FrameScrubber(QWidget):
     """Frame navigation scrubber with transport controls, coverage bar, and debounced output."""
 
-    frame_changed = Signal(int)      # emitted after debounce, stem index
-    in_point_changed = Signal(int)   # in-point set at stem index
+    frame_changed = Signal(int)  # emitted after debounce, stem index
+    in_point_changed = Signal(int)  # in-point set at stem index
     out_point_changed = Signal(int)  # out-point set at stem index
-    range_cleared = Signal()         # in/out range cleared
+    range_cleared = Signal()  # in/out range cleared
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -46,7 +47,7 @@ class FrameScrubber(QWidget):
         )
 
         # Jump to start
-        self._start_btn = QPushButton("\u25C0\u25C0")  # ◀◀
+        self._start_btn = QPushButton("\u25c0\u25c0")  # ◀◀
         self._start_btn.setFixedWidth(28)
         self._start_btn.setStyleSheet(btn_style)
         self._start_btn.setToolTip("Go to first frame")
@@ -54,7 +55,7 @@ class FrameScrubber(QWidget):
         row.addWidget(self._start_btn)
 
         # Step back
-        self._prev_btn = QPushButton("\u25C0")  # ◀
+        self._prev_btn = QPushButton("\u25c0")  # ◀
         self._prev_btn.setFixedWidth(24)
         self._prev_btn.setStyleSheet(btn_style)
         self._prev_btn.setToolTip("Previous frame")
@@ -62,7 +63,7 @@ class FrameScrubber(QWidget):
         row.addWidget(self._prev_btn)
 
         # Play/Pause toggle
-        self._play_btn = QPushButton("\u25B6")  # ▶ (play icon)
+        self._play_btn = QPushButton("\u25b6")  # ▶ (play icon)
         self._play_btn.setFixedWidth(24)
         self._play_btn.setStyleSheet(btn_style)
         self._play_btn.setToolTip("Play / Pause (Space)")
@@ -110,7 +111,7 @@ class FrameScrubber(QWidget):
         self._center.installEventFilter(self)
 
         # Step forward
-        self._next_btn = QPushButton("\u25B6")  # ▶
+        self._next_btn = QPushButton("\u25b6")  # ▶
         self._next_btn.setFixedWidth(24)
         self._next_btn.setStyleSheet(btn_style)
         self._next_btn.setToolTip("Next frame")
@@ -118,7 +119,7 @@ class FrameScrubber(QWidget):
         row.addWidget(self._next_btn)
 
         # Jump to end
-        self._end_btn = QPushButton("\u25B6\u25B6")  # ▶▶
+        self._end_btn = QPushButton("\u25b6\u25b6")  # ▶▶
         self._end_btn.setFixedWidth(28)
         self._end_btn.setStyleSheet(btn_style)
         self._end_btn.setToolTip("Go to last frame")
@@ -158,7 +159,8 @@ class FrameScrubber(QWidget):
                     self._marker_overlay._become_interactive()
         # Forward tooltip events from overlay or center to correct child
         if event.type() == QEvent.ToolTip and obj in (
-            self._marker_overlay, self._center,
+            self._marker_overlay,
+            self._center,
         ):
             local_y = int(event.pos().y())
             coverage_h = self._coverage_bar.height()
@@ -304,14 +306,14 @@ class FrameScrubber(QWidget):
         if self._total <= 1:
             return
         self._playing = True
-        self._play_btn.setText("\u275A\u275A")  # ❚❚ (pause icon)
+        self._play_btn.setText("\u275a\u275a")  # ❚❚ (pause icon)
         self._play_btn.setToolTip("Pause (Space)")
         self._playback_timer.start()
 
     def _stop_playback(self) -> None:
         self._playing = False
         self._playback_timer.stop()
-        self._play_btn.setText("\u25B6")  # ▶ (play icon)
+        self._play_btn.setText("\u25b6")  # ▶ (play icon)
         self._play_btn.setToolTip("Play (Space)")
 
     def _playback_tick(self) -> None:

--- a/ui/widgets/hotkeys_dialog.py
+++ b/ui/widgets/hotkeys_dialog.py
@@ -3,13 +3,21 @@
 Displays all keyboard shortcuts grouped by category. Users can click
 a key binding button to rebind, with conflict detection and reset-to-default.
 """
+
 from __future__ import annotations
 
 import logging
 
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QScrollArea, QWidget, QLineEdit, QMessageBox,
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QWidget,
+    QLineEdit,
+    QMessageBox,
 )
 from PySide6.QtCore import QKeyCombination, Qt
 from PySide6.QtGui import QKeySequence, QKeyEvent
@@ -37,8 +45,14 @@ class KeyBindButton(QPushButton):
         "border: 1px solid #FFF203; padding: 4px 12px; font-size: 12px; }"
     )
 
-    def __init__(self, action_id: str, key_str: str, registry: ShortcutRegistry,
-                 dialog: HotkeysDialog, parent=None):
+    def __init__(
+        self,
+        action_id: str,
+        key_str: str,
+        registry: ShortcutRegistry,
+        dialog: HotkeysDialog,
+        parent=None,
+    ):
         super().__init__(parent)
         self.action_id = action_id
         self._registry = registry
@@ -87,11 +101,11 @@ class KeyBindButton(QPushButton):
         conflicts = self._registry.find_conflicts(self.action_id, key_str)
         if conflicts:
             conflict_names = ", ".join(
-                d.display_name for d in self._registry.definitions()
-                if d.action_id in conflicts
+                d.display_name for d in self._registry.definitions() if d.action_id in conflicts
             )
             reply = QMessageBox.warning(
-                self, "Shortcut Conflict",
+                self,
+                "Shortcut Conflict",
                 f'"{key_str}" is already assigned to:\n{conflict_names}\n\n'
                 "Reassign anyway? The conflicting binding will be cleared.",
                 QMessageBox.Yes | QMessageBox.No,
@@ -156,9 +170,7 @@ class HotkeysDialog(QDialog):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        scroll.setStyleSheet(
-            "QScrollArea { background: #0E0D00; border: 1px solid #2A2910; }"
-        )
+        scroll.setStyleSheet("QScrollArea { background: #0E0D00; border: 1px solid #2A2910; }")
         content = QWidget()
         content.setStyleSheet("background: #0E0D00;")
         self._content_layout = QVBoxLayout(content)
@@ -221,9 +233,7 @@ class HotkeysDialog(QDialog):
                 reset_btn.setToolTip(f"Reset to default: {defn.default_key}")
                 reset_btn.setCursor(Qt.PointingHandCursor)
                 aid = defn.action_id
-                reset_btn.clicked.connect(
-                    lambda checked, a=aid: self._reset_single(a)
-                )
+                reset_btn.clicked.connect(lambda checked, a=aid: self._reset_single(a))
                 row_layout.addWidget(reset_btn)
 
                 self._content_layout.addWidget(row_widget)
@@ -307,7 +317,8 @@ class HotkeysDialog(QDialog):
 
     def _reset_all(self) -> None:
         reply = QMessageBox.question(
-            self, "Reset All Shortcuts",
+            self,
+            "Reset All Shortcuts",
             "Reset all shortcuts to their default values?",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,

--- a/ui/widgets/io_tray_actions.py
+++ b/ui/widgets/io_tray_actions.py
@@ -12,6 +12,7 @@ This mixin expects to be mixed into a class that has:
   - self.get_selected_clips() -> list[ClipEntry]
   - self._rebuild() -> None
 """
+
 from __future__ import annotations
 
 import logging
@@ -54,17 +55,21 @@ class IOTrayActionsMixin:
 
         # Run Extraction — for clips that have a video source and need frames
         from backend.clip_state import ClipState
+
         needs_extract = [
-            c for c in selected
+            c
+            for c in selected
             if c.state == ClipState.EXTRACTING
             or (c.input_asset and c.input_asset.asset_type == "video")
         ]
         if needs_extract:
-            label_ext = (f"Run Extraction ({len(needs_extract)} clips)"
-                         if len(needs_extract) > 1 else "Run Extraction")
+            label_ext = (
+                f"Run Extraction ({len(needs_extract)} clips)"
+                if len(needs_extract) > 1
+                else "Run Extraction"
+            )
             extract_action = QAction(label_ext, self)
-            extract_action.triggered.connect(
-                lambda: self.extract_requested.emit(needs_extract))
+            extract_action.triggered.connect(lambda: self.extract_requested.emit(needs_extract))
             menu.addAction(extract_action)
             menu.addSeparator()
 
@@ -136,6 +141,7 @@ class IOTrayActionsMixin:
         menu.addAction(remove_action)
 
         from PySide6.QtGui import QCursor
+
         menu.exec(QCursor.pos())
 
     def _on_export_context_menu(self, clip: ClipEntry) -> None:
@@ -143,11 +149,12 @@ class IOTrayActionsMixin:
         menu = QMenu(self)
 
         # Export Video — list each available output subdirectory
-        if clip.state == ClipState.COMPLETE and hasattr(clip, 'output_dir'):
+        if clip.state == ClipState.COMPLETE and hasattr(clip, "output_dir"):
             output_dir = clip.output_dir
             if os.path.isdir(output_dir):
                 subdirs = sorted(
-                    d for d in os.listdir(output_dir)
+                    d
+                    for d in os.listdir(output_dir)
                     if os.path.isdir(os.path.join(output_dir, d))
                     and os.listdir(os.path.join(output_dir, d))
                 )
@@ -156,7 +163,9 @@ class IOTrayActionsMixin:
                         src = os.path.join(output_dir, subdir)
                         action = QAction(f"Export {subdir} as Video...", self)
                         action.triggered.connect(
-                            lambda checked=False, c=clip, s=src: self.export_video_requested.emit(c, s)
+                            lambda checked=False, c=clip, s=src: self.export_video_requested.emit(
+                                c, s
+                            )
                         )
                         menu.addAction(action)
                     menu.addSeparator()
@@ -173,14 +182,18 @@ class IOTrayActionsMixin:
         menu.addAction(open_action)
 
         from PySide6.QtGui import QCursor
+
         menu.exec(QCursor.pos())
 
     def _set_output_dir(self, clip: ClipEntry) -> None:
         """Prompt user to pick a custom output directory for this clip."""
         from backend.project import save_custom_output_dir
+
         start = clip.custom_output_dir or clip.output_dir
         path = QFileDialog.getExistingDirectory(
-            self, f"Output Directory for '{clip.name}'", start,
+            self,
+            f"Output Directory for '{clip.name}'",
+            start,
             QFileDialog.ShowDirsOnly,
         )
         if not path:
@@ -192,6 +205,7 @@ class IOTrayActionsMixin:
     def _clear_output_dir(self, clip: ClipEntry) -> None:
         """Remove per-clip output directory override."""
         from backend.project import save_custom_output_dir
+
         clip.custom_output_dir = ""
         save_custom_output_dir(clip.root_path, None)
         logger.info(f"Cleared custom output dir for '{clip.name}'")
@@ -211,7 +225,10 @@ class IOTrayActionsMixin:
 
         current = clip.name
         new_name, ok = QInputDialog.getText(
-            self, "Rename Clip", "New name:", text=current,
+            self,
+            "Rename Clip",
+            "New name:",
+            text=current,
         )
         if not ok or not new_name.strip() or new_name.strip() == current:
             return
@@ -229,10 +246,12 @@ class IOTrayActionsMixin:
         if len(clips) > 3:
             names += f" (+{len(clips) - 3} more)"
         confirm = QMessageBox.question(
-            self, "Clear Mask",
+            self,
+            "Clear Mask",
             f"Delete tracked masks for {len(clips)} clip(s)?\n{names}\n\n"
             "This will remove all SAM2 mask frames from disk.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if confirm != QMessageBox.Yes:
             return
@@ -293,10 +312,12 @@ class IOTrayActionsMixin:
         if len(clips) > 3:
             names += f" (+{len(clips) - 3} more)"
         confirm = QMessageBox.question(
-            self, "Clear All",
+            self,
+            "Clear All",
             f"Remove ALL generated data for {len(clips)} clip(s)?\n{names}\n\n"
             "This will delete masks, alpha hints, and all output frames.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if confirm != QMessageBox.Yes:
             return
@@ -338,10 +359,12 @@ class IOTrayActionsMixin:
         if len(clips) > 3:
             names += f" (+{len(clips) - 3} more)"
         confirm = QMessageBox.question(
-            self, "Clear Alpha",
+            self,
+            "Clear Alpha",
             f"Delete AlphaHint for {len(clips)} clip(s)?\n{names}\n\n"
             "This will remove all generated alpha hint frames from disk.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if confirm != QMessageBox.Yes:
             return
@@ -370,10 +393,12 @@ class IOTrayActionsMixin:
         if len(clips) > 3:
             names += f" (+{len(clips) - 3} more)"
         confirm = QMessageBox.question(
-            self, "Clear Outputs",
+            self,
+            "Clear Outputs",
             f"Remove all output files for {len(clips)} clip(s)?\n{names}\n\n"
             "This will delete FG, Matte, Comp, and Processed frames.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if confirm != QMessageBox.Yes:
             return
@@ -406,9 +431,7 @@ class IOTrayActionsMixin:
         msg = QMessageBox(self)
         msg.setWindowTitle(title)
         msg.setIcon(QMessageBox.Warning)
-        msg.setText(
-            f"How would you like to remove {n} clip{'s' if n > 1 else ''}?"
-        )
+        msg.setText(f"How would you like to remove {n} clip{'s' if n > 1 else ''}?")
         msg.setInformativeText(paths_text)
 
         btn_list = msg.addButton("Remove from List", QMessageBox.AcceptRole)

--- a/ui/widgets/io_tray_panel.py
+++ b/ui/widgets/io_tray_panel.py
@@ -9,13 +9,22 @@ Ctrl+click to multi-select clips for batch operations.
 Right-click on INPUT cards shows project context menu.
 Supports drag-and-drop of video files and folders.
 """
+
 from __future__ import annotations
 
 import logging
 import os
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QScrollArea, QSplitter,
-    QPushButton, QMenu, QFileDialog, QMessageBox,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QSplitter,
+    QPushButton,
+    QMenu,
+    QFileDialog,
+    QMessageBox,
 )
 from PySide6.QtCore import Qt, Signal
 
@@ -37,13 +46,13 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
     Supports drag-and-drop of video files and folders.
     """
 
-    clip_clicked = Signal(object)   # ClipEntry
+    clip_clicked = Signal(object)  # ClipEntry
     selection_changed = Signal(list)  # list[ClipEntry] — multi-select changed
     clips_dir_changed = Signal(str)  # folder path (import folder)
-    files_imported = Signal(list)    # list of video file paths
+    files_imported = Signal(list)  # list of video file paths
     sequence_folder_imported = Signal(str)  # folder path containing image sequence
     image_files_dropped = Signal(list)  # list of image file paths (for <5 popup)
-    extract_requested = Signal(list) # list[ClipEntry] — re-run extraction
+    extract_requested = Signal(list)  # list[ClipEntry] — re-run extraction
     export_video_requested = Signal(object, str)  # ClipEntry, source_dir — export as video
     reset_in_out_requested = Signal()  # clear all in/out markers
 
@@ -51,7 +60,9 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
         super().__init__(parent)
         self.setObjectName("ioTrayPanel")
         self._model = model
-        self._select_anchor: str | None = None  # last single-clicked clip name for Shift+click range
+        self._select_anchor: str | None = (
+            None  # last single-clicked clip name for Shift+click range
+        )
         self.setMinimumHeight(80)
         self.setMaximumHeight(600)
         self.setAcceptDrops(True)
@@ -63,9 +74,7 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
         # Content: two strips in a splitter (synced with dual viewer divider)
         self._tray_splitter = QSplitter(Qt.Horizontal)
         self._tray_splitter.setHandleWidth(1)
-        self._tray_splitter.setStyleSheet(
-            "QSplitter::handle { background-color: #2A2910; }"
-        )
+        self._tray_splitter.setStyleSheet("QSplitter::handle { background-color: #2A2910; }")
 
         # Input section
         input_widget = QWidget()
@@ -177,7 +186,8 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
         clips_with_range = [c for c in self._model.clips if c.in_out_range is not None]
         if not clips_with_range:
             QMessageBox.information(
-                self, "No Markers",
+                self,
+                "No Markers",
                 "No clips have in/out markers set.",
             )
             return
@@ -185,21 +195,25 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
         n = len(clips_with_range)
         # First confirmation
         result = QMessageBox.question(
-            self, "Reset In/Out Markers",
+            self,
+            "Reset In/Out Markers",
             f"This will clear in/out markers on {n} clip{'s' if n > 1 else ''}.\n\n"
             "All clips will revert to full-clip processing.\n"
             "Continue?",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if result != QMessageBox.Yes:
             return
 
         # Second confirmation
         result2 = QMessageBox.warning(
-            self, "Confirm Reset",
+            self,
+            "Confirm Reset",
             f"Are you sure? This cannot be undone.\n\n"
             f"Clearing in/out markers on {n} clip{'s' if n > 1 else ''}.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if result2 != QMessageBox.Yes:
             return
@@ -209,7 +223,9 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
 
     def _import_folder(self) -> None:
         dir_path = QFileDialog.getExistingDirectory(
-            self, "Select Clips Directory", "",
+            self,
+            "Select Clips Directory",
+            "",
             QFileDialog.ShowDirsOnly,
         )
         if dir_path:
@@ -217,7 +233,9 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
 
     def _import_videos(self) -> None:
         paths, _ = QFileDialog.getOpenFileNames(
-            self, "Select Video Files", "",
+            self,
+            "Select Video Files",
+            "",
             VIDEO_FILE_FILTER,
         )
         if paths:
@@ -225,7 +243,9 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
 
     def _import_image_sequence(self) -> None:
         dir_path = QFileDialog.getExistingDirectory(
-            self, "Select Image Sequence Folder", "",
+            self,
+            "Select Image Sequence Folder",
+            "",
             QFileDialog.ShowDirsOnly,
         )
         if dir_path:
@@ -239,6 +259,7 @@ class IOTrayPanel(IOTrayActionsMixin, QWidget):
 
     def dropEvent(self, event) -> None:
         from backend.project import folder_has_image_sequence
+
         folders = []
         video_files = []
         image_files = []

--- a/ui/widgets/parameter_panel.py
+++ b/ui/widgets/parameter_panel.py
@@ -1,9 +1,18 @@
 """Right panel — alpha generation, tracking, and output config."""
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QSlider,
-    QComboBox, QCheckBox, QSpinBox, QPushButton, QGroupBox,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QSlider,
+    QComboBox,
+    QCheckBox,
+    QSpinBox,
+    QPushButton,
+    QGroupBox,
     QScrollArea,
 )
 from PySide6.QtCore import Qt, Signal, QEvent
@@ -36,6 +45,7 @@ class _WheelGuard(QWidget):
             event.ignore()
             return True
         return False
+
 
 from backend import InferenceParams, OutputConfig
 
@@ -70,9 +80,9 @@ class ParameterPanel(QWidget):
 
     params_changed = Signal()  # emitted when any parameter changes
     parallel_frames_changed = Signal(int)  # parallel engine count changed
-    gvm_requested = Signal()      # GVM AUTO button clicked
+    gvm_requested = Signal()  # GVM AUTO button clicked
     birefnet_requested = Signal(str)  # BiRefNet button clicked, emits model variant name
-    videomama_requested = Signal() # VIDEOMAMA button clicked
+    videomama_requested = Signal()  # VIDEOMAMA button clicked
     matanyone2_requested = Signal()  # MatAnyone2 button clicked
     track_masks_requested = Signal()  # Track annotation prompts into dense masks
     import_alpha_requested = Signal()  # Import own AlphaHint folder
@@ -148,10 +158,12 @@ class ParameterPanel(QWidget):
         self._birefnet_model.setToolTip("BiRefNet model variant — changes take effect on next run.")
         # Populate from the wrapper's model registry
         from modules.BiRefNetModule.wrapper import BIREFNET_MODELS, DEFAULT_MODEL
+
         for display_name in BIREFNET_MODELS:
             self._birefnet_model.addItem(display_name)
         # Restore last-used model from QSettings
         from PySide6.QtCore import QSettings
+
         saved_model = QSettings().value("alpha/birefnet_model", DEFAULT_MODEL)
         idx = self._birefnet_model.findText(saved_model)
         if idx >= 0:
@@ -342,7 +354,9 @@ class ParameterPanel(QWidget):
         self._fg_format = QComboBox()
         self._fg_format.addItems(["exr", "png"])
         self._fg_format.setFixedWidth(70)
-        self._fg_format.setToolTip("EXR = 32-bit float (post-production).\nPNG = 8-bit (general use).")
+        self._fg_format.setToolTip(
+            "EXR = 32-bit float (post-production).\nPNG = 8-bit (general use)."
+        )
         fg_row.addWidget(self._fg_format)
         out_layout.addLayout(fg_row)
 
@@ -359,7 +373,9 @@ class ParameterPanel(QWidget):
         self._matte_format = QComboBox()
         self._matte_format.addItems(["exr", "png"])
         self._matte_format.setFixedWidth(70)
-        self._matte_format.setToolTip("EXR = 32-bit float (post-production).\nPNG = 8-bit (general use).")
+        self._matte_format.setToolTip(
+            "EXR = 32-bit float (post-production).\nPNG = 8-bit (general use)."
+        )
         matte_row.addWidget(self._matte_format)
         out_layout.addLayout(matte_row)
 
@@ -376,7 +392,9 @@ class ParameterPanel(QWidget):
         self._comp_format = QComboBox()
         self._comp_format.addItems(["png", "exr"])
         self._comp_format.setFixedWidth(70)
-        self._comp_format.setToolTip("PNG = 8-bit with transparency.\nEXR = 32-bit float (post-production).")
+        self._comp_format.setToolTip(
+            "PNG = 8-bit with transparency.\nEXR = 32-bit float (post-production)."
+        )
         comp_row.addWidget(self._comp_format)
         out_layout.addLayout(comp_row)
 
@@ -393,7 +411,9 @@ class ParameterPanel(QWidget):
         self._proc_format = QComboBox()
         self._proc_format.addItems(["exr", "png"])
         self._proc_format.setFixedWidth(70)
-        self._proc_format.setToolTip("EXR = 32-bit float (recommended for Processed).\nPNG = 8-bit (lossy for straight linear RGBA).")
+        self._proc_format.setToolTip(
+            "EXR = 32-bit float (recommended for Processed).\nPNG = 8-bit (lossy for straight linear RGBA)."
+        )
         proc_row.addWidget(self._proc_format)
         out_layout.addLayout(proc_row)
 
@@ -422,7 +442,12 @@ class ParameterPanel(QWidget):
             "CUDA only right now. Not currently supported on Apple Silicon."
         )
         self._parallel_spin.setFixedWidth(60)
-        from ui.widgets.preferences_dialog import get_setting_int, KEY_PARALLEL_CLIPS, DEFAULT_PARALLEL_CLIPS
+        from ui.widgets.preferences_dialog import (
+            get_setting_int,
+            KEY_PARALLEL_CLIPS,
+            DEFAULT_PARALLEL_CLIPS,
+        )
+
         self._parallel_spin.setValue(get_setting_int(KEY_PARALLEL_CLIPS, DEFAULT_PARALLEL_CLIPS))
         self._parallel_spin.valueChanged.connect(self._on_parallel_changed)
         parallel_row.addWidget(self._parallel_spin)
@@ -437,9 +462,9 @@ class ParameterPanel(QWidget):
 
         # Middle-click reset: map widget → (setter_callable, default_value)
         self._middle_click_defaults: dict[QWidget, tuple] = {
-            self._despill_slider: (self._despill_slider.setValue, 5),       # 0.5
-            self._refiner_slider: (self._refiner_slider.setValue, 10),      # 1.0
-            self._despeckle_size: (self._despeckle_size.setValue, 400),      # 400px
+            self._despill_slider: (self._despill_slider.setValue, 5),  # 0.5
+            self._refiner_slider: (self._refiner_slider.setValue, 10),  # 1.0
+            self._despeckle_size: (self._despeckle_size.setValue, 400),  # 400px
         }
         for widget in self._middle_click_defaults:
             widget.installEventFilter(self)
@@ -478,11 +503,13 @@ class ParameterPanel(QWidget):
     def _on_birefnet_model_changed(self, text: str) -> None:
         """Persist the selected BiRefNet model variant to QSettings."""
         from PySide6.QtCore import QSettings
+
         QSettings().setValue("alpha/birefnet_model", text)
 
     def _on_parallel_changed(self, value: int) -> None:
         from PySide6.QtCore import QSettings
         from ui.widgets.preferences_dialog import KEY_PARALLEL_CLIPS
+
         QSettings().setValue(KEY_PARALLEL_CLIPS, value)
         self.parallel_frames_changed.emit(value)
 
@@ -498,15 +525,18 @@ class ParameterPanel(QWidget):
             auto_despeckle=self._despeckle_check.isChecked(),
             despeckle_size=self._despeckle_size.value(),
             despeckle_dilation=25,  # fixed default
-            despeckle_blur=5,       # fixed default
+            despeckle_blur=5,  # fixed default
             refiner_scale=self._refiner_slider.value() / 10.0,
         )
 
     def get_output_config(self) -> OutputConfig:
         """Snapshot current output format configuration."""
         from ui.widgets.preferences_dialog import (
-            KEY_EXR_COMPRESSION, DEFAULT_EXR_COMPRESSION, get_setting_str,
+            KEY_EXR_COMPRESSION,
+            DEFAULT_EXR_COMPRESSION,
+            get_setting_str,
         )
+
         return OutputConfig(
             fg_enabled=self._fg_check.isChecked(),
             fg_format=self._fg_format.currentText(),

--- a/ui/widgets/preferences_dialog.py
+++ b/ui/widgets/preferences_dialog.py
@@ -2,15 +2,29 @@
 
 Provides user-configurable settings that persist across sessions via QSettings.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
 
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QCheckBox, QPushButton, QLabel,
-    QComboBox, QGroupBox, QProgressBar, QMessageBox, QApplication,
-    QLineEdit, QFileDialog, QScrollArea, QWidget, QFrame,
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QCheckBox,
+    QPushButton,
+    QLabel,
+    QComboBox,
+    QGroupBox,
+    QProgressBar,
+    QMessageBox,
+    QApplication,
+    QLineEdit,
+    QFileDialog,
+    QScrollArea,
+    QWidget,
+    QFrame,
 )
 from PySide6.QtCore import QSettings, Qt, QUrl, QThread, Signal, QEvent
 
@@ -64,6 +78,7 @@ DEFAULT_TRACKER_MODEL = "facebook/sam2.1-hiera-base-plus"
 DEFAULT_PARALLEL_CLIPS = 1
 import platform as _platform
 import sys as _sys
+
 # MPS/MLX (Apple Silicon) defaults to 1024 — 2048 needs 20GB+ and is very slow.
 # CUDA defaults to 2048 (dedicated VRAM handles it fine).
 _is_apple_silicon = _sys.platform == "darwin" and _platform.machine() == "arm64"
@@ -153,6 +168,7 @@ class PreferencesDialog(QDialog):
         self.setModal(True)
         # Ctrl+, closes the dialog (toggle behavior matching F12 pattern)
         from PySide6.QtGui import QShortcut, QKeySequence
+
         QShortcut(QKeySequence("Ctrl+,"), self, self.reject)
         self._ffmpeg_repair_worker: _FFmpegRepairWorker | None = None
         self._local_ffmpeg_dir = get_local_ffmpeg_dir()
@@ -185,15 +201,11 @@ class PreferencesDialog(QDialog):
         ui_layout = QVBoxLayout(ui_group)
 
         self._tooltips_cb = QCheckBox("Show tooltips on controls")
-        self._tooltips_cb.setChecked(
-            get_setting_bool(KEY_SHOW_TOOLTIPS, DEFAULT_SHOW_TOOLTIPS)
-        )
+        self._tooltips_cb.setChecked(get_setting_bool(KEY_SHOW_TOOLTIPS, DEFAULT_SHOW_TOOLTIPS))
         ui_layout.addWidget(self._tooltips_cb)
 
         self._sounds_cb = QCheckBox("UI sounds")
-        self._sounds_cb.setChecked(
-            get_setting_bool(KEY_UI_SOUNDS, DEFAULT_UI_SOUNDS)
-        )
+        self._sounds_cb.setChecked(get_setting_bool(KEY_UI_SOUNDS, DEFAULT_UI_SOUNDS))
         ui_layout.addWidget(self._sounds_cb)
 
         # (added to layout below in display order)
@@ -208,9 +220,7 @@ class PreferencesDialog(QDialog):
             "When disabled, the project references the original file in place.\n\n"
             "Note: Deleting a project never touches the original source file."
         )
-        self._copy_source_cb.setChecked(
-            get_setting_bool(KEY_COPY_SOURCE, DEFAULT_COPY_SOURCE)
-        )
+        self._copy_source_cb.setChecked(get_setting_bool(KEY_COPY_SOURCE, DEFAULT_COPY_SOURCE))
         proj_layout.addWidget(self._copy_source_cb)
 
         self._copy_sequences_cb = QCheckBox("Copy imported image sequences into project folder")
@@ -341,9 +351,7 @@ class PreferencesDialog(QDialog):
             "When enabled, playback loops back to the in-point\n"
             "after reaching the out-point (or start/end if no range)."
         )
-        self._loop_cb.setChecked(
-            get_setting_bool(KEY_LOOP_PLAYBACK, DEFAULT_LOOP_PLAYBACK)
-        )
+        self._loop_cb.setChecked(get_setting_bool(KEY_LOOP_PLAYBACK, DEFAULT_LOOP_PLAYBACK))
         play_layout.addWidget(self._loop_cb)
 
         # (added to layout below in display order)
@@ -523,6 +531,7 @@ class PreferencesDialog(QDialog):
         s.setValue(KEY_OUTPUT_DIRECTORY, self._output_dir_edit.text().strip())
         # Apply sound mute immediately
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.set_muted(not self._sounds_cb.isChecked())
         self.accept()
 
@@ -530,7 +539,9 @@ class PreferencesDialog(QDialog):
         """Open folder picker for default output directory."""
         start = self._output_dir_edit.text() or ""
         path = QFileDialog.getExistingDirectory(
-            self, "Select Default Output Directory", start,
+            self,
+            "Select Default Output Directory",
+            start,
             QFileDialog.ShowDirsOnly,
         )
         if path:
@@ -574,6 +585,7 @@ class PreferencesDialog(QDialog):
     def _on_download_models(self) -> None:
         """Open the model download dialog (same UI as the first-launch wizard)."""
         from ui.widgets.setup_wizard import SetupWizard
+
         dialog = SetupWizard(parent=self)
         dialog.setWindowTitle("Download Models")
         dialog.exec()
@@ -581,7 +593,6 @@ class PreferencesDialog(QDialog):
     def _on_repair_ffmpeg(self) -> None:
         """Repair FFmpeg on Windows or show manual install guidance elsewhere."""
         from backend.ffmpeg_tools import get_ffmpeg_install_help, validate_ffmpeg_install
-        import sys
 
         current = validate_ffmpeg_install(require_probe=True)
         if current.ok:

--- a/ui/widgets/preview_viewport.py
+++ b/ui/widgets/preview_viewport.py
@@ -10,6 +10,7 @@ Architecture (Codex findings incorporated):
 - Worker preview gated: only applied if viewing same clip + COMP mode + latest frame
 - Frame list snapshot built once per clip selection (atomic)
 """
+
 from __future__ import annotations
 
 import os
@@ -202,9 +203,7 @@ class PreviewViewport(QWidget):
             self._split_view._single_image = None
             self._split_view._left_image = None
             self._split_view._right_image = None
-            self._split_view.set_placeholder(
-                f"Extracting frames...\n{clip.name}"
-            )
+            self._split_view.set_placeholder(f"Extracting frames...\n{clip.name}")
             return
 
         # Build frame index
@@ -320,7 +319,9 @@ class PreviewViewport(QWidget):
         video_path = clip.input_asset.path if (clip.input_asset and asset_type == "video") else None
         seq_dir = clip.input_asset.path if (clip.input_asset and asset_type == "sequence") else None
         return build_frame_index(
-            clip.root_path, asset_type, video_path=video_path,
+            clip.root_path,
+            asset_type,
+            video_path=video_path,
             input_sequence_dir=seq_dir,
         )
 
@@ -390,7 +391,7 @@ class PreviewViewport(QWidget):
             else:
                 parts.append("sequence")
         parts.append(clip.state.value)
-        self._clip_info.setText("  \u00B7  ".join(parts))  # middle dot separator
+        self._clip_info.setText("  \u00b7  ".join(parts))  # middle dot separator
 
     def set_split_mode(self, enabled: bool) -> None:
         """Toggle split view on/off."""
@@ -437,10 +438,14 @@ class PreviewViewport(QWidget):
             video_path = self._frame_index.video_modes.get(mode)
             if video_path:
                 self._decoder.request_decode(
-                    "", mode, stem_index,
+                    "",
+                    mode,
+                    stem_index,
                     video_path=video_path,
                     video_frame_index=stem_index,
-                    input_exr_is_linear=(self._input_exr_is_linear if mode == ViewMode.INPUT else False),
+                    input_exr_is_linear=(
+                        self._input_exr_is_linear if mode == ViewMode.INPUT else False
+                    ),
                 )
             return
 
@@ -451,13 +456,13 @@ class PreviewViewport(QWidget):
                 path,
                 mode,
                 stem_index,
-                input_exr_is_linear=(self._input_exr_is_linear if mode == ViewMode.INPUT else False),
+                input_exr_is_linear=(
+                    self._input_exr_is_linear if mode == ViewMode.INPUT else False
+                ),
             )
         else:
             # Frame not available in this mode for this stem
-            self._split_view.set_placeholder(
-                f"No {mode.value} frame for stem {stem_index}"
-            )
+            self._split_view.set_placeholder(f"No {mode.value} frame for stem {stem_index}")
 
     def _load_split_images(self) -> None:
         """Load both input and current-mode images for split view."""

--- a/ui/widgets/queue_panel.py
+++ b/ui/widgets/queue_panel.py
@@ -8,11 +8,19 @@ The tab is always present — click it to expand or collapse.
 Progress bars update in-place (no widget rebuild per frame) so the bar
 moves smoothly instead of stuttering on every progress tick.
 """
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QProgressBar, QScrollArea, QFrame, QSizePolicy,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QProgressBar,
+    QScrollArea,
+    QFrame,
+    QSizePolicy,
 )
 from PySide6.QtCore import Qt, Signal, QTimer
 
@@ -55,11 +63,24 @@ _ROW_H = 60
 
 class _JobRowCache:
     """Cached widgets for a single job row, enabling in-place updates."""
-    __slots__ = ("frame", "progress_bar", "frame_label", "status_label",
-                 "last_status", "last_current", "last_total")
 
-    def __init__(self, frame: QFrame, progress_bar: QProgressBar | None,
-                 frame_label: QLabel | None, status_label: QLabel | None):
+    __slots__ = (
+        "frame",
+        "progress_bar",
+        "frame_label",
+        "status_label",
+        "last_status",
+        "last_current",
+        "last_total",
+    )
+
+    def __init__(
+        self,
+        frame: QFrame,
+        progress_bar: QProgressBar | None,
+        frame_label: QLabel | None,
+        status_label: QLabel | None,
+    ):
         self.frame = frame
         self.progress_bar = progress_bar
         self.frame_label = frame_label
@@ -119,9 +140,7 @@ class QueuePanel(QWidget):
 
         # ── Content panel (shown when expanded) ──
         self._panel = QWidget()
-        self._panel.setStyleSheet(
-            "background-color: #0E0D00; border-right: 1px solid #2A2910;"
-        )
+        self._panel.setStyleSheet("background-color: #0E0D00; border-right: 1px solid #2A2910;")
         self._panel.setFixedWidth(_CONTENT_W)
         panel_layout = QVBoxLayout(self._panel)
         panel_layout.setContentsMargins(0, 0, 0, 0)
@@ -169,9 +188,7 @@ class QueuePanel(QWidget):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        scroll.setStyleSheet(
-            "QScrollArea { border: none; background: transparent; }"
-        )
+        scroll.setStyleSheet("QScrollArea { border: none; background: transparent; }")
         self._scroll = scroll
 
         self._job_container = QWidget()
@@ -276,9 +293,11 @@ class QueuePanel(QWidget):
             cache = self._row_cache.get(job.id)
             if cache is None:
                 continue
-            if (job.status == cache.last_status
-                    and job.current_frame == cache.last_current
-                    and job.total_frames == cache.last_total):
+            if (
+                job.status == cache.last_status
+                and job.current_frame == cache.last_current
+                and job.total_frames == cache.last_total
+            ):
                 continue
             self._update_row_in_place(cache, job)
 
@@ -302,9 +321,7 @@ class QueuePanel(QWidget):
         """Create a single job row — vertical stack: type+clip, progress/status."""
         row = QFrame()
         row.setFixedHeight(_ROW_H)
-        row.setStyleSheet(
-            "QFrame { background-color: #1A1900; border-bottom: 1px solid #151400; }"
-        )
+        row.setStyleSheet("QFrame { background-color: #1A1900; border-bottom: 1px solid #151400; }")
         layout = QVBoxLayout(row)
         layout.setContentsMargins(8, 4, 8, 4)
         layout.setSpacing(2)
@@ -335,9 +352,7 @@ class QueuePanel(QWidget):
             )
             dismiss_btn.setToolTip("Dismiss")
             job_id = job.id
-            dismiss_btn.clicked.connect(
-                lambda checked, jid=job_id: self._dismiss_job(jid)
-            )
+            dismiss_btn.clicked.connect(lambda checked, jid=job_id: self._dismiss_job(jid))
             top.addWidget(dismiss_btn)
 
         layout.addLayout(top)

--- a/ui/widgets/recent_projects_panel.py
+++ b/ui/widgets/recent_projects_panel.py
@@ -4,6 +4,7 @@ Shows a scrollable list of project cards representing recently-opened
 projects. Each card shows the project name, path, and last opened date,
 with an always-visible delete button. Right-click for rename/delete.
 """
+
 from __future__ import annotations
 
 import logging
@@ -14,9 +15,16 @@ import sys
 logger = logging.getLogger(__name__)
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel,
-    QFrame, QPushButton, QScrollArea, QMessageBox,
-    QMenu, QInputDialog,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QScrollArea,
+    QMessageBox,
+    QMenu,
+    QInputDialog,
 )
 from PySide6.QtCore import Qt, Signal, QUrl
 from PySide6.QtGui import QAction, QDesktopServices
@@ -27,7 +35,7 @@ from ui.recent_sessions import RecentSessionsStore, RecentSession
 class RecentProjectCard(QFrame):
     """Single project card — clickable row with always-visible X button."""
 
-    clicked = Signal(str)         # workspace_path
+    clicked = Signal(str)  # workspace_path
     delete_clicked = Signal(str)  # workspace_path
     rename_clicked = Signal(str)  # workspace_path
 
@@ -51,7 +59,7 @@ class RecentProjectCard(QFrame):
 
         btn_layout.addStretch(1)
 
-        folder_btn = QPushButton("\uD83D\uDCC2")  # open folder icon
+        folder_btn = QPushButton("\ud83d\udcc2")  # open folder icon
         folder_btn.setObjectName("projectFolderBtn")
         folder_btn.setFixedSize(16, 16)
         folder_btn.setToolTip("Open in Finder" if sys.platform == "darwin" else "Open in Explorer")
@@ -60,7 +68,7 @@ class RecentProjectCard(QFrame):
 
         btn_layout.addStretch(2)
 
-        delete_btn = QPushButton("\u00D7")  # ×
+        delete_btn = QPushButton("\u00d7")  # ×
         delete_btn.setObjectName("projectDeleteBtn")
         delete_btn.setFixedSize(16, 16)
         delete_btn.setToolTip("Remove project")
@@ -88,12 +96,14 @@ class RecentProjectCard(QFrame):
 
     def enterEvent(self, event):
         from ui.sounds.audio_manager import UIAudio
+
         UIAudio.hover()
         super().enterEvent(event)
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             from ui.sounds.audio_manager import UIAudio
+
             UIAudio.click()  # ProjectCard is not QPushButton, manual click needed
             self.clicked.emit(self._workspace_path)
         super().mousePressEvent(event)
@@ -123,8 +133,8 @@ class RecentProjectCard(QFrame):
 class RecentProjectsPanel(QWidget):
     """Scrollable list of recent project cards."""
 
-    project_selected = Signal(str)   # workspace_path
-    project_deleted = Signal(str)    # workspace_path
+    project_selected = Signal(str)  # workspace_path
+    project_deleted = Signal(str)  # workspace_path
 
     def __init__(self, store: RecentSessionsStore, parent=None):
         super().__init__(parent)
@@ -169,6 +179,7 @@ class RecentProjectsPanel(QWidget):
         """Check if a path is the Projects root directory."""
         try:
             from backend.project import projects_root
+
             return os.path.normcase(os.path.abspath(path)) == os.path.normcase(
                 os.path.abspath(projects_root())
             )
@@ -208,7 +219,10 @@ class RecentProjectsPanel(QWidget):
 
         current_name = get_display_name(workspace_path)
         new_name, ok = QInputDialog.getText(
-            self, "Rename Project", "Project name:", text=current_name,
+            self,
+            "Rename Project",
+            "Project name:",
+            text=current_name,
         )
         if ok and new_name.strip() and new_name.strip() != current_name:
             new_name = new_name.strip()
@@ -226,6 +240,7 @@ class RecentProjectsPanel(QWidget):
         Safety: refuses to delete the Projects root directory.
         """
         from backend.project import get_display_name
+
         name = get_display_name(workspace_path)
 
         # Safety: never allow disk-delete of the Projects root
@@ -236,7 +251,7 @@ class RecentProjectsPanel(QWidget):
 
         msg = QMessageBox(self)
         msg.setWindowTitle("Remove Project")
-        msg.setText(f"Remove \"{name}\" from recent projects?")
+        msg.setText(f'Remove "{name}" from recent projects?')
         msg.setInformativeText(
             "Remove from List: hides it from recents (files stay on disk).\n"
             "Delete from Disk: permanently deletes the project folder."
@@ -257,7 +272,8 @@ class RecentProjectsPanel(QWidget):
         elif clicked == delete_btn:
             # Second confirmation with path shown
             confirm = QMessageBox.warning(
-                self, "Confirm Delete",
+                self,
+                "Confirm Delete",
                 f"Permanently delete this project folder?\n\n{workspace_path}",
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,
@@ -267,20 +283,20 @@ class RecentProjectsPanel(QWidget):
                 try:
                     # Safety: only delete if path is inside the Projects root
                     from backend.project import projects_root
+
                     root = os.path.realpath(projects_root())
                     target = os.path.realpath(workspace_path)
                     if not target.startswith(root + os.sep):
                         logger.warning(f"Refusing to delete outside Projects folder: {target}")
-                        raise OSError(
-                            f"Refusing to delete outside Projects folder: {target}"
-                        )
+                        raise OSError(f"Refusing to delete outside Projects folder: {target}")
                     if os.path.isdir(workspace_path):
                         logger.info(f"Deleting project folder: {workspace_path}")
                         shutil.rmtree(workspace_path)
                 except OSError as e:
                     logger.error(f"Failed to delete project: {e}")
                     QMessageBox.warning(
-                        self, "Delete Failed",
+                        self,
+                        "Delete Failed",
                         f"Could not delete project:\n{e}",
                     )
                 self.project_deleted.emit(workspace_path)

--- a/ui/widgets/report_issue_dialog.py
+++ b/ui/widgets/report_issue_dialog.py
@@ -3,6 +3,7 @@
 Collects a user description, auto-gathers system info and recent error logs,
 then opens the default browser to a pre-filled GitHub issue page.
 """
+
 from __future__ import annotations
 
 import logging
@@ -34,8 +35,9 @@ _MAX_URL_LENGTH = 7500  # stay well under 8192 to avoid 414 errors
 def _get_app_version() -> str:
     """Read app version from pyproject.toml (single source of truth)."""
     import tomllib
+
     candidates = []
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         candidates.append(os.path.join(sys._MEIPASS, "pyproject.toml"))
     candidates.append(
         os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "pyproject.toml")
@@ -160,6 +162,7 @@ class ReportIssueDialog(QDialog):
         # PyTorch + CUDA
         try:
             import torch
+
             pairs.append(("PyTorch", torch.version.__version__))
             if torch.cuda.is_available():
                 pairs.append(("CUDA", torch.version.cuda or "N/A"))
@@ -175,10 +178,9 @@ class ReportIssueDialog(QDialog):
         if gpu.get("name"):
             pairs.append(("GPU", gpu["name"]))
             if "total_gb" in gpu and "used_gb" in gpu:
-                pairs.append((
-                    "VRAM",
-                    f"{gpu['total_gb']:.1f} GB total, {gpu['used_gb']:.1f} GB used"
-                ))
+                pairs.append(
+                    ("VRAM", f"{gpu['total_gb']:.1f} GB total, {gpu['used_gb']:.1f} GB used")
+                )
         else:
             pairs.append(("GPU", "N/A"))
 
@@ -202,9 +204,7 @@ class ReportIssueDialog(QDialog):
 
     def _build_system_info_md(self) -> str:
         """Markdown-formatted system info for the GitHub issue body."""
-        return "\n".join(
-            f"- **{label}:** {value}" for label, value in self._gather_info_pairs()
-        )
+        return "\n".join(f"- **{label}:** {value}" for label, value in self._gather_info_pairs())
 
     # ------------------------------------------------------------------
     # URL builder

--- a/ui/widgets/setup_wizard.py
+++ b/ui/widgets/setup_wizard.py
@@ -4,6 +4,7 @@ Shown automatically when the required CorridorKey checkpoint is missing.
 Provides the same model selection as 1-install.sh / 1-install.bat but in
 a PySide6 GUI with checkboxes and progress bars.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -11,15 +12,22 @@ import logging
 import os
 import platform
 import sys
-import traceback
 from pathlib import Path
 
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QCheckBox,
-    QPushButton, QProgressBar, QWidget,
-    QFrame, QLineEdit, QFileDialog,
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QCheckBox,
+    QPushButton,
+    QProgressBar,
+    QWidget,
+    QFrame,
+    QLineEdit,
+    QFileDialog,
 )
-from PySide6.QtCore import Qt, Signal, QThread, QObject
+from PySide6.QtCore import Qt, Signal, QThread
 from PySide6.QtGui import QFont
 
 logger = logging.getLogger(__name__)
@@ -27,6 +35,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Path helpers
 # ---------------------------------------------------------------------------
+
 
 def _project_root() -> Path:
     if getattr(sys, "frozen", False):
@@ -53,6 +62,7 @@ def _data_root() -> Path:
         return _project_root()
     try:
         from backend.project import get_data_dir
+
         return Path(get_data_dir())
     except ImportError:
         return _default_install_dir()
@@ -80,14 +90,16 @@ MODELS: list[dict] = [
 ]
 
 if _IS_APPLE_SILICON:
-    MODELS.append({
-        "key": "corridorkey-mlx",
-        "label": "CorridorKey MLX (Apple Silicon)",
-        "size": "380 MB",
-        "required": False,
-        "description": "1.5-2x faster inference on Apple Silicon",
-        "default_checked": True,
-    })
+    MODELS.append(
+        {
+            "key": "corridorkey-mlx",
+            "label": "CorridorKey MLX (Apple Silicon)",
+            "size": "380 MB",
+            "required": False,
+            "description": "1.5-2x faster inference on Apple Silicon",
+            "default_checked": True,
+        }
+    )
 
 MODELS += [
     {
@@ -127,6 +139,7 @@ MODELS += [
 
 def needs_setup() -> bool:
     import glob
+
     ckpt_dir = _checkpoint_dir()
     return len(glob.glob(str(ckpt_dir / "*.pth"))) == 0
 
@@ -134,6 +147,7 @@ def needs_setup() -> bool:
 # ---------------------------------------------------------------------------
 # Import setup_models
 # ---------------------------------------------------------------------------
+
 
 def _load_setup_models():
     script_path = _project_root() / "scripts" / "setup_models.py"
@@ -151,16 +165,18 @@ def _load_setup_models():
 # Download worker
 # ---------------------------------------------------------------------------
 
+
 class _DownloadWorker(QThread):
     """Download selected models sequentially in a background thread.
 
     IMPORTANT: This thread must be properly waited on before the parent
     dialog is destroyed, otherwise Qt will abort() on ~QThread.
     """
-    model_started = Signal(str, str)          # key, label
-    model_progress = Signal(str, int, int)    # key, downloaded_mb, total_mb
-    model_finished = Signal(str, bool, str)   # key, success, message
-    all_finished = Signal(bool)               # overall success
+
+    model_started = Signal(str, str)  # key, label
+    model_progress = Signal(str, int, int)  # key, downloaded_mb, total_mb
+    model_finished = Signal(str, bool, str)  # key, success, message
+    all_finished = Signal(bool)  # overall success
 
     def __init__(self, selected_keys: list[str], parent=None):
         super().__init__(parent)
@@ -174,7 +190,7 @@ class _DownloadWorker(QThread):
     def run(self):
         try:
             setup_models = _load_setup_models()
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to load setup_models")
             self.all_finished.emit(False)
             return
@@ -192,7 +208,7 @@ class _DownloadWorker(QThread):
 
             try:
                 ok = self._download_one(setup_models, key)
-            except Exception as e:
+            except Exception:
                 logger.exception("Download failed for %s", key)
                 ok = False
 
@@ -222,10 +238,10 @@ class _DownloadWorker(QThread):
 
     def _patch_mlx_progress(self, setup_models):
         worker = self
-        original = setup_models.download_corridorkey_mlx
 
         def patched():
             import urllib.request
+
             cfg = setup_models.MLX_CHECKPOINT
             local_dir = cfg["local_dir"]
             local_dir.mkdir(parents=True, exist_ok=True)
@@ -237,6 +253,7 @@ class _DownloadWorker(QThread):
 
             tmp = dest.with_suffix(".safetensors.tmp")
             try:
+
                 def hook(bn, bs, total):
                     if total > 0 and not worker._cancelled:
                         worker.model_progress.emit(
@@ -244,9 +261,11 @@ class _DownloadWorker(QThread):
                             (bn * bs) // (1024 * 1024),
                             total // (1024 * 1024),
                         )
+
                 urllib.request.urlretrieve(cfg["url"], str(tmp), reporthook=hook)
                 try:
                     import hashlib
+
                     resp = urllib.request.urlopen(cfg["sha256_url"])
                     expected = resp.read().decode().strip().split()[0]
                     actual = hashlib.sha256(tmp.read_bytes()).hexdigest()
@@ -265,11 +284,14 @@ class _DownloadWorker(QThread):
 
         try:
             import huggingface_hub
+
             orig_hf = huggingface_hub.hf_hub_download
+
             def patched_hf(*a, **kw):
                 r = orig_hf(*a, **kw)
                 worker.model_progress.emit(worker._current_key, 100, 100)
                 return r
+
             huggingface_hub.hf_hub_download = patched_hf
         except ImportError:
             pass
@@ -278,6 +300,7 @@ class _DownloadWorker(QThread):
 # ---------------------------------------------------------------------------
 # Model row widget
 # ---------------------------------------------------------------------------
+
 
 class _ModelRow(QWidget):
     def __init__(self, model: dict, parent=None):
@@ -364,6 +387,7 @@ class _ModelRow(QWidget):
 # Setup Wizard Dialog
 # ---------------------------------------------------------------------------
 
+
 class SetupWizard(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -380,7 +404,9 @@ class SetupWizard(QDialog):
         layout.setSpacing(16)
         layout.setContentsMargins(28, 28, 28, 28)
 
-        title = QLabel('Welcome to <span style="color:#FFF203;">EZ</span><span style="color:#4CAF50;">-</span><span style="color:#FFF203;">Corridor</span><span style="color:#4CAF50;">Key</span>')
+        title = QLabel(
+            'Welcome to <span style="color:#FFF203;">EZ</span><span style="color:#4CAF50;">-</span><span style="color:#FFF203;">Corridor</span><span style="color:#4CAF50;">Key</span>'
+        )
         title.setFont(QFont("Open Sans", 18, QFont.Bold))
         title.setAlignment(Qt.AlignCenter)
         title.setStyleSheet("color: #FFFFFF;")
@@ -426,6 +452,7 @@ class SetupWizard(QDialog):
 
         # Scrollable model list — labels always display full width
         from PySide6.QtWidgets import QScrollArea
+
         model_container = QWidget()
         model_layout = QVBoxLayout(model_container)
         model_layout.setContentsMargins(0, 0, 0, 0)
@@ -440,8 +467,9 @@ class SetupWizard(QDialog):
         scroll.setWidget(model_container)
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QScrollArea.NoFrame)
-        scroll.setStyleSheet("QScrollArea { background: transparent; }"
-                             "QWidget { background: transparent; }")
+        scroll.setStyleSheet(
+            "QScrollArea { background: transparent; }QWidget { background: transparent; }"
+        )
         layout.addWidget(scroll, 1)
 
         # Divider + desktop shortcut
@@ -520,6 +548,7 @@ class SetupWizard(QDialog):
         # Save chosen install directory
         install_dir = self._loc_edit.text()
         from PySide6.QtCore import QSettings
+
         QSettings().setValue("app/install_path", install_dir)
 
         self._downloading = True
@@ -613,20 +642,22 @@ class SetupWizard(QDialog):
             elif sys.platform == "win32":
                 # Windows: create a .lnk shortcut via PowerShell
                 import subprocess
+
                 app_exe = sys.executable
                 icon = Path(sys._MEIPASS) / "ui" / "theme" / "corridorkey.ico"
                 lnk = desktop / "CorridorKey.lnk"
                 ps_cmd = (
-                    f'$ws = New-Object -ComObject WScript.Shell; '
+                    f"$ws = New-Object -ComObject WScript.Shell; "
                     f'$s = $ws.CreateShortcut("{lnk}"); '
                     f'$s.TargetPath = "{app_exe}"; '
                     f'$s.IconLocation = "{icon},0"; '
                     f'$s.Description = "CorridorKey - AI Green Screen"; '
-                    f'$s.Save()'
+                    f"$s.Save()"
                 )
                 subprocess.run(
                     ["powershell", "-NoProfile", "-Command", ps_cmd],
-                    capture_output=True, timeout=10,
+                    capture_output=True,
+                    timeout=10,
                 )
                 logger.info("Desktop shortcut created: %s", lnk)
         except Exception as e:

--- a/ui/widgets/split_view.py
+++ b/ui/widgets/split_view.py
@@ -12,23 +12,36 @@ Hit-test precedence: divider drag > pan > annotation > zoom (Codex finding).
 Annotation mode: hotkey 1/2 activates green/red brush. Left-click draws
 strokes in image-pixel coordinates. Shift+drag resizes brush.
 """
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import QWidget
 from PySide6.QtCore import Qt, Signal, QPointF, QRectF
 from PySide6.QtGui import (
-    QPainter, QPen, QColor, QImage, QMouseEvent, QWheelEvent,
-    QCursor,
+    QPainter,
+    QPen,
+    QColor,
+    QImage,
+    QMouseEvent,
+    QWheelEvent,
 )
 
 from ui.widgets.annotation_overlay import (
-    AnnotationModel, paint_annotations, paint_brush_cursor,
-    paint_resize_indicator, paint_annotation_hud,
+    AnnotationModel,
+    paint_annotations,
+    paint_brush_cursor,
+    paint_resize_indicator,
+    paint_annotation_hud,
 )
 from ui.widgets.wipe_controller import (
-    wipe_line_endpoints, wipe_handle_rect, wipe_distance_to_line,
-    paint_wipe, handle_wipe_press, handle_wipe_drag,
-    wipe_cursor_for_pos, handle_wipe_scroll,
+    wipe_line_endpoints,
+    wipe_handle_rect,
+    wipe_distance_to_line,
+    paint_wipe,
+    handle_wipe_press,
+    handle_wipe_drag,
+    wipe_cursor_for_pos,
+    handle_wipe_scroll,
 )
 
 
@@ -36,7 +49,7 @@ class SplitViewWidget(QWidget):
     """Image display with optional split view, zoom, and pan."""
 
     zoom_changed = Signal(float)  # current zoom level
-    stroke_finished = Signal()    # emitted when an annotation stroke completes
+    stroke_finished = Signal()  # emitted when an annotation stroke completes
 
     # Divider hit zone (pixels from divider line)
     _DIVIDER_HIT_ZONE = 8
@@ -58,8 +71,8 @@ class SplitViewWidget(QWidget):
 
         # Wipe mode (A/B comparison — diagonal divider, A=left, B=right)
         self._wipe_mode = False
-        self._wipe_angle = -45.0      # degrees, default: bottom-left to top-right. Range -90 to 90
-        self._wipe_offset = 0.0       # perpendicular offset from center (-0.5 to 0.5)
+        self._wipe_angle = -45.0  # degrees, default: bottom-left to top-right. Range -90 to 90
+        self._wipe_offset = 0.0  # perpendicular offset from center (-0.5 to 0.5)
         self._wipe_dragging: str | None = None  # "handle" or "line" or None
         self._wipe_drag_start = QPointF()
         self._wipe_drag_start_offset = 0.0
@@ -96,7 +109,7 @@ class SplitViewWidget(QWidget):
         self._resize_start_y: float = 0.0
         self._resize_start_radius: float = 0.0
         self._mouse_pos: QPointF = QPointF()  # last known mouse position (display)
-        self._straight_line: bool = False    # Alt+click straight-line mode
+        self._straight_line: bool = False  # Alt+click straight-line mode
         self._line_anchor: tuple[float, float] | None = None  # anchor in image-pixel coords
 
     # ── Public API ──
@@ -262,6 +275,7 @@ class SplitViewWidget(QWidget):
         ]
         from PySide6.QtGui import QPolygon
         from PySide6.QtCore import QPoint
+
         painter.drawPolygon(QPolygon([QPoint(x, y) for x, y in top_points]))
 
         # Bottom triangle
@@ -277,8 +291,7 @@ class SplitViewWidget(QWidget):
 
     def _wipe_line_endpoints(self):
         """Compute the wipe line endpoints from angle + offset."""
-        return wipe_line_endpoints(
-            self.width(), self.height(), self._wipe_angle, self._wipe_offset)
+        return wipe_line_endpoints(self.width(), self.height(), self._wipe_angle, self._wipe_offset)
 
     def _wipe_handle_rect(self, center: QPointF, hit=False) -> QRectF:
         """Return the center square handle rect. hit=True returns 2x hitbox."""
@@ -288,9 +301,12 @@ class SplitViewWidget(QWidget):
         """Draw A/B wipe comparison with diagonal divider."""
         paint_wipe(
             painter,
-            self.width(), self.height(),
-            self._wipe_angle, self._wipe_offset,
-            self._left_image, self._right_image,
+            self.width(),
+            self.height(),
+            self._wipe_angle,
+            self._wipe_offset,
+            self._left_image,
+            self._right_image,
             self._image_rect,
             self._DIVIDER_WIDTH,
         )
@@ -347,7 +363,8 @@ class SplitViewWidget(QWidget):
         painter.fillRect(text_rect.adjusted(-8, -2, 8, 2), QColor(0, 0, 0, 140))
         painter.setPen(QColor("#FF8C00"))
         painter.drawText(
-            text_rect, Qt.AlignCenter,
+            text_rect,
+            Qt.AlignCenter,
             f"{pct}%  ({current}/{self._extraction_total} frames)",
         )
 
@@ -382,12 +399,17 @@ class SplitViewWidget(QWidget):
             radius_display = self._brush_radius * dest.width() / iw
             if self._resizing_brush:
                 paint_resize_indicator(
-                    painter, self._mouse_pos, radius_display,
-                    self._brush_radius, self._annotation_mode,
+                    painter,
+                    self._mouse_pos,
+                    radius_display,
+                    self._brush_radius,
+                    self._annotation_mode,
                 )
             else:
                 paint_brush_cursor(
-                    painter, self._mouse_pos, radius_display,
+                    painter,
+                    self._mouse_pos,
+                    radius_display,
                     self._annotation_mode,
                 )
 
@@ -465,16 +487,18 @@ class SplitViewWidget(QWidget):
     def _wipe_distance_to_line(self, pos: QPointF) -> float:
         """Signed perpendicular distance from pos to the wipe line (pixels)."""
         return wipe_distance_to_line(
-            pos, self.width(), self.height(),
-            self._wipe_angle, self._wipe_offset)
+            pos, self.width(), self.height(), self._wipe_angle, self._wipe_offset
+        )
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
         # Wipe mode: check handle and line hit
         if event.button() == Qt.LeftButton and self._wipe_mode:
             drag_type, drag_start, start_offset, start_angle = handle_wipe_press(
                 event.position(),
-                self.width(), self.height(),
-                self._wipe_angle, self._wipe_offset,
+                self.width(),
+                self.height(),
+                self._wipe_angle,
+                self._wipe_offset,
                 self._DIVIDER_HIT_ZONE,
             )
             if drag_type is not None:
@@ -492,9 +516,11 @@ class SplitViewWidget(QWidget):
                 return
 
         # Annotation: Shift+left-click = brush resize
-        if (event.button() == Qt.LeftButton
-                and self._annotation_mode
-                and event.modifiers() & Qt.ShiftModifier):
+        if (
+            event.button() == Qt.LeftButton
+            and self._annotation_mode
+            and event.modifiers() & Qt.ShiftModifier
+        ):
             self._resizing_brush = True
             self._resize_start_y = event.position().y()
             self._resize_start_radius = self._brush_radius
@@ -502,10 +528,12 @@ class SplitViewWidget(QWidget):
             return
 
         # Annotation: Alt+left-click = straight line
-        if (event.button() == Qt.LeftButton
-                and self._annotation_mode
-                and self._annotation_model is not None
-                and event.modifiers() & Qt.AltModifier):
+        if (
+            event.button() == Qt.LeftButton
+            and self._annotation_mode
+            and self._annotation_model is not None
+            and event.modifiers() & Qt.AltModifier
+        ):
             pos = self._display_to_image(event.position())
             if pos is not None:
                 self._drawing = True
@@ -513,7 +541,8 @@ class SplitViewWidget(QWidget):
                 self._line_anchor = pos
                 self._annotation_model.start_stroke(
                     self._annotation_stem_idx,
-                    pos[0], pos[1],
+                    pos[0],
+                    pos[1],
                     self._annotation_mode,
                     self._brush_radius,
                 )
@@ -521,16 +550,19 @@ class SplitViewWidget(QWidget):
                 return
 
         # Annotation: left-click = start freehand drawing
-        if (event.button() == Qt.LeftButton
-                and self._annotation_mode
-                and self._annotation_model is not None):
+        if (
+            event.button() == Qt.LeftButton
+            and self._annotation_mode
+            and self._annotation_model is not None
+        ):
             pos = self._display_to_image(event.position())
             if pos is not None:
                 self._drawing = True
                 self._straight_line = False
                 self._annotation_model.start_stroke(
                     self._annotation_stem_idx,
-                    pos[0], pos[1],
+                    pos[0],
+                    pos[1],
                     self._annotation_mode,
                     self._brush_radius,
                 )
@@ -566,7 +598,8 @@ class SplitViewWidget(QWidget):
                 self._wipe_drag_start,
                 self._wipe_drag_start_offset,
                 self._wipe_drag_start_angle,
-                self.width(), self.height(),
+                self.width(),
+                self.height(),
                 self._wipe_angle,
             )
             if self._wipe_dragging == "handle":
@@ -580,8 +613,10 @@ class SplitViewWidget(QWidget):
         if self._wipe_mode and not self._panning:
             cursor = wipe_cursor_for_pos(
                 event.position(),
-                self.width(), self.height(),
-                self._wipe_angle, self._wipe_offset,
+                self.width(),
+                self.height(),
+                self._wipe_angle,
+                self._wipe_offset,
                 self._DIVIDER_HIT_ZONE,
             )
             if cursor is not None:
@@ -590,8 +625,7 @@ class SplitViewWidget(QWidget):
                 self.unsetCursor()
 
         if self._dragging_divider:
-            self._divider_pos = max(0.05, min(0.95,
-                event.position().x() / self.width()))
+            self._divider_pos = max(0.05, min(0.95, event.position().x() / self.width()))
             self.update()
             return
 
@@ -696,7 +730,8 @@ class SplitViewWidget(QWidget):
         if self._wipe_mode and mods in (Qt.KeyboardModifier(0), Qt.ShiftModifier):
             delta = event.angleDelta().y()
             self._wipe_offset = handle_wipe_scroll(
-                delta, bool(mods & Qt.ShiftModifier), self._wipe_offset)
+                delta, bool(mods & Qt.ShiftModifier), self._wipe_offset
+            )
             self.update()
             return
         if mods & Qt.ControlModifier:

--- a/ui/widgets/status_bar.py
+++ b/ui/widgets/status_bar.py
@@ -10,14 +10,22 @@ RUN text changes to "RUN SELECTED" when in/out range is set.
 
 GPU/VRAM info is displayed in the top brand bar (see main_window.py).
 """
+
 from __future__ import annotations
 
 import textwrap
 import time
 
 from PySide6.QtWidgets import (
-    QWidget, QHBoxLayout, QLabel, QPushButton,
-    QProgressBar, QDialog, QVBoxLayout, QTextEdit, QDialogButtonBox,
+    QWidget,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QProgressBar,
+    QDialog,
+    QVBoxLayout,
+    QTextEdit,
+    QDialogButtonBox,
 )
 from PySide6.QtCore import Qt, Signal, QTimer
 from PySide6.QtGui import QTextCursor
@@ -151,7 +159,9 @@ class StatusBar(QWidget):
         self._stop_btn.setObjectName("stopButton")
         self._stop_btn.setFixedWidth(80)
         self._stop_btn.setFixedHeight(32)
-        self._stop_btn.setToolTip("Stop the current job (Escape).\nAlready-processed frames are kept on disk.")
+        self._stop_btn.setToolTip(
+            "Stop the current job (Escape).\nAlready-processed frames are kept on disk."
+        )
         self._stop_btn.clicked.connect(self.stop_clicked.emit)
         self._stop_btn.hide()
         layout.addWidget(self._stop_btn)
@@ -170,7 +180,6 @@ class StatusBar(QWidget):
         self._tick_timer = QTimer(self)
         self._tick_timer.setInterval(1000)
         self._tick_timer.timeout.connect(self._on_tick)
-
 
     def set_running(self, running: bool) -> None:
         """Toggle between run/resume and stop state."""
@@ -197,8 +206,7 @@ class StatusBar(QWidget):
             self._stop_btn.setText("STOP")
             self._stop_btn.setFixedWidth(80)
             self._stop_btn.setToolTip(
-                "Stop the current job (Escape).\n"
-                "Already-processed frames are kept on disk."
+                "Stop the current job (Escape).\nAlready-processed frames are kept on disk."
             )
 
     def _on_run_clicked(self) -> None:
@@ -209,8 +217,12 @@ class StatusBar(QWidget):
             self.run_clicked.emit()
 
     def update_button_state(
-        self, can_run: bool, has_partial: bool, has_in_out: bool,
-        batch_count: int = 0, needs_extraction: bool = False,
+        self,
+        can_run: bool,
+        has_partial: bool,
+        has_in_out: bool,
+        batch_count: int = 0,
+        needs_extraction: bool = False,
         needs_pipeline: bool = False,
     ) -> None:
         """Update run/resume button visibility and text based on clip state.
@@ -358,7 +370,7 @@ class StatusBar(QWidget):
         elapsed = time.monotonic() - self._job_start if self._job_start > 0 else 0
         elapsed_str = _fmt_duration(elapsed)
         label = f"{self._job_label}  " if self._job_label else ""
-        phase = getattr(self, '_phase', '')
+        phase = getattr(self, "_phase", "")
 
         if self._last_total > 0 and self._last_current > 0:
             # Real frame progress — show frame counter + ETA + FPS

--- a/ui/widgets/thumbnail_canvas.py
+++ b/ui/widgets/thumbnail_canvas.py
@@ -2,6 +2,7 @@
 
 Extracted from io_tray_panel.py for maintainability.
 """
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import QWidget, QToolTip
@@ -68,8 +69,7 @@ class ThumbnailCanvas(QWidget):
         new_names = {c.name for c in clips}
         old_names = {c.name for c in self._clips}
         if new_names != old_names:
-            self._thumb_cache = {k: v for k, v in self._thumb_cache.items()
-                                 if k in new_names}
+            self._thumb_cache = {k: v for k, v in self._thumb_cache.items() if k in new_names}
         self._clips = list(clips)
         self._model = model
         self._reflow()
@@ -81,7 +81,7 @@ class ThumbnailCanvas(QWidget):
     def _reflow(self) -> None:
         """Recompute grid layout: wrap cards into rows, set min height for vertical scroll."""
         parent_scroll = self.parent()
-        if parent_scroll and hasattr(parent_scroll, 'viewport'):
+        if parent_scroll and hasattr(parent_scroll, "viewport"):
             avail_w = parent_scroll.viewport().width()
         else:
             avail_w = self.width()
@@ -173,8 +173,10 @@ class ThumbnailCanvas(QWidget):
             thumb = self._model.get_thumbnail(clip.name, kind=self._thumbnail_kind)
             if isinstance(thumb, QImage) and not thumb.isNull():
                 scaled = thumb.scaled(
-                    self.THUMB_W, self.THUMB_H,
-                    Qt.KeepAspectRatio, Qt.SmoothTransformation,
+                    self.THUMB_W,
+                    self.THUMB_H,
+                    Qt.KeepAspectRatio,
+                    Qt.SmoothTransformation,
                 )
                 self._thumb_cache[clip.name] = scaled
         if scaled is not None:
@@ -198,7 +200,8 @@ class ThumbnailCanvas(QWidget):
         bg_rect = QRect(
             rect.x() + self.CARD_WIDTH - pad - text_w - 6,
             rect.y() + pad,
-            text_w + 6, 14,
+            text_w + 6,
+            14,
         )
         p.fillRect(bg_rect, QColor(0, 0, 0, 128))
         p.setPen(badge_color)
@@ -218,7 +221,9 @@ class ThumbnailCanvas(QWidget):
 
         # Source type badge (top-left over thumbnail, input cards only)
         if not self._show_manifest_tooltip and clip.source_type != "unknown":
-            src_icon = "\U0001F39E" if clip.source_type == "video" else "\U0001F4F7"  # film frames / camera
+            src_icon = (
+                "\U0001f39e" if clip.source_type == "video" else "\U0001f4f7"
+            )  # film frames / camera
             src_font = p.font()
             src_font.setPointSize(9)
             src_font.setBold(False)
@@ -247,9 +252,11 @@ class ThumbnailCanvas(QWidget):
         if self._show_manifest_tooltip:
             icon_size = 18
             icon_rect = QRect(rect.x() + pad, rect.y() + pad, icon_size, icon_size)
-            is_icon_hovered = (clip.name == self._hovered_name
-                               and hasattr(self, '_hover_pos')
-                               and icon_rect.contains(self._hover_pos))
+            is_icon_hovered = (
+                clip.name == self._hovered_name
+                and hasattr(self, "_hover_pos")
+                and icon_rect.contains(self._hover_pos)
+            )
             bg_alpha = 200 if is_icon_hovered else 140
             p.fillRect(icon_rect, QColor(0, 0, 0, bg_alpha))
             folder_font = p.font()
@@ -257,7 +264,7 @@ class ThumbnailCanvas(QWidget):
             folder_font.setBold(False)
             p.setFont(folder_font)
             p.setPen(QColor("#FFF203") if is_icon_hovered else QColor("#C0C0A0"))
-            p.drawText(icon_rect, Qt.AlignCenter, "\U0001F4C2")
+            p.drawText(icon_rect, Qt.AlignCenter, "\U0001f4c2")
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
         pos = event.position().toPoint()
@@ -289,6 +296,7 @@ class ThumbnailCanvas(QWidget):
                         self.folder_icon_clicked.emit(clip)
                         return
                 from ui.sounds.audio_manager import UIAudio
+
                 UIAudio.click()
                 if event.modifiers() & Qt.ShiftModifier:
                     self.shift_select_requested.emit(clip)
@@ -362,6 +370,6 @@ def _format_manifest_tooltip(clip: ClipEntry) -> str:
             sz = params.get("despeckle_size", 400)
             lines.append(f"<b>Despeckle:</b> On (size {sz})")
         else:
-            lines.append(f"<b>Despeckle:</b> Off")
+            lines.append("<b>Despeckle:</b> Off")
 
     return "<br>".join(lines)

--- a/ui/widgets/timeline_widgets.py
+++ b/ui/widgets/timeline_widgets.py
@@ -7,6 +7,7 @@ CoverageBar: multi-lane bar showing alpha, inference, and annotation coverage.
 MarkerOverlay: transparent overlay for in/out bracket markers with drag handles.
 _FatSlider: QSlider with enlarged clickable groove area.
 """
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import QSlider, QWidget, QStyle, QStyleOptionSlider
@@ -29,9 +30,7 @@ class _FatSlider(QSlider):
         """Return the expanded groove rect used for hit-testing."""
         opt = QStyleOptionSlider()
         self.initStyleOption(opt)
-        base = self.style().subControlRect(
-            QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self
-        )
+        base = self.style().subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self)
         # Expand groove to full widget height
         base.setTop(0)
         base.setBottom(self.height())
@@ -59,10 +58,10 @@ class CoverageBar(QWidget):
     Bottom lane: inference output coverage (brand yellow segments).
     """
 
-    _ALPHA_COLOR = QColor(200, 200, 200)       # Soft white for alpha
-    _INFERENCE_COLOR = QColor(255, 242, 3)      # Brand yellow #FFF203
-    _ANNOTATION_COLOR = QColor(44, 195, 80)     # Green #2CC350 for annotations
-    _TRACK_COLOR = QColor(26, 25, 0)            # Dark track
+    _ALPHA_COLOR = QColor(200, 200, 200)  # Soft white for alpha
+    _INFERENCE_COLOR = QColor(255, 242, 3)  # Brand yellow #FFF203
+    _ANNOTATION_COLOR = QColor(44, 195, 80)  # Green #2CC350 for annotations
+    _TRACK_COLOR = QColor(26, 25, 0)  # Dark track
     _LANE_HEIGHT = 3
     _GAP = 1
 
@@ -167,12 +166,12 @@ class MarkerOverlay(QWidget):
     out_point_dragged = Signal(int)
     scrub_to_frame = Signal(int)  # request scrubber jump during drag
 
-    GRAB_WIDTH = 8    # px hitbox for drag detection
-    HANDLE_W = 6      # px visible handle width
-    HANDLE_H = 8      # px handle nub height at bottom
+    GRAB_WIDTH = 8  # px hitbox for drag detection
+    HANDLE_W = 6  # px visible handle width
+    HANDLE_H = 8  # px handle nub height at bottom
     MARKER_WIDTH = 2  # px bracket line width
-    MARKER_COLOR = QColor(255, 242, 3)      # Brand yellow
-    DIM_COLOR = QColor(0, 0, 0, 120)        # Semi-transparent dim
+    MARKER_COLOR = QColor(255, 242, 3)  # Brand yellow
+    DIM_COLOR = QColor(0, 0, 0, 120)  # Semi-transparent dim
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -208,19 +207,19 @@ class MarkerOverlay(QWidget):
         """Return pixel x for in or out marker, or None if not set."""
         if self._in_point is None or self._out_point is None or self._total <= 0:
             return None
-        if which == 'in':
+        if which == "in":
             return self._frame_to_x(self._in_point)
         else:
             return self._frame_to_x(self._out_point + 1)
 
     def _hit_marker(self, x: int) -> str | None:
         """Return 'in', 'out', or None based on proximity to markers."""
-        x_in = self._marker_x('in')
-        x_out = self._marker_x('out')
+        x_in = self._marker_x("in")
+        x_out = self._marker_x("out")
         if x_in is not None and abs(x - x_in) <= self.GRAB_WIDTH:
-            return 'in'
+            return "in"
         if x_out is not None and abs(x - x_out) <= self.GRAB_WIDTH:
-            return 'out'
+            return "out"
         return None
 
     def paintEvent(self, event) -> None:
@@ -248,28 +247,33 @@ class MarkerOverlay(QWidget):
         painter.fillRect(x_in, 0, self.MARKER_WIDTH, h, self.MARKER_COLOR)
 
         # Out-point bracket line
-        painter.fillRect(max(0, x_out - self.MARKER_WIDTH), 0,
-                         self.MARKER_WIDTH, h, self.MARKER_COLOR)
+        painter.fillRect(
+            max(0, x_out - self.MARKER_WIDTH), 0, self.MARKER_WIDTH, h, self.MARKER_COLOR
+        )
 
         # Handle nubs at bottom (small triangles pointing inward)
         painter.setBrush(self.MARKER_COLOR)
         painter.setPen(Qt.NoPen)
 
         # In-point handle: triangle pointing right at bottom-left of bracket
-        in_tri = QPolygonF([
-            QPointF(x_in, h),
-            QPointF(x_in + self.HANDLE_W, h),
-            QPointF(x_in, h - self.HANDLE_H),
-        ])
+        in_tri = QPolygonF(
+            [
+                QPointF(x_in, h),
+                QPointF(x_in + self.HANDLE_W, h),
+                QPointF(x_in, h - self.HANDLE_H),
+            ]
+        )
         painter.drawPolygon(in_tri)
 
         # Out-point handle: triangle pointing left at bottom-right of bracket
         ox = max(0, x_out - self.MARKER_WIDTH)
-        out_tri = QPolygonF([
-            QPointF(ox + self.MARKER_WIDTH, h),
-            QPointF(ox + self.MARKER_WIDTH - self.HANDLE_W, h),
-            QPointF(ox + self.MARKER_WIDTH, h - self.HANDLE_H),
-        ])
+        out_tri = QPolygonF(
+            [
+                QPointF(ox + self.MARKER_WIDTH, h),
+                QPointF(ox + self.MARKER_WIDTH - self.HANDLE_W, h),
+                QPointF(ox + self.MARKER_WIDTH, h - self.HANDLE_H),
+            ]
+        )
         painter.drawPolygon(out_tri)
 
         painter.end()
@@ -295,13 +299,13 @@ class MarkerOverlay(QWidget):
         elif event.button() == Qt.MiddleButton:
             # Middle-click on a marker resets it to boundary
             hit = self._hit_marker(int(event.position().x()))
-            if hit == 'in':
+            if hit == "in":
                 self._in_point = 0
                 self.update()
                 self.in_point_dragged.emit(0)
                 event.accept()
                 return
-            elif hit == 'out' and self._total > 0:
+            elif hit == "out" and self._total > 0:
                 self._out_point = self._total - 1
                 self.update()
                 self.out_point_dragged.emit(self._total - 1)
@@ -315,7 +319,7 @@ class MarkerOverlay(QWidget):
         x = int(event.position().x())
         if self._dragging:
             frame = self._x_to_frame(x)
-            if self._dragging == 'in':
+            if self._dragging == "in":
                 if self._out_point is not None:
                     frame = min(frame, self._out_point)
                 self._in_point = frame
@@ -336,9 +340,9 @@ class MarkerOverlay(QWidget):
 
     def mouseReleaseEvent(self, event) -> None:
         if self._dragging:
-            if self._dragging == 'in' and self._in_point is not None:
+            if self._dragging == "in" and self._in_point is not None:
                 self.in_point_dragged.emit(self._in_point)
-            elif self._dragging == 'out' and self._out_point is not None:
+            elif self._dragging == "out" and self._out_point is not None:
                 self.out_point_dragged.emit(self._out_point)
             self._dragging = None
             # Check if still near a marker

--- a/ui/widgets/view_mode_bar.py
+++ b/ui/widgets/view_mode_bar.py
@@ -4,6 +4,7 @@ Uses QButtonGroup with exclusive selection. Active button highlighted
 with brand yellow. Buttons are enabled/disabled based on which output
 directories actually have frames (via FrameIndex availability).
 """
+
 from __future__ import annotations
 
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton, QButtonGroup
@@ -96,7 +97,6 @@ class ViewModeBar(QWidget):
 
         self._button_group.idClicked.connect(self._on_mode_clicked)
         layout.addStretch()
-
 
     def set_available_modes(self, modes: list[ViewMode]) -> None:
         """Enable buttons for modes that have frames."""

--- a/ui/widgets/welcome_screen.py
+++ b/ui/widgets/welcome_screen.py
@@ -5,14 +5,19 @@ browse button) — exactly like the original welcome screen. A small panel
 on the left shows recent projects as clickable cards. Clicks on the
 drop zone open the file dialog; clicks on project cards open that project.
 """
+
 from __future__ import annotations
 
 import os
 import sys
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
-    QFileDialog, QSizePolicy,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QFileDialog,
 )
 from PySide6.QtCore import Qt, Signal, QEvent
 from PySide6.QtGui import QPixmap, QImage, QPainter
@@ -20,12 +25,12 @@ from PySide6.QtSvg import QSvgRenderer
 
 from ui.recent_sessions import RecentSessionsStore
 from ui.widgets.recent_projects_panel import RecentProjectsPanel
-from backend.project import is_video_file, is_image_file, VIDEO_FILE_FILTER
+from backend.project import is_video_file, is_image_file
 
 
 def _load_brand_logo(size: int) -> QPixmap | None:
     """Load brand logo from SVG (crisp at any size) with PNG fallback."""
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, "frozen", False):
         base = os.path.join(sys._MEIPASS, "ui", "theme")
     else:
         base = os.path.join(os.path.dirname(os.path.dirname(__file__)), "theme")
@@ -101,6 +106,7 @@ class _DropZone(QWidget):
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Enter and obj.objectName() == "welcomeBrowse":
             from ui.sounds.audio_manager import UIAudio
+
             UIAudio.hover()
         return super().eventFilter(obj, event)
 
@@ -126,8 +132,8 @@ class WelcomeScreen(QWidget):
     └─────────────┴────────────────────────────────────────────┘
     """
 
-    folder_selected = Signal(str)     # directory path
-    files_selected = Signal(list)     # list of file paths
+    folder_selected = Signal(str)  # directory path
+    files_selected = Signal(list)  # list of file paths
     recent_project_opened = Signal(str)  # workspace path from recents
 
     def __init__(self, store: RecentSessionsStore, parent=None):
@@ -172,7 +178,9 @@ class WelcomeScreen(QWidget):
             "All Files (*)"
         )
         paths, _ = QFileDialog.getOpenFileNames(
-            self, "Select Media Files", "",
+            self,
+            "Select Media Files",
+            "",
             media_filter,
         )
         if paths:

--- a/ui/widgets/wipe_controller.py
+++ b/ui/widgets/wipe_controller.py
@@ -5,6 +5,7 @@ and painting. Used by SplitViewWidget to keep wipe concerns separate.
 
 All methods are pure functions of explicit parameters — no widget state owned here.
 """
+
 from __future__ import annotations
 
 import math
@@ -15,9 +16,12 @@ from PySide6.QtGui import QPainter, QPen, QColor, QPolygonF, QPainterPath
 
 # ── Geometry helpers ──
 
+
 def wipe_line_endpoints(
-    width: float, height: float,
-    wipe_angle: float, wipe_offset: float,
+    width: float,
+    height: float,
+    wipe_angle: float,
+    wipe_offset: float,
 ) -> tuple[QPointF, QPointF, QPointF]:
     """Compute the wipe line endpoints from angle + offset.
 
@@ -55,8 +59,10 @@ def wipe_handle_rect(center: QPointF, hit: bool = False) -> QRectF:
 
 def wipe_distance_to_line(
     pos: QPointF,
-    width: float, height: float,
-    wipe_angle: float, wipe_offset: float,
+    width: float,
+    height: float,
+    wipe_angle: float,
+    wipe_offset: float,
 ) -> float:
     """Signed perpendicular distance from pos to the wipe line (pixels)."""
     angle_rad = math.radians(wipe_angle)
@@ -68,11 +74,15 @@ def wipe_distance_to_line(
 
 # ── Painting ──
 
+
 def paint_wipe(
     painter: QPainter,
-    width: float, height: float,
-    wipe_angle: float, wipe_offset: float,
-    left_image, right_image,
+    width: float,
+    height: float,
+    wipe_angle: float,
+    wipe_offset: float,
+    left_image,
+    right_image,
     image_rect_fn,
     divider_width: int = 2,
 ) -> None:
@@ -146,19 +156,22 @@ def paint_wipe(
 
     label_offset = 16
     painter.drawText(
-        QPointF(center.x() - perp_x * label_offset - 4,
-                center.y() - perp_y * label_offset + 4), "A")
+        QPointF(center.x() - perp_x * label_offset - 4, center.y() - perp_y * label_offset + 4), "A"
+    )
     painter.drawText(
-        QPointF(center.x() + perp_x * label_offset - 4,
-                center.y() + perp_y * label_offset + 4), "B")
+        QPointF(center.x() + perp_x * label_offset - 4, center.y() + perp_y * label_offset + 4), "B"
+    )
 
 
 # ── Drag handling ──
 
+
 def handle_wipe_press(
     pos: QPointF,
-    width: float, height: float,
-    wipe_angle: float, wipe_offset: float,
+    width: float,
+    height: float,
+    wipe_angle: float,
+    wipe_offset: float,
     hit_zone: int,
 ) -> tuple[str | None, QPointF, float, float]:
     """Check if a left-click hits the wipe handle or line.
@@ -181,7 +194,8 @@ def handle_wipe_drag(
     drag_start: QPointF,
     start_offset: float,
     start_angle: float,
-    width: float, height: float,
+    width: float,
+    height: float,
     wipe_angle: float,
 ) -> tuple[float, float]:
     """Process a wipe drag move event.
@@ -194,7 +208,7 @@ def handle_wipe_drag(
         ny = math.cos(angle_rad)
         dx = event_pos.x() - drag_start.x()
         dy = event_pos.y() - drag_start.y()
-        diag = math.sqrt(width ** 2 + height ** 2)
+        diag = math.sqrt(width**2 + height**2)
         delta_offset = (dx * nx + dy * ny) / diag
         new_offset = max(-0.5, min(0.5, start_offset + delta_offset))
         return new_offset, wipe_angle
@@ -215,8 +229,10 @@ def handle_wipe_drag(
 
 def wipe_cursor_for_pos(
     pos: QPointF,
-    width: float, height: float,
-    wipe_angle: float, wipe_offset: float,
+    width: float,
+    height: float,
+    wipe_angle: float,
+    wipe_offset: float,
     hit_zone: int,
 ) -> Qt.CursorShape | None:
     """Return cursor shape for wipe hover, or None if not near wipe elements."""

--- a/ui/workers/extract_worker.py
+++ b/ui/workers/extract_worker.py
@@ -6,6 +6,7 @@ queue (extraction is CPU/hardware decode, not GPU inference).
 Supports multiple concurrent extraction requests via an internal job
 queue. Each clip gets its own cancel event for independent cancellation.
 """
+
 from __future__ import annotations
 
 import logging
@@ -18,8 +19,11 @@ from dataclasses import dataclass, field
 from PySide6.QtCore import QThread, Signal
 
 from backend.ffmpeg_tools import (
-    require_ffmpeg_install, probe_video, extract_frames,
-    write_video_metadata, build_exr_vf,
+    require_ffmpeg_install,
+    probe_video,
+    extract_frames,
+    write_video_metadata,
+    build_exr_vf,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,8 +73,7 @@ class ExtractWorker(QThread):
                 if job.clip_name == clip_name:
                     logger.debug(f"Extraction already queued: {clip_name}")
                     return
-        job = _ExtractJob(clip_name=clip_name, video_path=video_path,
-                          clip_root=clip_root)
+        job = _ExtractJob(clip_name=clip_name, video_path=video_path, clip_root=clip_root)
         with self._lock:
             self._jobs.append(job)
         self._wake.set()
@@ -158,6 +161,7 @@ class ExtractWorker(QThread):
             # main thread with expensive UI updates).  Emit at most every
             # 100 ms, plus always emit the final frame so the bar hits 100%.
             import time as _time
+
             _MIN_INTERVAL = 0.10  # seconds between progress emissions
             _last_emit = [0.0]  # mutable closure — [timestamp]
 
@@ -173,9 +177,7 @@ class ExtractWorker(QThread):
             def on_recompress(current: int, total: int) -> None:
                 # Report as total_frames + progress to show "compressing"
                 # without resetting the counter
-                _throttled_emit(job.clip_name,
-                                total_frames + current,
-                                total_frames + total)
+                _throttled_emit(job.clip_name, total_frames + current, total_frames + total)
 
             # Run extraction (two-pass: FFmpeg EXR ZIP16 → DWAB recompress)
             extracted = extract_frames(
@@ -237,7 +239,6 @@ class ExtractWorker(QThread):
         Naming convention:  ``input_alphahint.mov`` alongside ``input.mov``.
         Also checks the Source/ folder if the video lives there.
         """
-        import glob as _glob
 
         stem = os.path.splitext(os.path.basename(video_path))[0]
         parent = os.path.dirname(video_path)
@@ -255,6 +256,7 @@ class ExtractWorker(QThread):
         clip_json = os.path.join(clip_root, "clip.json")
         if os.path.isfile(clip_json):
             import json
+
             try:
                 with open(clip_json, "r") as fh:
                     data = json.load(fh)
@@ -295,37 +297,41 @@ class ExtractWorker(QThread):
             out_pattern = os.path.join(alpha_dir, "frame%06d.png")
 
             import subprocess
+
             cmd = [
-                ffmpeg, "-y",
-                "-i", alpha_video,
-                "-vf", "format=gray",
-                "-pix_fmt", "gray",
+                ffmpeg,
+                "-y",
+                "-i",
+                alpha_video,
+                "-vf",
+                "format=gray",
+                "-pix_fmt",
+                "gray",
                 out_pattern,
             ]
             result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=600,
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=600,
                 creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
             )
             if result.returncode != 0:
-                logger.error("Alpha hint extraction failed: %s",
-                             result.stderr[-500:])
+                logger.error("Alpha hint extraction failed: %s", result.stderr[-500:])
                 # Clean up partial output
                 if os.path.isdir(alpha_dir):
                     shutil.rmtree(alpha_dir)
                 return
 
             # Count extracted frames
-            alpha_frames = len([
-                f for f in os.listdir(alpha_dir)
-                if f.lower().endswith(".png")
-            ])
-            logger.info("Auto-extracted %d alpha hint frames into %s",
-                         alpha_frames, alpha_dir)
+            alpha_frames = len([f for f in os.listdir(alpha_dir) if f.lower().endswith(".png")])
+            logger.info("Auto-extracted %d alpha hint frames into %s", alpha_frames, alpha_dir)
 
             if alpha_frames != frame_count:
                 logger.warning(
                     "Alpha hint frame count (%d) != source frame count (%d)",
-                    alpha_frames, frame_count,
+                    alpha_frames,
+                    frame_count,
                 )
 
         except Exception as exc:

--- a/ui/workers/gpu_job_worker.py
+++ b/ui/workers/gpu_job_worker.py
@@ -13,6 +13,7 @@ Design decisions (from Codex review):
 - Model residency: service._ensure_model() unloads previous model type
 - Lock order: service._gpu_lock > job_queue._lock > never hold while joining
 """
+
 from __future__ import annotations
 
 import os
@@ -22,19 +23,15 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 
 import cv2
-import numpy as np
 from PySide6.QtCore import QThread, Signal, QMutex, QWaitCondition
 
 from backend import (
     CorridorKeyService,
     ClipEntry,
-    ClipState,
     GPUJob,
-    GPUJobQueue,
     InferenceParams,
     JobType,
 )
-from backend.job_queue import JobStatus
 from backend.errors import JobCancelledError, CorridorKeyError
 
 # Re-export create_job_snapshot for backward compatibility
@@ -61,14 +58,16 @@ class GPUJobWorker(QThread):
     """
 
     # Signals — all carry job_id as first arg for stale detection
-    progress = Signal(str, str, int, int, float)  # job_id, clip_name, current_frame, total_frames, fps
-    preview_ready = Signal(str, str, int, str) # job_id, clip_name, frame_index, temp_file_path
-    clip_finished = Signal(str, str, str)       # job_id, clip_name, job_type_value
-    warning = Signal(str, str)                 # job_id, message
-    status_update = Signal(str, str)           # job_id, status_text (phase label for status bar)
-    error = Signal(str, str, str)              # job_id, clip_name, error_message
-    queue_empty = Signal()                     # all jobs done
-    reprocess_result = Signal(str, object)     # job_id, result_dict (for preview display)
+    progress = Signal(
+        str, str, int, int, float
+    )  # job_id, clip_name, current_frame, total_frames, fps
+    preview_ready = Signal(str, str, int, str)  # job_id, clip_name, frame_index, temp_file_path
+    clip_finished = Signal(str, str, str)  # job_id, clip_name, job_type_value
+    warning = Signal(str, str)  # job_id, message
+    status_update = Signal(str, str)  # job_id, status_text (phase label for status bar)
+    error = Signal(str, str, str)  # job_id, clip_name, error_message
+    queue_empty = Signal()  # all jobs done
+    reprocess_result = Signal(str, object)  # job_id, result_dict (for preview display)
 
     def __init__(self, service: CorridorKeyService, max_workers: int = 1, parent=None):
         super().__init__(parent)
@@ -227,7 +226,9 @@ class GPUJobWorker(QThread):
         Assumes start_job() has already been called.
         """
         job_id = job.id
-        logger.info(f">>> PROCESS_JOB START [{job_id}]: type={job.job_type.value}, clip={job.clip_name}")
+        logger.info(
+            f">>> PROCESS_JOB START [{job_id}]: type={job.job_type.value}, clip={job.clip_name}"
+        )
 
         try:
             if job.job_type == JobType.INFERENCE:
@@ -295,7 +296,9 @@ class GPUJobWorker(QThread):
         skip_stems = job.params.get("_skip_stems", set())
 
         if clip is None or params is None:
-            raise CorridorKeyError(f"Job [{job.id}] for '{job.clip_name}' missing clip or params snapshot")
+            raise CorridorKeyError(
+                f"Job [{job.id}] for '{job.clip_name}' missing clip or params snapshot"
+            )
 
         def on_progress(clip_name: str, current: int, total: int, **kwargs) -> None:
             self.progress.emit(job.id, clip_name, current, total, kwargs.get("fps", 0.0))
@@ -361,7 +364,9 @@ class GPUJobWorker(QThread):
 
         self._service.run_sam2_track(
             clip=clip,
-            input_is_linear=(params.input_is_linear if isinstance(params, InferenceParams) else None),
+            input_is_linear=(
+                params.input_is_linear if isinstance(params, InferenceParams) else None
+            ),
             job=job,
             on_progress=on_progress,
             on_warning=on_warning,
@@ -388,7 +393,9 @@ class GPUJobWorker(QThread):
         result = self._service.preview_sam2_prompt(
             clip=clip,
             preferred_frame_index=frame_index,
-            input_is_linear=(params.input_is_linear if isinstance(params, InferenceParams) else None),
+            input_is_linear=(
+                params.input_is_linear if isinstance(params, InferenceParams) else None
+            ),
             job=job,
             on_progress=on_progress,
             on_warning=on_warning,
@@ -509,6 +516,7 @@ class GPUJobWorker(QThread):
 
             # Find the most recently written comp frame (natural sort)
             from backend.natural_sort import natsorted
+
             comp_files = natsorted(os.listdir(comp_dir))
             if not comp_files:
                 return

--- a/ui/workers/gpu_monitor.py
+++ b/ui/workers/gpu_monitor.py
@@ -7,6 +7,7 @@ Design decisions (from Codex review):
 - Polling interval: 2000ms (not too aggressive on GPU queries)
 - Emits lightweight dict signal, QPixmap/rendering stays on main thread
 """
+
 from __future__ import annotations
 
 import logging
@@ -32,7 +33,7 @@ class GPUMonitor(QObject):
     """
 
     vram_updated = Signal(dict)  # GPU info dict
-    gpu_name = Signal(str)       # emitted once on first successful poll
+    gpu_name = Signal(str)  # emitted once on first successful poll
 
     def __init__(self, interval_ms: int = 2000, parent=None):
         super().__init__(parent)
@@ -51,6 +52,7 @@ class GPUMonitor(QObject):
         """Try to initialize NVML for GPU monitoring."""
         try:
             import pynvml
+
             pynvml.nvmlInit()
             self._nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
             self._nvml_available = True
@@ -60,6 +62,7 @@ class GPUMonitor(QObject):
             # Check torch fallback
             try:
                 import torch
+
                 if torch.cuda.is_available():
                     self._torch_fallback = True
                     logger.info("GPU monitor: NVML unavailable, using torch.cuda fallback")
@@ -71,8 +74,10 @@ class GPUMonitor(QObject):
             if sys.platform == "darwin" and platform.machine() == "arm64":
                 self._apple_silicon = True
                 self._apple_chip_name = self._detect_apple_chip()
-                logger.info("GPU monitor: Apple Silicon (%s), reporting unified memory",
-                            self._apple_chip_name or "unknown chip")
+                logger.info(
+                    "GPU monitor: Apple Silicon (%s), reporting unified memory",
+                    self._apple_chip_name or "unknown chip",
+                )
             else:
                 logger.info("GPU monitor: no GPU monitoring available")
 
@@ -108,13 +113,14 @@ class GPUMonitor(QObject):
         """Query via NVML (preferred — no CUDA context interference)."""
         try:
             import pynvml
+
             mem = pynvml.nvmlDeviceGetMemoryInfo(self._nvml_handle)
             name = pynvml.nvmlDeviceGetName(self._nvml_handle)
             if isinstance(name, bytes):
                 name = name.decode("utf-8")
-            total_gb = mem.total / (1024 ** 3)
-            used_gb = mem.used / (1024 ** 3)
-            free_gb = mem.free / (1024 ** 3)
+            total_gb = mem.total / (1024**3)
+            used_gb = mem.used / (1024**3)
+            free_gb = mem.free / (1024**3)
             return {
                 "available": True,
                 "name": name,
@@ -131,13 +137,14 @@ class GPUMonitor(QObject):
         """Fallback: query via torch.cuda (may contend with inference)."""
         try:
             import torch
+
             props = torch.cuda.get_device_properties(0)
             total = props.total_memory
             reserved = torch.cuda.memory_reserved(0)
             free = total - reserved
-            total_gb = total / (1024 ** 3)
-            used_gb = reserved / (1024 ** 3)
-            free_gb = free / (1024 ** 3)
+            total_gb = total / (1024**3)
+            used_gb = reserved / (1024**3)
+            free_gb = free / (1024**3)
             return {
                 "available": True,
                 "name": torch.cuda.get_device_name(0),
@@ -156,7 +163,9 @@ class GPUMonitor(QObject):
         try:
             result = subprocess.run(
                 ["sysctl", "-n", "machdep.cpu.brand_string"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             return result.stdout.strip() or None
         except Exception:
@@ -170,13 +179,14 @@ class GPUMonitor(QObject):
         """
         try:
             import psutil
+
             mem = psutil.virtual_memory()
             total_bytes = int(mem.total)
             free_bytes = int(mem.available)
             used_bytes = max(0, total_bytes - free_bytes)
-            total_gb = total_bytes / (1024 ** 3)
-            used_gb = used_bytes / (1024 ** 3)
-            free_gb = free_bytes / (1024 ** 3)
+            total_gb = total_bytes / (1024**3)
+            used_gb = used_bytes / (1024**3)
+            free_gb = free_bytes / (1024**3)
             usage_pct = (used_bytes / total_bytes * 100.0) if total_bytes > 0 else 0.0
             return {
                 "available": True,

--- a/ui/workers/job_helpers.py
+++ b/ui/workers/job_helpers.py
@@ -1,4 +1,5 @@
 """Helper functions for GPU job creation and snapshot management."""
+
 from __future__ import annotations
 
 import copy

--- a/ui/workers/thumbnail_worker.py
+++ b/ui/workers/thumbnail_worker.py
@@ -7,6 +7,7 @@ thread for storage in the model. Uses QStandardPaths for cache location
 Codex finding: don't create QPixmap off main thread. Generate QImage
 in worker, promote to QPixmap on main thread only if needed.
 """
+
 from __future__ import annotations
 
 import os
@@ -148,8 +149,16 @@ class _ThumbTask(QRunnable):
             if self._input_path is None or not os.path.isdir(self._input_path):
                 return None
             from backend.natural_sort import natsorted
-            files = natsorted([f for f in os.listdir(self._input_path)
-                             if f.lower().endswith(('.png', '.jpg', '.jpeg', '.exr', '.tif', '.tiff', '.bmp'))])
+
+            files = natsorted(
+                [
+                    f
+                    for f in os.listdir(self._input_path)
+                    if f.lower().endswith(
+                        (".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff", ".bmp")
+                    )
+                ]
+            )
             if not files:
                 return None
             path = os.path.join(self._input_path, files[0])
@@ -179,10 +188,15 @@ class _ThumbTask(QRunnable):
             dir_path = mode_dirs.get(mode)
             if dir_path is None or not os.path.isdir(dir_path):
                 continue
-            files = natsorted([
-                f for f in os.listdir(dir_path)
-                if f.lower().endswith(('.png', '.jpg', '.jpeg', '.exr', '.tif', '.tiff', '.bmp'))
-            ])
+            files = natsorted(
+                [
+                    f
+                    for f in os.listdir(dir_path)
+                    if f.lower().endswith(
+                        (".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff", ".bmp")
+                    )
+                ]
+            )
             if not files:
                 continue
             path = os.path.join(dir_path, files[0])
@@ -211,6 +225,7 @@ class _ThumbTask(QRunnable):
         except Exception:
             pass
         return None
+
 
 class ThumbnailGenerator(QObject):
     """Manages background thumbnail generation for clips.

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,2538 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <3.14"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "accelerate"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/46/02ac5e262d4af18054b3e922b2baedbb2a03289ee792162de60a865defc5/accelerate-1.13.0-py3-none-any.whl", hash = "sha256:cf1a3efb96c18f7b152eb0fa7490f3710b19c3f395699358f08decca2b8b62e0", size = 383744, upload-time = "2026-03-04T19:34:10.313Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "av"
+version = "17.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/eb/abca886df3a091bc406feb5ff71b4c4f426beaae6b71b9697264ce8c7211/av-17.0.0.tar.gz", hash = "sha256:c53685df73775a8763c375c7b2d62a6cb149d992a26a4b098204da42ade8c3df", size = 4410769, upload-time = "2026-03-14T14:38:45.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/4d/ea1ac272eeea83014daca1783679a9e9f894e1e68e5eb4f717dd8813da2a/av-17.0.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:4b21bcff4144acae658c0efb011fa8668c7a9638384f3ae7f5add33f35b907c6", size = 23407827, upload-time = "2026-03-14T14:37:47.337Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1a/e433766470c57c9c1c8558021de4d2466b3403ed629e48722d39d12baa6c/av-17.0.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:17cd518fc88dc449ce9dcfd0b40e9b3530266927375a743efc80d510adfb188b", size = 18829899, upload-time = "2026-03-14T14:37:50.493Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/25/95ad714f950c188495ffbfef235d06a332123d6f266026a534801ffc2171/av-17.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9a8b7b63a92d8dc7cbe5000546e4684176124ddd49fdd9c12570e3aa6dadf11a", size = 35348062, upload-time = "2026-03-14T14:37:52.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/db/7f3f9e92f2ac8dba639ab01d69a33b723aa16b5e3e612dbfe667fbc02dcd/av-17.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8706ce9b5d8d087d093b46a9781e7532c4a9e13874bca1da468be78efc56cecc", size = 37684503, upload-time = "2026-03-14T14:37:55.628Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/3b356b14ba72354688c8d9777cf67b707769b6e14b63aaeb0cddeeac8d32/av-17.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3a074835ce807434451086993fedfb3b223dacedb2119ab9d7a72480f2d77f32", size = 36547601, upload-time = "2026-03-14T14:37:58.465Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8d/f489cd6f9fe9c8b38dca00ecb39dc38836761767a4ec07dd95e62e124ac3/av-17.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f8ef8e8f1a0cbb2e0ad49266015e2277801a916e2186ac9451b493ff6dfdec27", size = 38815129, upload-time = "2026-03-14T14:38:01.277Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bd/e42536234e37caffd1a054de1a0e6abca226c5686e9672726a8d95511422/av-17.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:a795e153ff31a6430e974b4e6ad0d0fab695b78e3f17812293a0a34cd03ee6a9", size = 28984602, upload-time = "2026-03-14T14:38:03.632Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fb/55e3b5b5d1fc61466292f26fbcbabafa2642f378dc48875f8f554591e1a4/av-17.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ed4013fac77c309a4a68141dcf6148f1821bb1073a36d4289379762a6372f711", size = 23238424, upload-time = "2026-03-14T14:38:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/9ace1acc08bc9ae38c14bf3a4b1360e995e4d999d1d33c2cbd7c9e77582a/av-17.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:e44b6c83e9f3be9f79ee87d0b77a27cea9a9cd67bd630362c86b7e56a748dfbb", size = 18709043, upload-time = "2026-03-14T14:38:08.288Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c0/637721f3cd5bb8bd16105a1a08efd781fc12f449931bdb3a4d0cfd63fa55/av-17.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b440da6ac47da0629d509316f24bcd858f33158dbdd0f1b7293d71e99beb26de", size = 34018780, upload-time = "2026-03-14T14:38:10.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/d19bc3257dd985d55337d7f0414c019414b97e16cd3690ebf9941a847543/av-17.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1060cba85f97f4a337311169d92c0b5e143452cfa5ca0e65fa499d7955e8592e", size = 36358757, upload-time = "2026-03-14T14:38:13.092Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6c/a1f4f2677bae6f2ade7a8a18e90ebdcf70690c9b1c4e40e118aa30fa313f/av-17.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:deda202e6021cfc7ba3e816897760ec5431309d59a4da1f75df3c0e9413d71e7", size = 35195281, upload-time = "2026-03-14T14:38:15.789Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ea/52b0fc6f69432c7bf3f5fbe6f707113650aa40a1a05b9096ffc2bba4f77d/av-17.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffaf266a1a9c2148072de0a4b5ae98061465178d2cfaa69ee089761149342974", size = 37444817, upload-time = "2026-03-14T14:38:18.563Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/d2172966282cb8f146c13b6be7416efefde74186460c5e1708ddfc13dba6/av-17.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:45a35a40b2875bf2f98de7c952d74d960f92f319734e6d28e03b4c62a49e6f49", size = 28888553, upload-time = "2026-03-14T14:38:21.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/bb/c5a4c4172c514d631fb506e6366b503576b8c7f29809cf42aca73e28ff01/av-17.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:3d32e9b5c5bbcb872a0b6917b352a1db8a42142237826c9b49a36d5dbd9e9c26", size = 21916910, upload-time = "2026-03-14T14:38:23.706Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a3/da4153ec8fe25d263aa48c1a4cbde7f49b59af86f0b6f7862788c60da737/contourpy-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba38e3f9f330af820c4b27ceb4b9c7feee5fe0493ea53a8720f4792667465934", size = 268551, upload-time = "2025-04-15T17:34:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6c/330de89ae1087eb622bfca0177d32a7ece50c3ef07b28002de4757d9d875/contourpy-1.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc41ba0714aa2968d1f8674ec97504a8f7e334f48eeacebcaa6256213acb0989", size = 253399, upload-time = "2025-04-15T17:34:51.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/20c6726b1b7f81a8bee5271bed5c165f0a8e1f572578a9d27e2ccb763cb2/contourpy-1.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9be002b31c558d1ddf1b9b415b162c603405414bacd6932d031c5b5a8b757f0d", size = 312061, upload-time = "2025-04-15T17:34:55.961Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fc/a9665c88f8a2473f823cf1ec601de9e5375050f1958cbb356cdf06ef1ab6/contourpy-1.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2e74acbcba3bfdb6d9d8384cdc4f9260cae86ed9beee8bd5f54fee49a430b9", size = 351956, upload-time = "2025-04-15T17:35:00.992Z" },
+    { url = "https://files.pythonhosted.org/packages/25/eb/9f0a0238f305ad8fb7ef42481020d6e20cf15e46be99a1fcf939546a177e/contourpy-1.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e259bced5549ac64410162adc973c5e2fb77f04df4a439d00b478e57a0e65512", size = 320872, upload-time = "2025-04-15T17:35:06.177Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5c/1ee32d1c7956923202f00cf8d2a14a62ed7517bdc0ee1e55301227fc273c/contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad687a04bc802cbe8b9c399c07162a3c35e227e2daccf1668eb1f278cb698631", size = 325027, upload-time = "2025-04-15T17:35:11.244Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bf/9baed89785ba743ef329c2b07fd0611d12bfecbedbdd3eeecf929d8d3b52/contourpy-1.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cdd22595308f53ef2f891040ab2b93d79192513ffccbd7fe19be7aa773a5e09f", size = 1306641, upload-time = "2025-04-15T17:35:26.701Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cc/74e5e83d1e35de2d28bd97033426b450bc4fd96e092a1f7a63dc7369b55d/contourpy-1.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b4f54d6a2defe9f257327b0f243612dd051cc43825587520b1bf74a31e2f6ef2", size = 1374075, upload-time = "2025-04-15T17:35:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/42/17f3b798fd5e033b46a16f8d9fcb39f1aba051307f5ebf441bad1ecf78f8/contourpy-1.3.2-cp310-cp310-win32.whl", hash = "sha256:f939a054192ddc596e031e50bb13b657ce318cf13d264f095ce9db7dc6ae81c0", size = 177534, upload-time = "2025-04-15T17:35:46.554Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ec/5162b8582f2c994721018d0c9ece9dc6ff769d298a8ac6b6a652c307e7df/contourpy-1.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:c440093bbc8fc21c637c03bafcbef95ccd963bc6e0514ad887932c18ca2a759a", size = 221188, upload-time = "2025-04-15T17:35:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/b9/ede788a0b56fc5b071639d06c33cb893f68b1178938f3425debebe2dab78/contourpy-1.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a37a2fb93d4df3fc4c0e363ea4d16f83195fc09c891bc8ce072b9d084853445", size = 269636, upload-time = "2025-04-15T17:35:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/75/3469f011d64b8bbfa04f709bfc23e1dd71be54d05b1b083be9f5b22750d1/contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b7cd50c38f500bbcc9b6a46643a40e0913673f869315d8e70de0438817cb7773", size = 254636, upload-time = "2025-04-15T17:35:58.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2f/95adb8dae08ce0ebca4fd8e7ad653159565d9739128b2d5977806656fcd2/contourpy-1.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6658ccc7251a4433eebd89ed2672c2ed96fba367fd25ca9512aa92a4b46c4f1", size = 313053, upload-time = "2025-04-15T17:36:03.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a6/8ccf97a50f31adfa36917707fe39c9a0cbc24b3bbb58185577f119736cc9/contourpy-1.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:70771a461aaeb335df14deb6c97439973d253ae70660ca085eec25241137ef43", size = 352985, upload-time = "2025-04-15T17:36:08.275Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b6/7925ab9b77386143f39d9c3243fdd101621b4532eb126743201160ffa7e6/contourpy-1.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65a887a6e8c4cd0897507d814b14c54a8c2e2aa4ac9f7686292f9769fcf9a6ab", size = 323750, upload-time = "2025-04-15T17:36:13.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/20c5d1ef4f4748e52d60771b8560cf00b69d5c6368b5c2e9311bcfa2a08b/contourpy-1.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3859783aefa2b8355697f16642695a5b9792e7a46ab86da1118a4a23a51a33d7", size = 326246, upload-time = "2025-04-15T17:36:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e5/9dae809e7e0b2d9d70c52b3d24cba134dd3dad979eb3e5e71f5df22ed1f5/contourpy-1.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eab0f6db315fa4d70f1d8ab514e527f0366ec021ff853d7ed6a2d33605cf4b83", size = 1308728, upload-time = "2025-04-15T17:36:33.878Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/0058ba34aeea35c0b442ae61a4f4d4ca84d6df8f91309bc2d43bb8dd248f/contourpy-1.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d91a3ccc7fea94ca0acab82ceb77f396d50a1f67412efe4c526f5d20264e6ecd", size = 1375762, upload-time = "2025-04-15T17:36:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/09/33/7174bdfc8b7767ef2c08ed81244762d93d5c579336fc0b51ca57b33d1b80/contourpy-1.3.2-cp311-cp311-win32.whl", hash = "sha256:1c48188778d4d2f3d48e4643fb15d8608b1d01e4b4d6b0548d9b336c28fc9b6f", size = 178196, upload-time = "2025-04-15T17:36:55.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fe/4029038b4e1c4485cef18e480b0e2cd2d755448bb071eb9977caac80b77b/contourpy-1.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:5ebac872ba09cb8f2131c46b8739a7ff71de28a24c869bcad554477eb089a878", size = 222017, upload-time = "2025-04-15T17:36:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/44785876384eff370c251d58fd65f6ad7f39adce4a093c934d4a67a7c6b6/contourpy-1.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4caf2bcd2969402bf77edc4cb6034c7dd7c0803213b3523f111eb7460a51b8d2", size = 271580, upload-time = "2025-04-15T17:37:03.105Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3b/0004767622a9826ea3d95f0e9d98cd8729015768075d61f9fea8eeca42a8/contourpy-1.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:82199cb78276249796419fe36b7386bd8d2cc3f28b3bc19fe2454fe2e26c4c15", size = 255530, upload-time = "2025-04-15T17:37:07.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bb/7bd49e1f4fa805772d9fd130e0d375554ebc771ed7172f48dfcd4ca61549/contourpy-1.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106fab697af11456fcba3e352ad50effe493a90f893fca6c2ca5c033820cea92", size = 307688, upload-time = "2025-04-15T17:37:11.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/e1d5dbbfa170725ef78357a9a0edc996b09ae4af170927ba8ce977e60a5f/contourpy-1.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d14f12932a8d620e307f715857107b1d1845cc44fdb5da2bc8e850f5ceba9f87", size = 347331, upload-time = "2025-04-15T17:37:18.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/66/e69e6e904f5ecf6901be3dd16e7e54d41b6ec6ae3405a535286d4418ffb4/contourpy-1.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:532fd26e715560721bb0d5fc7610fce279b3699b018600ab999d1be895b09415", size = 318963, upload-time = "2025-04-15T17:37:22.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/32/b8a1c8965e4f72482ff2d1ac2cd670ce0b542f203c8e1d34e7c3e6925da7/contourpy-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b383144cf2d2c29f01a1e8170f50dacf0eac02d64139dcd709a8ac4eb3cfe", size = 323681, upload-time = "2025-04-15T17:37:33.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c6/12a7e6811d08757c7162a541ca4c5c6a34c0f4e98ef2b338791093518e40/contourpy-1.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c49f73e61f1f774650a55d221803b101d966ca0c5a2d6d5e4320ec3997489441", size = 1308674, upload-time = "2025-04-15T17:37:48.64Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8a/bebe5a3f68b484d3a2b8ffaf84704b3e343ef1addea528132ef148e22b3b/contourpy-1.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d80b2c0300583228ac98d0a927a1ba6a2ba6b8a742463c564f1d419ee5b211e", size = 1380480, upload-time = "2025-04-15T17:38:06.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/fcd325f19b5978fb509a7d55e06d99f5f856294c1991097534360b307cf1/contourpy-1.3.2-cp312-cp312-win32.whl", hash = "sha256:90df94c89a91b7362e1142cbee7568f86514412ab8a2c0d0fca72d7e91b62912", size = 178489, upload-time = "2025-04-15T17:38:10.338Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/fadd0b92ffa7b5eb5949bf340a63a4a496a6930a6c37a7ba0f12acb076d6/contourpy-1.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c942a01d9163e2e5cfb05cb66110121b8d07ad438a17f9e766317bcb62abf73", size = 223042, upload-time = "2025-04-15T17:38:14.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/61/5673f7e364b31e4e7ef6f61a4b5121c5f170f941895912f773d95270f3a2/contourpy-1.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:de39db2604ae755316cb5967728f4bea92685884b1e767b7c24e983ef5f771cb", size = 271630, upload-time = "2025-04-15T17:38:19.142Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/66/a40badddd1223822c95798c55292844b7e871e50f6bfd9f158cb25e0bd39/contourpy-1.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3f9e896f447c5c8618f1edb2bafa9a4030f22a575ec418ad70611450720b5b08", size = 255670, upload-time = "2025-04-15T17:38:23.688Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c7/cf9fdee8200805c9bc3b148f49cb9482a4e3ea2719e772602a425c9b09f8/contourpy-1.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71e2bd4a1c4188f5c2b8d274da78faab884b59df20df63c34f74aa1813c4427c", size = 306694, upload-time = "2025-04-15T17:38:28.238Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e7/ccb9bec80e1ba121efbffad7f38021021cda5be87532ec16fd96533bb2e0/contourpy-1.3.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de425af81b6cea33101ae95ece1f696af39446db9682a0b56daaa48cfc29f38f", size = 345986, upload-time = "2025-04-15T17:38:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/49/ca13bb2da90391fa4219fdb23b078d6065ada886658ac7818e5441448b78/contourpy-1.3.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:977e98a0e0480d3fe292246417239d2d45435904afd6d7332d8455981c408b85", size = 318060, upload-time = "2025-04-15T17:38:38.672Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/65/5245ce8c548a8422236c13ffcdcdada6a2a812c361e9e0c70548bb40b661/contourpy-1.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:434f0adf84911c924519d2b08fc10491dd282b20bdd3fa8f60fd816ea0b48841", size = 322747, upload-time = "2025-04-15T17:38:43.712Z" },
+    { url = "https://files.pythonhosted.org/packages/72/30/669b8eb48e0a01c660ead3752a25b44fdb2e5ebc13a55782f639170772f9/contourpy-1.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c66c4906cdbc50e9cba65978823e6e00b45682eb09adbb78c9775b74eb222422", size = 1308895, upload-time = "2025-04-15T17:39:00.224Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5a/b569f4250decee6e8d54498be7bdf29021a4c256e77fe8138c8319ef8eb3/contourpy-1.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8b7fc0cd78ba2f4695fd0a6ad81a19e7e3ab825c31b577f384aa9d7817dc3bef", size = 1379098, upload-time = "2025-04-15T17:43:29.649Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/b227c3886d120e60e41b28740ac3617b2f2b971b9f601c835661194579f1/contourpy-1.3.2-cp313-cp313-win32.whl", hash = "sha256:15ce6ab60957ca74cff444fe66d9045c1fd3e92c8936894ebd1f3eef2fff075f", size = 178535, upload-time = "2025-04-15T17:44:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/12/6e/2fed56cd47ca739b43e892707ae9a13790a486a3173be063681ca67d2262/contourpy-1.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:e1578f7eafce927b168752ed7e22646dad6cd9bca673c60bff55889fa236ebf9", size = 223096, upload-time = "2025-04-15T17:44:48.194Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4c/e76fe2a03014a7c767d79ea35c86a747e9325537a8b7627e0e5b3ba266b4/contourpy-1.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0475b1f6604896bc7c53bb070e355e9321e1bc0d381735421a2d2068ec56531f", size = 285090, upload-time = "2025-04-15T17:43:34.084Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e2/5aba47debd55d668e00baf9651b721e7733975dc9fc27264a62b0dd26eb8/contourpy-1.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c85bb486e9be652314bb5b9e2e3b0d1b2e643d5eec4992c0fbe8ac71775da739", size = 268643, upload-time = "2025-04-15T17:43:38.626Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/cd45f1f051fe6230f751cc5cdd2728bb3a203f5619510ef11e732109593c/contourpy-1.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:745b57db7758f3ffc05a10254edd3182a2a83402a89c00957a8e8a22f5582823", size = 310443, upload-time = "2025-04-15T17:43:44.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/a2/36ea6140c306c9ff6dd38e3bcec80b3b018474ef4d17eb68ceecd26675f4/contourpy-1.3.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:970e9173dbd7eba9b4e01aab19215a48ee5dd3f43cef736eebde064a171f89a5", size = 349865, upload-time = "2025-04-15T17:43:49.545Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b7/2fc76bc539693180488f7b6cc518da7acbbb9e3b931fd9280504128bf956/contourpy-1.3.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c4639a9c22230276b7bffb6a850dfc8258a2521305e1faefe804d006b2e532", size = 321162, upload-time = "2025-04-15T17:43:54.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/10/76d4f778458b0aa83f96e59d65ece72a060bacb20cfbee46cf6cd5ceba41/contourpy-1.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc829960f34ba36aad4302e78eabf3ef16a3a100863f0d4eeddf30e8a485a03b", size = 327355, upload-time = "2025-04-15T17:44:01.025Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/10cf483ea683f9f8ab096c24bad3cce20e0d1dd9a4baa0e2093c1c962d9d/contourpy-1.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d32530b534e986374fc19eaa77fcb87e8a99e5431499949b828312bdcd20ac52", size = 1307935, upload-time = "2025-04-15T17:44:17.322Z" },
+    { url = "https://files.pythonhosted.org/packages/78/73/69dd9a024444489e22d86108e7b913f3528f56cfc312b5c5727a44188471/contourpy-1.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e298e7e70cf4eb179cc1077be1c725b5fd131ebc81181bf0c03525c8abc297fd", size = 1372168, upload-time = "2025-04-15T17:44:33.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1b/96d586ccf1b1a9d2004dd519b25fbf104a11589abfd05484ff12199cca21/contourpy-1.3.2-cp313-cp313t-win32.whl", hash = "sha256:d0e589ae0d55204991450bb5c23f571c64fe43adaa53f93fc902a84c96f52fe1", size = 189550, upload-time = "2025-04-15T17:44:37.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e6/6000d0094e8a5e32ad62591c8609e269febb6e4db83a1c75ff8868b42731/contourpy-1.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:78e9253c3de756b3f6a5174d024c4835acd59eb3f8e2ca13e775dbffe1558f69", size = 238214, upload-time = "2025-04-15T17:44:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/33/05/b26e3c6ecc05f349ee0013f0bb850a761016d89cec528a98193a48c34033/contourpy-1.3.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fd93cc7f3139b6dd7aab2f26a90dde0aa9fc264dbf70f6740d498a70b860b82c", size = 265681, upload-time = "2025-04-15T17:44:59.314Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/25/ac07d6ad12affa7d1ffed11b77417d0a6308170f44ff20fa1d5aa6333f03/contourpy-1.3.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:107ba8a6a7eec58bb475329e6d3b95deba9440667c4d62b9b6063942b61d7f16", size = 315101, upload-time = "2025-04-15T17:45:04.165Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/4d/5bb3192bbe9d3f27e3061a6a8e7733c9120e203cb8515767d30973f71030/contourpy-1.3.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ded1706ed0c1049224531b81128efbd5084598f18d8a2d9efae833edbd2b40ad", size = 220599, upload-time = "2025-04-15T17:45:08.456Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c0/91f1215d0d9f9f343e4773ba6c9b89e8c0cc7a64a6263f21139da639d848/contourpy-1.3.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5f5964cdad279256c084b69c3f412b7801e15356b16efa9d78aa974041903da0", size = 266807, upload-time = "2025-04-15T17:45:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/79/6be7e90c955c0487e7712660d6cead01fa17bff98e0ea275737cc2bc8e71/contourpy-1.3.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49b65a95d642d4efa8f64ba12558fcb83407e58a2dfba9d796d77b63ccfcaff5", size = 318729, upload-time = "2025-04-15T17:45:20.166Z" },
+    { url = "https://files.pythonhosted.org/packages/87/68/7f46fb537958e87427d98a4074bcde4b67a70b04900cfc5ce29bc2f556c1/contourpy-1.3.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8c5acb8dddb0752bf252e01a3035b21443158910ac16a3b0d20e7fed7d534ce5", size = 221791, upload-time = "2025-04-15T17:45:24.794Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/2e/c4390a31919d8a78b90e8ecf87cd4b4c4f05a5b48d05ec17db8e5404c6f4/contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1", size = 288773, upload-time = "2025-07-26T12:01:02.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/44/c4b0b6095fef4dc9c420e041799591e3b63e9619e3044f7f4f6c21c0ab24/contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381", size = 270149, upload-time = "2025-07-26T12:01:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2e/dd4ced42fefac8470661d7cb7e264808425e6c5d56d175291e93890cce09/contourpy-1.3.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:929ddf8c4c7f348e4c0a5a3a714b5c8542ffaa8c22954862a46ca1813b667ee7", size = 329222, upload-time = "2025-07-26T12:01:05.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/74/cc6ec2548e3d276c71389ea4802a774b7aa3558223b7bade3f25787fafc2/contourpy-1.3.3-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9e999574eddae35f1312c2b4b717b7885d4edd6cb46700e04f7f02db454e67c1", size = 377234, upload-time = "2025-07-26T12:01:07.054Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/64ef723029f917410f75c09da54254c5f9ea90ef89b143ccadb09df14c15/contourpy-1.3.3-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0bf67e0e3f482cb69779dd3061b534eb35ac9b17f163d851e2a547d56dba0a3a", size = 380555, upload-time = "2025-07-26T12:01:08.801Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4b/6157f24ca425b89fe2eb7e7be642375711ab671135be21e6faa100f7448c/contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51e79c1f7470158e838808d4a996fa9bac72c498e93d8ebe5119bc1e6becb0db", size = 355238, upload-time = "2025-07-26T12:01:10.319Z" },
+    { url = "https://files.pythonhosted.org/packages/98/56/f914f0dd678480708a04cfd2206e7c382533249bc5001eb9f58aa693e200/contourpy-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:598c3aaece21c503615fd59c92a3598b428b2f01bfb4b8ca9c4edeecc2438620", size = 1326218, upload-time = "2025-07-26T12:01:12.659Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d7/4a972334a0c971acd5172389671113ae82aa7527073980c38d5868ff1161/contourpy-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:322ab1c99b008dad206d406bb61d014cf0174df491ae9d9d0fac6a6fda4f977f", size = 1392867, upload-time = "2025-07-26T12:01:15.533Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/f2cc6cd56dc8cff46b1a56232eabc6feea52720083ea71ab15523daab796/contourpy-1.3.3-cp311-cp311-win32.whl", hash = "sha256:fd907ae12cd483cd83e414b12941c632a969171bf90fc937d0c9f268a31cafff", size = 183677, upload-time = "2025-07-26T12:01:17.088Z" },
+    { url = "https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:3519428f6be58431c56581f1694ba8e50626f2dd550af225f82fb5f5814d2a42", size = 225234, upload-time = "2025-07-26T12:01:18.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b6/71771e02c2e004450c12b1120a5f488cad2e4d5b590b1af8bad060360fe4/contourpy-1.3.3-cp311-cp311-win_arm64.whl", hash = "sha256:15ff10bfada4bf92ec8b31c62bf7c1834c244019b4a33095a68000d7075df470", size = 193123, upload-time = "2025-07-26T12:01:19.848Z" },
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/29/8dcfe16f0107943fa92388c23f6e05cff0ba58058c4c95b00280d4c75a14/contourpy-1.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:cd5dfcaeb10f7b7f9dc8941717c6c2ade08f587be2226222c12b25f0483ed497", size = 278809, upload-time = "2025-07-26T12:02:52.74Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/8b37ef4f7dafeb335daee3c8254645ef5725be4d9c6aa70b50ec46ef2f7e/contourpy-1.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0c1fc238306b35f246d61a1d416a627348b5cf0648648a031e14bb8705fcdfe8", size = 261593, upload-time = "2025-07-26T12:02:54.037Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202, upload-time = "2025-07-26T12:02:55.947Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
+]
+
+[[package]]
+name = "corridorkey"
+version = "1.9.1"
+source = { editable = "." }
+dependencies = [
+    { name = "accelerate" },
+    { name = "av" },
+    { name = "diffusers" },
+    { name = "easydict" },
+    { name = "einops" },
+    { name = "huggingface-hub" },
+    { name = "imageio" },
+    { name = "kornia" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-ml-py" },
+    { name = "opencv-python-headless" },
+    { name = "openexr" },
+    { name = "peft" },
+    { name = "pillow" },
+    { name = "pims" },
+    { name = "pyside6" },
+    { name = "setuptools" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "triton-windows", marker = "sys_platform == 'win32'" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+mlx = [
+    { name = "corridorkey-mlx", marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+]
+quality = [
+    { name = "lpips" },
+    { name = "pytorch-msssim" },
+    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+tracker = [
+    { name = "sam-2" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "accelerate" },
+    { name = "av" },
+    { name = "corridorkey-mlx", marker = "python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'mlx'", git = "https://github.com/nikopueringer/corridorkey-mlx.git?tag=v1.0.0" },
+    { name = "diffusers" },
+    { name = "easydict" },
+    { name = "einops" },
+    { name = "huggingface-hub" },
+    { name = "imageio" },
+    { name = "kornia" },
+    { name = "lpips", marker = "extra == 'quality'" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "nvidia-ml-py" },
+    { name = "opencv-python-headless" },
+    { name = "openexr", specifier = ">=3.4" },
+    { name = "peft" },
+    { name = "pillow" },
+    { name = "pims" },
+    { name = "pyside6", specifier = ">=6.7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytorch-msssim", marker = "extra == 'quality'" },
+    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "sam-2", marker = "extra == 'tracker'", git = "https://github.com/facebookresearch/sam2.git" },
+    { name = "scikit-image", marker = "extra == 'quality'" },
+    { name = "setuptools" },
+    { name = "timm", specifier = "==1.0.24" },
+    { name = "torch", specifier = "==2.9.1" },
+    { name = "torchvision", specifier = "==0.24.1" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "triton-windows", marker = "sys_platform == 'win32'", specifier = ">=3.5,<3.6" },
+]
+provides-extras = ["dev", "tracker", "quality", "mlx"]
+
+[[package]]
+name = "corridorkey-mlx"
+version = "0.1.0"
+source = { git = "https://github.com/nikopueringer/corridorkey-mlx.git?tag=v1.0.0#7f1c2ee221b91d68cf98b928f800f08d6a5eea40" }
+dependencies = [
+    { name = "mlx", marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "pillow", marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "rich", marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "safetensors", marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "diffusers"
+version = "0.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "importlib-metadata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/5c/f4c2eb8d481fe8784a7e2331fbaab820079c06676185fa6d2177b386d590/diffusers-0.37.1.tar.gz", hash = "sha256:2346c21f77f835f273b7aacbaada1c34a596a3a2cc6ddc99d149efcd0ec298fa", size = 4135139, upload-time = "2026-03-25T08:04:04.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/dd/51c38785ce5e1c287b5ad17ba550edaaaffce0deb0da4857019c6700fbaf/diffusers-0.37.1-py3-none-any.whl", hash = "sha256:0537c0b28cb53cf39d6195489bcf8f833986df556c10f5e28ab7427b86fc8b90", size = 5001536, upload-time = "2026-03-25T08:04:02.385Z" },
+]
+
+[[package]]
+name = "easydict"
+version = "1.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/9f/d18d6b5e19244788a6d09c14a8406376b4f4bfcc008e6d17a4f4c15362e8/easydict-1.13.tar.gz", hash = "sha256:b1135dedbc41c8010e2bc1f77ec9744c7faa42bce1a1c87416791449d6c87780", size = 6809, upload-time = "2024-03-04T12:04:41.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/ec/fa6963f1198172c2b75c9ab6ecefb3045991f92f75f5eb41b6621b198123/easydict-1.13-py3-none-any.whl", hash = "sha256:6b787daf4dcaf6377b4ad9403a5cee5a86adbc0ca9a5bcf5410e9902002aeac2", size = 6804, upload-time = "2024-03-04T12:04:39.508Z" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/532ed43808b469c807e8cb6b21358da3fe6fd51486b3a8c93db0bb5d957f/fonttools-4.62.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ad5cca75776cd453b1b035b530e943334957ae152a36a88a320e779d61fc980c", size = 2873740, upload-time = "2026-03-13T13:52:11.822Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e4/2318d2b430562da7227010fb2bb029d2fa54d7b46443ae8942bab224e2a0/fonttools-4.62.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0b3ae47e8636156a9accff64c02c0924cbebad62854c4a6dbdc110cd5b4b341a", size = 2417649, upload-time = "2026-03-13T13:52:14.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/40f15523b5188598018e7956899fed94eb7debec89e2dd70cb4a8df90492/fonttools-4.62.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b9e288b4da2f64fd6180644221749de651703e8d0c16bd4b719533a3a7d6e3", size = 4935213, upload-time = "2026-03-13T13:52:17.399Z" },
+    { url = "https://files.pythonhosted.org/packages/42/09/7dbe3d7023f57d9b580cfa832109d521988112fd59dddfda3fddda8218f9/fonttools-4.62.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bca7a1c1faf235ffe25d4f2e555246b4750220b38de8261d94ebc5ce8a23c23", size = 4892374, upload-time = "2026-03-13T13:52:20.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/2d/84509a2e32cb925371560ef5431365d8da2183c11d98e5b4b8b4e42426a5/fonttools-4.62.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b4e0fcf265ad26e487c56cb12a42dffe7162de708762db951e1b3f755319507d", size = 4911856, upload-time = "2026-03-13T13:52:22.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/80/df28131379eed93d9e6e6fccd3bf6e3d077bebbfe98cc83f21bbcd83ed02/fonttools-4.62.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2d850f66830a27b0d498ee05adb13a3781637b1826982cd7e2b3789ef0cc71ae", size = 5031712, upload-time = "2026-03-13T13:52:25.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/03/3c8f09aad64230cd6d921ae7a19f9603c36f70930b00459f112706f6769a/fonttools-4.62.1-cp310-cp310-win32.whl", hash = "sha256:486f32c8047ccd05652aba17e4a8819a3a9d78570eb8a0e3b4503142947880ed", size = 1507878, upload-time = "2026-03-13T13:52:28.149Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f53f626f8f3e89f4cadd8fc08f3452c8fd182c951ad5caa35efac22b29ab/fonttools-4.62.1-cp310-cp310-win_amd64.whl", hash = "sha256:5a648bde915fba9da05ae98856987ca91ba832949a9e2888b48c47ef8b96c5a9", size = 1556766, upload-time = "2026-03-13T13:52:30.814Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/23ff32561ec8d45a4d48578b4d241369d9270dc50926c017570e60893701/fonttools-4.62.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:40975849bac44fb0b9253d77420c6d8b523ac4dcdcefeff6e4d706838a5b80f7", size = 2871039, upload-time = "2026-03-13T13:52:33.127Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7f/66d3f8a9338a9b67fe6e1739f47e1cd5cee78bd3bc1206ef9b0b982289a5/fonttools-4.62.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9dde91633f77fa576879a0c76b1d89de373cae751a98ddf0109d54e173b40f14", size = 2416346, upload-time = "2026-03-13T13:52:35.676Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/53/5276ceba7bff95da7793a07c5284e1da901cf00341ce5e2f3273056c0cca/fonttools-4.62.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6acb4109f8bee00fec985c8c7afb02299e35e9c94b57287f3ea542f28bd0b0a7", size = 5100897, upload-time = "2026-03-13T13:52:38.102Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a1/40a5c4d8e28b0851d53a8eeeb46fbd73c325a2a9a165f290a5ed90e6c597/fonttools-4.62.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1c5c25671ce8805e0d080e2ffdeca7f1e86778c5cbfbeae86d7f866d8830517b", size = 5071078, upload-time = "2026-03-13T13:52:41.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/d378fca4c65ea1956fee6d90ace6e861776809cbbc5af22388a090c3c092/fonttools-4.62.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a5d8825e1140f04e6c99bb7d37a9e31c172f3bc208afbe02175339e699c710e1", size = 5076908, upload-time = "2026-03-13T13:52:44.122Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d9/ae6a1d0693a4185a84605679c8a1f719a55df87b9c6e8e817bfdd9ef5936/fonttools-4.62.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:268abb1cb221e66c014acc234e872b7870d8b5d4657a83a8f4205094c32d2416", size = 5202275, upload-time = "2026-03-13T13:52:46.591Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6c/af95d9c4efb15cabff22642b608342f2bd67137eea6107202d91b5b03184/fonttools-4.62.1-cp311-cp311-win32.whl", hash = "sha256:942b03094d7edbb99bdf1ae7e9090898cad7bf9030b3d21f33d7072dbcb51a53", size = 2293075, upload-time = "2026-03-13T13:52:48.711Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/bf54c5b3f2be34e1f143e6db838dfdc54f2ffa3e68c738934c82f3b2a08d/fonttools-4.62.1-cp311-cp311-win_amd64.whl", hash = "sha256:e8514f4924375f77084e81467e63238b095abda5107620f49421c368a6017ed2", size = 2344593, upload-time = "2026-03-13T13:52:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/28/baf5d745559503ce8d28cf5bc9551f5ac59158eafd7b6a6afff0bcdb0f50/huggingface_hub-1.10.1.tar.gz", hash = "sha256:696c53cf9c2ac9befbfb5dd41d05392a031c69fc6930d1ed9671debd405b6fff", size = 758094, upload-time = "2026-04-09T15:01:18.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/8c/c7a33f3efaa8d6a5bc40e012e5ecc2d72c2e6124550ca9085fe0ceed9993/huggingface_hub-1.10.1-py3-none-any.whl", hash = "sha256:6b981107a62fbe68c74374418983399c632e35786dcd14642a9f2972633c8b5a", size = 642630, upload-time = "2026-04-09T15:01:17.35Z" },
+]
+
+[[package]]
+name = "hydra-core"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "iopath"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "portalocker" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz", hash = "sha256:3311c16a4d9137223e20f141655759933e1eda24f8bff166af834af3c645ef01", size = 42226, upload-time = "2022-07-09T19:00:50.866Z" }
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f8/06549565caa026e540b7e7bab5c5a90eb7ca986015f4c48dace243cd24d9/kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374", size = 122802, upload-time = "2026-03-09T13:12:37.515Z" },
+    { url = "https://files.pythonhosted.org/packages/84/eb/8476a0818850c563ff343ea7c9c05dcdcbd689a38e01aa31657df01f91fa/kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd", size = 66216, upload-time = "2026-03-09T13:12:38.812Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/f9c8a6b4c21aed4198566e45923512986d6cef530e7263b3a5f823546561/kiwisolver-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86e0287879f75621ae85197b0877ed2f8b7aa57b511c7331dce2eb6f4de7d476", size = 63917, upload-time = "2026-03-09T13:12:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/0e/ba4ae25d03722f64de8b2c13e80d82ab537a06b30fc7065183c6439357e3/kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22", size = 1628776, upload-time = "2026-03-09T13:12:41.976Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e4/3f43a011bc8a0860d1c96f84d32fa87439d3feedf66e672fef03bf5e8bac/kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9190426b7aa26c5229501fa297b8d0653cfd3f5a36f7990c264e157cbf886b3b", size = 1228164, upload-time = "2026-03-09T13:12:44.002Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/34/3a901559a1e0c218404f9a61a93be82d45cb8f44453ba43088644980f033/kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c8277104ded0a51e699c8c3aff63ce2c56d4ed5519a5f73e0fd7057f959a2b9e", size = 1246656, upload-time = "2026-03-09T13:12:45.557Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9e/f78c466ea20527822b95ad38f141f2de1dcd7f23fb8716b002b0d91bbe59/kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f9baf6f0a6e7571c45c8863010b45e837c3ee1c2c77fcd6ef423be91b21fedb", size = 1295562, upload-time = "2026-03-09T13:12:47.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/66/fd0e4a612e3a286c24e6d6f3a5428d11258ed1909bc530ba3b59807fd980/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cff8e5383db4989311f99e814feeb90c4723eb4edca425b9d5d9c3fefcdd9537", size = 2178473, upload-time = "2026-03-09T13:12:50.254Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/6cac929e0049539e5ee25c1ee937556f379ba5204840d03008363ced662d/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ebae99ed6764f2b5771c522477b311be313e8841d2e0376db2b10922daebbba4", size = 2274035, upload-time = "2026-03-09T13:12:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d3/9d0c18f1b52ea8074b792452cf17f1f5a56bd0302a85191f405cfbf9da16/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d5cd5189fc2b6a538b75ae45433140c4823463918f7b1617c31e68b085c0022c", size = 2443217, upload-time = "2026-03-09T13:12:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2a/6e19368803a038b2a90857bf4ee9e3c7b667216d045866bf22d3439fd75e/kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f42c23db5d1521218a3276bb08666dcb662896a0be7347cba864eca45ff64ede", size = 2249196, upload-time = "2026-03-09T13:12:55.057Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2b/3f641dfcbe72e222175d626bacf2f72c3b34312afec949dd1c50afa400f5/kiwisolver-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:94eff26096eb5395136634622515b234ecb6c9979824c1f5004c6e3c3c85ccd2", size = 73389, upload-time = "2026-03-09T13:12:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/da/88/299b137b9e0025d8982e03d2d52c123b0a2b159e84b0ef1501ef446339cf/kiwisolver-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:dd952e03bfbb096cfe2dd35cd9e00f269969b67536cb4370994afc20ff2d0875", size = 64782, upload-time = "2026-03-09T13:12:57.609Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dd/a495a9c104be1c476f0386e714252caf2b7eca883915422a64c50b88c6f5/kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c", size = 122798, upload-time = "2026-03-09T13:12:58.963Z" },
+    { url = "https://files.pythonhosted.org/packages/11/60/37b4047a2af0cf5ef6d8b4b26e91829ae6fc6a2d1f74524bcb0e7cd28a32/kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb", size = 66216, upload-time = "2026-03-09T13:13:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/aa/510dc933d87767584abfe03efa445889996c70c2990f6f87c3ebaa0a18c5/kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac", size = 63911, upload-time = "2026-03-09T13:13:01.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/46/bddc13df6c2a40741e0cc7865bb1c9ed4796b6760bd04ce5fae3928ef917/kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27", size = 1438209, upload-time = "2026-03-09T13:13:03.385Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d6/76621246f5165e5372f02f5e6f3f48ea336a8f9e96e43997d45b240ed8cd/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398", size = 1248888, upload-time = "2026-03-09T13:13:05.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c1/31559ec6fb39a5b48035ce29bb63ade628f321785f38c384dee3e2c08bc1/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db", size = 1266304, upload-time = "2026-03-09T13:13:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ef/1cb8276f2d29cc6a41e0a042f27946ca347d3a4a75acf85d0a16aa6dcc82/kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc", size = 1319650, upload-time = "2026-03-09T13:13:08.607Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e4/5ba3cecd7ce6236ae4a80f67e5d5531287337d0e1f076ca87a5abe4cd5d0/kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679", size = 970949, upload-time = "2026-03-09T13:13:10.299Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/69/dc61f7ae9a2f071f26004ced87f078235b5507ab6e5acd78f40365655034/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309", size = 2199125, upload-time = "2026-03-09T13:13:11.841Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/abbe0f1b5afa85f8d084b73e90e5f801c0939eba16ac2e49af7c61a6c28d/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2", size = 2293783, upload-time = "2026-03-09T13:13:14.399Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/80/5908ae149d96d81580d604c7f8aefd0e98f4fd728cf172f477e9f2a81744/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c", size = 1960726, upload-time = "2026-03-09T13:13:16.047Z" },
+    { url = "https://files.pythonhosted.org/packages/84/08/a78cb776f8c085b7143142ce479859cfec086bd09ee638a317040b6ef420/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08", size = 2464738, upload-time = "2026-03-09T13:13:17.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/65584da5356ed6cb12c63791a10b208860ac40a83de165cb6a6751a686e3/kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4", size = 2270718, upload-time = "2026-03-09T13:13:19.421Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6c/28f17390b62b8f2f520e2915095b3c94d88681ecf0041e75389d9667f202/kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b", size = 73480, upload-time = "2026-03-09T13:13:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0e/2ee5debc4f77a625778fec5501ff3e8036fe361b7ee28ae402a485bb9694/kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac", size = 64930, upload-time = "2026-03-09T13:13:21.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/6fd4f690a40c2582fa34b97d2678f718acf3706b91d270c65ecb455d0a06/kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4", size = 59606, upload-time = "2026-03-09T13:15:40.81Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a0/2355d5e3b338f13ce63f361abb181e3b6ea5fffdb73f739b3e80efa76159/kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca", size = 57537, upload-time = "2026-03-09T13:15:42.071Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b9/1d50e610ecadebe205b71d6728fd224ce0e0ca6aba7b9cbe1da049203ac5/kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f", size = 79888, upload-time = "2026-03-09T13:15:43.317Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ee/b85ffcd75afed0357d74f0e6fc02a4507da441165de1ca4760b9f496390d/kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf4679a3d71012a7c2bf360e5cd878fbd5e4fcac0896b56393dec239d81529ed", size = 77584, upload-time = "2026-03-09T13:15:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/dd/644d0dde6010a8583b4cd66dd41c5f83f5325464d15c4f490b3340ab73b4/kiwisolver-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41024ed50e44ab1a60d3fe0a9d15a4ccc9f5f2b1d814ff283c8d01134d5b81bc", size = 73390, upload-time = "2026-03-09T13:15:45.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/eb/5fcbbbf9a0e2c3a35effb88831a483345326bbc3a030a3b5b69aee647f84/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232", size = 59532, upload-time = "2026-03-09T13:15:47.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9b/e17104555bb4db148fd52327feea1e96be4b88e8e008b029002c281a21ab/kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a", size = 57420, upload-time = "2026-03-09T13:15:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
+]
+
+[[package]]
+name = "kornia"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "kornia-rs" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e6/45e757d4924176e4d4e111e10effaab7db382313243e0188a06805010073/kornia-0.8.2.tar.gz", hash = "sha256:5411b2ce0dd909d1608016308cd68faeef90f88c47f47e8ecd40553fd4d8b937", size = 667151, upload-time = "2025-11-08T12:10:03.042Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d4/e9bd12b7b4cbd23b4dfb47e744ee1fa54d6d9c3c9bc406ec86c1be8c8307/kornia-0.8.2-py2.py3-none-any.whl", hash = "sha256:32dfe77c9c74a87a2de49395aa3c2c376a1b63c27611a298b394d02d13905819", size = 1095012, upload-time = "2025-11-08T12:10:01.226Z" },
+]
+
+[[package]]
+name = "kornia-rs"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/17/8b3518ece01512a575b18f86b346879793d3dea264b314796bbd44d42e11/kornia_rs-0.1.10.tar.gz", hash = "sha256:5fd3fbc65240fa751975f5870b079f98e7fdcaa2885ea577b3da324d8bf01d81", size = 145610, upload-time = "2025-11-08T11:29:32.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/40/6a59c5b99e19e1be7fff1d68dd3b3eddc80e5304dab75ebb78d0199e2484/kornia_rs-0.1.10-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e95ccd4b3f73a0d5cbe16c03fd705fa8d75e9df7b044ba9a6c5957b2591003f3", size = 2815093, upload-time = "2025-11-08T11:30:17.98Z" },
+    { url = "https://files.pythonhosted.org/packages/17/aa/77f5882707467a6af0833b3ac1497638352bc391d082713b24a3bd187f73/kornia_rs-0.1.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9bc8d5de7d7611b68746b2feff594a073740c4f915d0ccc37bd1d189029c20fe", size = 2078046, upload-time = "2025-11-08T11:30:04.952Z" },
+    { url = "https://files.pythonhosted.org/packages/31/43/cff694d864bf60e1e3853ec98bdabc66433f0eeffb7e7f97d27a0b907a88/kornia_rs-0.1.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edb94ce80a614a5f00cb68755d7a182236482584e78388217974ef811f4dbb30", size = 2204974, upload-time = "2025-11-08T11:29:30.626Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5a/907580d1e573bc1862557cb70d1f1888bde1b33240d15cd10ff06c93a57c/kornia_rs-0.1.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:859942c70f503bba813c99a39d3011d3e51f294db8058f87842efa180955cab4", size = 3042947, upload-time = "2025-11-08T11:29:48.431Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/13/3d0a45f297b1a3f308893751b62080898ce415c61a3629a3d6b04cf55db7/kornia_rs-0.1.10-cp310-cp310-win_amd64.whl", hash = "sha256:74f17ea9afc0a5312832c32f6670e1a4b2162dcf9a8908fb46bbb56d2c707e9e", size = 2543744, upload-time = "2025-11-08T11:30:30.929Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/ab91a87cefd8d92a10749fa5d923366dfd2a2d240d9e57260e4218e9a5af/kornia_rs-0.1.10-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6757940733f13c52c4f142b9b11e3e9bd12ef9d209e333300602e86e21f5ae2f", size = 2811949, upload-time = "2025-11-08T11:30:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/61/6125a970249e04dd31cf3edf3fb0ceb98ea65269bc416ba48fd70f9a8f5e/kornia_rs-0.1.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:68e90101a34ba2bbce920332b25fd4d25c8c546d9a241b2606a6d886df2dd1ed", size = 2078639, upload-time = "2025-11-08T11:30:06.363Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e4/c3484e5921a08e6368f0565c30646741fd12b46cb45c962d519cac3d12ad/kornia_rs-0.1.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b0adb81858a8963455f2f0da01fcd6ea3296147b918306488edeeaf6bc2a979", size = 2204722, upload-time = "2025-11-08T11:29:33.566Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a4/2e6e33da900f19ae6411bfad41d317e56f1ae4f204bd73e61f0881bd5418/kornia_rs-0.1.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c3e237a8428524ad9f86599c0c47b355bc3007669fe297ea3fbd59cd64bc2f7", size = 3042890, upload-time = "2025-11-08T11:29:50.15Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/5e171c98b742139bebd1bd593d768e3c045f824bf0ae14190b63f0ac0acc/kornia_rs-0.1.10-cp311-cp311-win_amd64.whl", hash = "sha256:1d300ea6d4666e47302fba6cc438556d91e37ce41caf291a9a04a8f74c231d0b", size = 2544572, upload-time = "2025-11-08T11:30:32.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/6c/8248f08c90a10d6b8ca2e74783da8df7fa509f46b64a3b4fbb7dd0ac4e9c/kornia_rs-0.1.10-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f0809277e51156d59be3c39605ba9659e94f7a4cf3b0b6c035ec2f06f6067881", size = 2811606, upload-time = "2025-11-08T11:30:21.346Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/29e5710cbc5d01c155ee1fd7621db48b94378a7ae394741bb34a6bfb36d9/kornia_rs-0.1.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ecf2ba0291cc1bb178073d56e46b16296a8864a20272b63af02ee88771cb574", size = 2076141, upload-time = "2025-11-08T11:30:07.527Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/0b3e90b9d0a25e6211c7ac9fa1dfed4db1306a812c359ee49678390a1bdc/kornia_rs-0.1.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d874ca12dd58871f9849672d9bf9fa998398470a88b52d61223ce2133b196662", size = 2205562, upload-time = "2025-11-08T11:29:35.353Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d4/315f358b2a2c29d9af3a73f3d1973c2fd8e0cdeb65a57af98643e66fa7c8/kornia_rs-0.1.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f332a2a034cc791006f25c2d85e342a060887145e9236e8e43562badcadededf", size = 3042197, upload-time = "2025-11-08T11:29:51.614Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b8/0ddbdf1d35fec3ef24f5b8cc29eb633ce5ce16c94c9fb090408c1280abe9/kornia_rs-0.1.10-cp312-cp312-win_amd64.whl", hash = "sha256:34111ce1c8abe930079b4b0aeb8d372f876c621a867ed03f77181de685e71a8f", size = 2539656, upload-time = "2025-11-08T11:30:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/90/01/1d658b11635431f8c31f416c90ca99befdc1f4fdd20e91a05b480b9c0ea8/kornia_rs-0.1.10-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:950a943f91c2cff94d80282886b0d48bbc15ef4a7cc4b15ac819724dfdb2f414", size = 2811810, upload-time = "2025-11-08T11:30:22.497Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ed/bd970ded1d819557cc33055d982b1847eb385151ea5b0c915c16ed74f5c0/kornia_rs-0.1.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:63b802aaf95590276d3426edc6d23ff11caf269d2bc2ec37cb6c679b7b2a8ee0", size = 2076195, upload-time = "2025-11-08T11:30:08.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/10/afd700455105fdba5b043d724f3a65ca36259b89c736a3b71d5a03103808/kornia_rs-0.1.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38087da7cdf2bffe10530c0d53335dd1fc107fae6521f2dd4797c6522b6d11b3", size = 2205781, upload-time = "2025-11-08T11:29:36.8Z" },
+    { url = "https://files.pythonhosted.org/packages/25/16/ec8dc3ce1d79660ddd6a186a77037e0c3bf61648e6c72250280b648fb291/kornia_rs-0.1.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa3464de8f9920d87415721c36840ceea23e054dcb54dd9f69189ba9eabce0c7", size = 3042272, upload-time = "2025-11-08T11:29:52.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/75/62785aba777d35a562a97a987d65840306fab7a8ecd2d928dd8ac779e29b/kornia_rs-0.1.10-cp313-cp313-win_amd64.whl", hash = "sha256:c57d157bebe64c22e2e44c72455b1c7365eee4d767e0c187dc28f22d072ebaf7", size = 2539802, upload-time = "2025-11-08T11:30:35.753Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d5/32b23d110109eb77b2dc952be75411f7e495da9105058e2cb08924a9cc90/kornia_rs-0.1.10-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:0b375f02422ef5986caed612799b4ddcc91f57f303906868b0a8c397a17e7607", size = 2810244, upload-time = "2025-11-08T11:30:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5f/5ecde42b7c18e7df26c413848a98744427c3d370f5eed725b65f0bc356fb/kornia_rs-0.1.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2bcfa438d6b5dbe07d573afc980f2871f6639b2eac5148b8c0bba4f82357b9a", size = 2074220, upload-time = "2025-11-08T11:30:09.972Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6c/6fc86eb855bcc723924c3b91de98dc6c0f381987ce582e080b8eade3bc88/kornia_rs-0.1.10-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:021b0a02b2356b12b3954a298f369ed4fe2dd522dcf8b6d72f91bf3bd8eea201", size = 2204672, upload-time = "2025-11-08T11:29:38.777Z" },
+    { url = "https://files.pythonhosted.org/packages/19/26/3ac706d1b36761c0f7a36934327079adcb42d761c8c219865123d49fc1b2/kornia_rs-0.1.10-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d9b07e2ae79e423b3248d94afd092e324c5ddfe3157fafc047531cc8bffa6a3", size = 3042797, upload-time = "2025-11-08T11:29:54.719Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/d62728d86bc67f5516249b154ff0bdfcf38a854dae284ff0ce62da87af99/kornia_rs-0.1.10-cp313-cp313t-win_amd64.whl", hash = "sha256:b80a037e34d63cb021bcd5fc571e41aff804a2981311f66e883768c6b8e5f8de", size = 2543855, upload-time = "2025-11-08T11:30:37.437Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "lpips"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/2d/4b8148d32f5bd461eb7d5daa54fcc998f86eaa709a57f4ef6aa4c62f024f/lpips-0.1.4.tar.gz", hash = "sha256:3846331df6c69688aec3d300a5eeef6c529435bc8460bd58201c3d62e56188fa", size = 18029, upload-time = "2021-08-25T22:10:32.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/13/1df50c7925d9d2746702719f40e864f51ed66f307b20ad32392f1ad2bb87/lpips-0.1.4-py3-none-any.whl", hash = "sha256:fd537af5828b69d2e6ffc0a397bd506dbc28ca183543617690844c08e102ec5e", size = 53763, upload-time = "2021-08-25T22:10:31.257Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", size = 34806269, upload-time = "2025-12-10T22:56:51.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/a30bd917018ad220c400169fba298f2bb7003c8ccbc0c3e24ae2aacad1e8/matplotlib-3.10.8-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:00270d217d6b20d14b584c521f810d60c5c78406dc289859776550df837dcda7", size = 8239828, upload-time = "2025-12-10T22:55:02.313Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/ca01e043c4841078e82cf6e80a6993dfecd315c3d79f5f3153afbb8e1ec6/matplotlib-3.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37b3c1cc42aa184b3f738cfa18c1c1d72fd496d85467a6cf7b807936d39aa656", size = 8128050, upload-time = "2025-12-10T22:55:04.997Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/aa/7ab67f2b729ae6a91bcf9dcac0affb95fb8c56f7fd2b2af894ae0b0cf6fa/matplotlib-3.10.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ee40c27c795bda6a5292e9cff9890189d32f7e3a0bf04e0e3c9430c4a00c37df", size = 8700452, upload-time = "2025-12-10T22:55:07.47Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ae/2d5817b0acee3c49b7e7ccfbf5b273f284957cc8e270adf36375db353190/matplotlib-3.10.8-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a48f2b74020919552ea25d222d5cc6af9ca3f4eb43a93e14d068457f545c2a17", size = 9534928, upload-time = "2025-12-10T22:55:10.566Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5b/8e66653e9f7c39cb2e5cab25fce4810daffa2bff02cbf5f3077cea9e942c/matplotlib-3.10.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f254d118d14a7f99d616271d6c3c27922c092dac11112670b157798b89bf4933", size = 9586377, upload-time = "2025-12-10T22:55:12.362Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/fd0bbadf837f81edb0d208ba8f8cb552874c3b16e27cb91a31977d90875d/matplotlib-3.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:f9b587c9c7274c1613a30afabf65a272114cd6cdbe67b3406f818c79d7ab2e2a", size = 8128127, upload-time = "2025-12-10T22:55:14.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/86/de7e3a1cdcfc941483af70609edc06b83e7c8a0e0dc9ac325200a3f4d220/matplotlib-3.10.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6be43b667360fef5c754dda5d25a32e6307a03c204f3c0fc5468b78fa87b4160", size = 8251215, upload-time = "2025-12-10T22:55:16.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/14/baad3222f424b19ce6ad243c71de1ad9ec6b2e4eb1e458a48fdc6d120401/matplotlib-3.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2b336e2d91a3d7006864e0990c83b216fcdca64b5a6484912902cef87313d78", size = 8139625, upload-time = "2025-12-10T22:55:17.712Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a0/7024215e95d456de5883e6732e708d8187d9753a21d32f8ddb3befc0c445/matplotlib-3.10.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efb30e3baaea72ce5928e32bab719ab4770099079d66726a62b11b1ef7273be4", size = 8712614, upload-time = "2025-12-10T22:55:20.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f4/b8347351da9a5b3f41e26cf547252d861f685c6867d179a7c9d60ad50189/matplotlib-3.10.8-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d56a1efd5bfd61486c8bc968fa18734464556f0fb8e51690f4ac25d85cbbbbc2", size = 9540997, upload-time = "2025-12-10T22:55:23.258Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c0/c7b914e297efe0bc36917bf216b2acb91044b91e930e878ae12981e461e5/matplotlib-3.10.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:238b7ce5717600615c895050239ec955d91f321c209dd110db988500558e70d6", size = 9596825, upload-time = "2025-12-10T22:55:25.217Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a4bbc01c237ab710a1f22b4da72f4ff6d77eb4c7735ea9811a94ae239067/matplotlib-3.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:18821ace09c763ec93aef5eeff087ee493a24051936d7b9ebcad9662f66501f9", size = 8135090, upload-time = "2025-12-10T22:55:27.162Z" },
+    { url = "https://files.pythonhosted.org/packages/89/dd/a0b6588f102beab33ca6f5218b31725216577b2a24172f327eaf6417d5c9/matplotlib-3.10.8-cp311-cp311-win_arm64.whl", hash = "sha256:bab485bcf8b1c7d2060b4fcb6fc368a9e6f4cd754c9c2fea281f4be21df394a2", size = 8012377, upload-time = "2025-12-10T22:55:29.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/67/f997cdcbb514012eb0d10cd2b4b332667997fb5ebe26b8d41d04962fa0e6/matplotlib-3.10.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:64fcc24778ca0404ce0cb7b6b77ae1f4c7231cdd60e6778f999ee05cbd581b9a", size = 8260453, upload-time = "2025-12-10T22:55:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/07d5f5c7f7c994f12c768708bd2e17a4f01a2b0f44a1c9eccad872433e2e/matplotlib-3.10.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9a5ca4ac220a0cdd1ba6bcba3608547117d30468fefce49bb26f55c1a3d5c58", size = 8148321, upload-time = "2025-12-10T22:55:33.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ab4aabc72de4ff77b3ec33a6d78a68227bf1123465887f9905ba79184a1cc04", size = 8716944, upload-time = "2025-12-10T22:55:34.922Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f9/7638f5cc82ec8a7aa005de48622eecc3ed7c9854b96ba15bd76b7fd27574/matplotlib-3.10.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24d50994d8c5816ddc35411e50a86ab05f575e2530c02752e02538122613371f", size = 9550099, upload-time = "2025-12-10T22:55:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/78cd5920d35b29fd2a0fe894de8adf672ff52939d2e9b43cb83cd5ce1bc7/matplotlib-3.10.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:99eefd13c0dc3b3c1b4d561c1169e65fe47aab7b8158754d7c084088e2329466", size = 9613040, upload-time = "2025-12-10T22:55:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4e/c10f171b6e2f44d9e3a2b96efa38b1677439d79c99357600a62cc1e9594e/matplotlib-3.10.8-cp312-cp312-win_amd64.whl", hash = "sha256:dd80ecb295460a5d9d260df63c43f4afbdd832d725a531f008dad1664f458adf", size = 8142717, upload-time = "2025-12-10T22:55:41.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/76/934db220026b5fef85f45d51a738b91dea7d70207581063cd9bd8fafcf74/matplotlib-3.10.8-cp312-cp312-win_arm64.whl", hash = "sha256:3c624e43ed56313651bc18a47f838b60d7b8032ed348911c54906b130b20071b", size = 8012751, upload-time = "2025-12-10T22:55:42.684Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b9/15fd5541ef4f5b9a17eefd379356cf12175fe577424e7b1d80676516031a/matplotlib-3.10.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3f2e409836d7f5ac2f1c013110a4d50b9f7edc26328c108915f9075d7d7a91b6", size = 8261076, upload-time = "2025-12-10T22:55:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a0/2ba3473c1b66b9c74dc7107c67e9008cb1782edbe896d4c899d39ae9cf78/matplotlib-3.10.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56271f3dac49a88d7fca5060f004d9d22b865f743a12a23b1e937a0be4818ee1", size = 8148794, upload-time = "2025-12-10T22:55:46.252Z" },
+    { url = "https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a0a7f52498f72f13d4a25ea70f35f4cb60642b466cbb0a9be951b5bc3f45a486", size = 8718474, upload-time = "2025-12-10T22:55:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/01/be/cd478f4b66f48256f42927d0acbcd63a26a893136456cd079c0cc24fbabf/matplotlib-3.10.8-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:646d95230efb9ca614a7a594d4fcacde0ac61d25e37dd51710b36477594963ce", size = 9549637, upload-time = "2025-12-10T22:55:50.048Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8dc289776eae5109e268c4fb92baf870678dc048a25d4ac903683b86d5bf/matplotlib-3.10.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f89c151aab2e2e23cb3fe0acad1e8b82841fd265379c4cecd0f3fcb34c15e0f6", size = 9613678, upload-time = "2025-12-10T22:55:52.21Z" },
+    { url = "https://files.pythonhosted.org/packages/64/40/37612487cc8a437d4dd261b32ca21fe2d79510fe74af74e1f42becb1bdb8/matplotlib-3.10.8-cp313-cp313-win_amd64.whl", hash = "sha256:e8ea3e2d4066083e264e75c829078f9e149fa119d27e19acd503de65e0b13149", size = 8142686, upload-time = "2025-12-10T22:55:54.253Z" },
+    { url = "https://files.pythonhosted.org/packages/66/52/8d8a8730e968185514680c2a6625943f70269509c3dcfc0dcf7d75928cb8/matplotlib-3.10.8-cp313-cp313-win_arm64.whl", hash = "sha256:c108a1d6fa78a50646029cb6d49808ff0fc1330fda87fa6f6250c6b5369b6645", size = 8012917, upload-time = "2025-12-10T22:55:56.268Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/27/51fe26e1062f298af5ef66343d8ef460e090a27fea73036c76c35821df04/matplotlib-3.10.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ad3d9833a64cf48cc4300f2b406c3d0f4f4724a91c0bd5640678a6ba7c102077", size = 8305679, upload-time = "2025-12-10T22:55:57.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/4de865bc591ac8e3062e835f42dd7fe7a93168d519557837f0e37513f629/matplotlib-3.10.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:eb3823f11823deade26ce3b9f40dcb4a213da7a670013929f31d5f5ed1055b22", size = 8198336, upload-time = "2025-12-10T22:55:59.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cb/2f7b6e75fb4dce87ef91f60cac4f6e34f4c145ab036a22318ec837971300/matplotlib-3.10.8-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d9050fee89a89ed57b4fb2c1bfac9a3d0c57a0d55aed95949eedbc42070fea39", size = 8731653, upload-time = "2025-12-10T22:56:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b3/bd9c57d6ba670a37ab31fb87ec3e8691b947134b201f881665b28cc039ff/matplotlib-3.10.8-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b44d07310e404ba95f8c25aa5536f154c0a8ec473303535949e52eb71d0a1565", size = 9561356, upload-time = "2025-12-10T22:56:02.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3d/8b94a481456dfc9dfe6e39e93b5ab376e50998cddfd23f4ae3b431708f16/matplotlib-3.10.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0a33deb84c15ede243aead39f77e990469fff93ad1521163305095b77b72ce4a", size = 9614000, upload-time = "2025-12-10T22:56:05.411Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cd/bc06149fe5585ba800b189a6a654a75f1f127e8aab02fd2be10df7fa500c/matplotlib-3.10.8-cp313-cp313t-win_amd64.whl", hash = "sha256:3a48a78d2786784cc2413e57397981fb45c79e968d99656706018d6e62e57958", size = 8220043, upload-time = "2025-12-10T22:56:07.551Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/de/b22cf255abec916562cc04eef457c13e58a1990048de0c0c3604d082355e/matplotlib-3.10.8-cp313-cp313t-win_arm64.whl", hash = "sha256:15d30132718972c2c074cd14638c7f4592bd98719e2308bccea40e0538bc0cb5", size = 8062075, upload-time = "2025-12-10T22:56:09.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/43/31d59500bb950b0d188e149a2e552040528c13d6e3d6e84d0cccac593dcd/matplotlib-3.10.8-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f97aeb209c3d2511443f8797e3e5a569aebb040d4f8bc79aa3ee78a8fb9e3dd8", size = 8237252, upload-time = "2025-12-10T22:56:39.529Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2c/615c09984f3c5f907f51c886538ad785cf72e0e11a3225de2c0f9442aecc/matplotlib-3.10.8-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:fb061f596dad3a0f52b60dc6a5dec4a0c300dec41e058a7efe09256188d170b7", size = 8124693, upload-time = "2025-12-10T22:56:41.758Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e1/2757277a1c56041e1fc104b51a0f7b9a4afc8eb737865d63cababe30bc61/matplotlib-3.10.8-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12d90df9183093fcd479f4172ac26b322b1248b15729cb57f42f71f24c7e37a3", size = 8702205, upload-time = "2025-12-10T22:56:43.415Z" },
+    { url = "https://files.pythonhosted.org/packages/04/30/3afaa31c757f34b7725ab9d2ba8b48b5e89c2019c003e7d0ead143aabc5a/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6da7c2ce169267d0d066adcf63758f0604aa6c3eebf67458930f9d9b79ad1db1", size = 8249198, upload-time = "2025-12-10T22:56:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2f/6334aec331f57485a642a7c8be03cb286f29111ae71c46c38b363230063c/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9153c3292705be9f9c64498a8872118540c3f4123d1a1c840172edf262c8be4a", size = 8136817, upload-time = "2025-12-10T22:56:47.339Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e4/6d6f14b2a759c622f191b2d67e9075a3f56aaccb3be4bb9bb6890030d0a0/matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2", size = 8713867, upload-time = "2025-12-10T22:56:48.954Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mlx"
+version = "0.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/f9/f1663dafd45af02467f4f41777c13ec34b9104b2b0450d870c3f906285cd/mlx-0.31.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:bc46c911cc060d2eaf21b9e24a1712dc56763b660b53631b9057a32ab1c0271a", size = 574137, upload-time = "2026-03-12T02:15:54.996Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/26/1fd632f537a5160a21475a70aaef252090c62f9629f45ad20f5acfe810f3/mlx-0.31.1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:fa132def5b3d959362077521c80f1fc80f64c45060d2940dc1d66a1aa19ce5f6", size = 574140, upload-time = "2026-03-12T02:15:56.709Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/e790fa8ddc1b27fea7ba749699883f31c65e166b18e4598beab4574e4686/mlx-0.31.1-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:877ff2f98debd035b922825a0d7e7e1be0959fc5ca1d24cb5020a23e510ff16d", size = 574124, upload-time = "2026-03-12T02:15:58.323Z" },
+    { url = "https://files.pythonhosted.org/packages/75/32/25dc2eae1d6f867224ef2bca2c644e3e913fe8067991f8394c090b720e3e/mlx-0.31.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8863835fb36c7c4f65008b1426ddb9ff7931a13c975e0ef58a40002ae8048922", size = 574311, upload-time = "2026-03-12T02:16:02.651Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/bf/c5aa1d1154f5a216139c8162cd3e6568b7eb427390d655f7f5ae3a1a61e7/mlx-0.31.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:0de504c1f1fe73b32fc3cf457b8eac30d1f7ce22440ef075c1970f96712e6fff", size = 574312, upload-time = "2026-03-12T02:16:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/88/ef57747552c9e9da0c28465d9266c05a0009b698d90fb0bc63eb81840b8d/mlx-0.31.1-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:10715b895e1f3e984c2c54257b7db956ff8af1fa93255412794a3724fe2dd3b1", size = 574385, upload-time = "2026-03-12T02:16:05.528Z" },
+    { url = "https://files.pythonhosted.org/packages/38/29/71fe1f68756f515856e6930973c23245810d4aa3cd22fddd719d86a709dc/mlx-0.31.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8a63b31a398c9519f2bb0c81cf3865d9baca4ff573ffc31ead465d18286184e8", size = 574308, upload-time = "2026-03-12T02:16:10.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/be/70654a2cee0d71fd10bd237a50a79d06ae51679a194db6a3b16c0c84e6a5/mlx-0.31.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:a7a9347df4dcc41f0d16ff70b65650820af4879f686534b233b16826a22afa00", size = 574309, upload-time = "2026-03-12T02:16:11.577Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/69/c7bc7b04f76b0cbd678f328011d1634bd0bcfc2da45aba06e084cb031127/mlx-0.31.1-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:6cdb797ea31787d1ce9e5be77991c4bd5cbf129ab15f7253b78e09737f535fce", size = 574289, upload-time = "2026-03-12T02:16:13.146Z" },
+    { url = "https://files.pythonhosted.org/packages/44/45/04465da443634b23fb11670bbd2f7538b1ed43ffc5e0de44a95b3c29e9c1/mlx-0.31.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9a6d3410fc951bd28508fed9c1ab5d9903f6f6bb101c3a5d63d4191d49a384a1", size = 574268, upload-time = "2026-03-12T02:16:17.27Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7b/84956960356ff36e8c1bbed68fac96709e98e6a1adbc8e3d0ff71022d84e/mlx-0.31.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:20bd7ba19882603ac22711092d0e799f1ff7b5183c2c641d417dab4d2423d99e", size = 574265, upload-time = "2026-03-12T02:16:18.479Z" },
+    { url = "https://files.pythonhosted.org/packages/86/01/d6f0ef5b8c0b390af08246d1301e9717dfb076b3920012b53105a888ed8c/mlx-0.31.1-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4c4565d6f4f8ce295613ee342d313ee5ab0b0eab9a6272954450f8343f7876bc", size = 574172, upload-time = "2026-03-12T02:16:19.898Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.31.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/66/2313497fdbc7fbadf8e026c09366e3f049f9114e65ca4edc23cdb8699186/mlx_metal-0.31.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:70741174131dbf7fdd479cb730e06e08c358eac3bf7905d9e884e7960cfdd5b8", size = 38624074, upload-time = "2026-03-12T02:15:48.036Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/34/4c3c6890ce6095b2ab2ba2f5f15c9a7ba17208d47f8cacb572885a2dc0eb/mlx_metal-0.31.1-py3-none-macosx_15_0_arm64.whl", hash = "sha256:6c56bd8cd27743e635f5a90a22535af7c31bd22b4b126d46b6da2da52d72e413", size = 38618950, upload-time = "2026-03-12T02:15:51.908Z" },
+    { url = "https://files.pythonhosted.org/packages/51/bc/987cb99e3aafb296aa11ce5133838a10eae8447edd53168d0804d4fb3a14/mlx_metal-0.31.1-py3-none-macosx_26_0_arm64.whl", hash = "sha256:e7324b7c56b519ae67c025d3ced07e5d35bc3a9f19d4c45fe4927f385148c59e", size = 49256543, upload-time = "2026-03-12T02:15:54.851Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c6/4218570d8c8ecc9704b5157a3348e486e84ef4be0ed3e38218ab473c83d2/numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db", size = 16976799, upload-time = "2026-03-29T13:18:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/92/b4d922c4a5f5dab9ed44e6153908a5c665b71acf183a83b93b690996e39b/numpy-2.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72944b19f2324114e9dc86a159787333b77874143efcf89a5167ef83cfee8af0", size = 14971552, upload-time = "2026-03-29T13:18:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/dc/df98c095978fa6ee7b9a9387d1d58cbb3d232d0e69ad169a4ce784bde4fd/numpy-2.4.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:86b6f55f5a352b48d7fbfd2dbc3d5b780b2d79f4d3c121f33eb6efb22e9a2015", size = 5476566, upload-time = "2026-03-29T13:18:21.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/34/b3fdcec6e725409223dd27356bdf5a3c2cc2282e428218ecc9cb7acc9763/numpy-2.4.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:ba1f4fc670ed79f876f70082eff4f9583c15fb9a4b89d6188412de4d18ae2f40", size = 6806482, upload-time = "2026-03-29T13:18:23.634Z" },
+    { url = "https://files.pythonhosted.org/packages/68/62/63417c13aa35d57bee1337c67446761dc25ea6543130cf868eace6e8157b/numpy-2.4.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a87ec22c87be071b6bdbd27920b129b94f2fc964358ce38f3822635a3e2e03d", size = 15973376, upload-time = "2026-03-29T13:18:26.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c5/9fcb7e0e69cef59cf10c746b84f7d58b08bc66a6b7d459783c5a4f6101a6/numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df3775294accfdd75f32c74ae39fcba920c9a378a2fc18a12b6820aa8c1fb502", size = 16925137, upload-time = "2026-03-29T13:18:30.14Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/43/80020edacb3f84b9efdd1591120a4296462c23fd8db0dde1666f6ef66f13/numpy-2.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d4e437e295f18ec29bc79daf55e8a47a9113df44d66f702f02a293d93a2d6dd", size = 17329414, upload-time = "2026-03-29T13:18:33.733Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/06/af0658593b18a5f73532d377188b964f239eb0894e664a6c12f484472f97/numpy-2.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa3236c78803afbcb255045fbef97a9e25a1f6c9888357d205ddc42f4d6eba5", size = 18658397, upload-time = "2026-03-29T13:18:37.511Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ce/13a09ed65f5d0ce5c7dd0669250374c6e379910f97af2c08c57b0608eee4/numpy-2.4.4-cp311-cp311-win32.whl", hash = "sha256:30caa73029a225b2d40d9fae193e008e24b2026b7ee1a867b7ee8d96ca1a448e", size = 6239499, upload-time = "2026-03-29T13:18:40.372Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/63/05d193dbb4b5eec1eca73822d80da98b511f8328ad4ae3ca4caf0f4db91d/numpy-2.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:6bbe4eb67390b0a0265a2c25458f6b90a409d5d069f1041e6aff1e27e3d9a79e", size = 12614257, upload-time = "2026-03-29T13:18:42.95Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c5/8168052f080c26fa984c413305012be54741c9d0d74abd7fbeeccae3889f/numpy-2.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:fcfe2045fd2e8f3cb0ce9d4ba6dba6333b8fa05bb8a4939c908cd43322d14c7e", size = 10486775, upload-time = "2026-03-29T13:18:45.835Z" },
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/33/8fae8f964a4f63ed528264ddf25d2b683d0b663e3cba26961eb838a7c1bd/numpy-2.4.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:58c8b5929fcb8287cbd6f0a3fae19c6e03a5c48402ae792962ac465224a629a4", size = 16854491, upload-time = "2026-03-29T13:21:38.03Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d0/1aabee441380b981cf8cdda3ae7a46aa827d1b5a8cce84d14598bc94d6d9/numpy-2.4.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eea7ac5d2dce4189771cedb559c738a71512768210dc4e4753b107a2048b3d0e", size = 14895830, upload-time = "2026-03-29T13:21:41.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b8/aafb0d1065416894fccf4df6b49ef22b8db045187949545bced89c034b8e/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:51fc224f7ca4d92656d5a5eb315f12eb5fe2c97a66249aa7b5f562528a3be38c", size = 5400927, upload-time = "2026-03-29T13:21:44.747Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/77/063baa20b08b431038c7f9ff5435540c7b7265c78cf56012a483019ca72d/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:28a650663f7314afc3e6ec620f44f333c386aad9f6fc472030865dc0ebb26ee3", size = 6715557, upload-time = "2026-03-29T13:21:47.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.11' or sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11' or sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.11' or sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse-cu12", marker = "python_full_version < '3.11' or sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11' or sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11' or sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-ml-py"
+version = "13.595.45"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/49/c29f6e30d8662d2e94fef17739ea7309cc76aba269922ae999e4cc07f268/nvidia_ml_py-13.595.45.tar.gz", hash = "sha256:c9f34897fe0441ff35bc8f35baf80f830a20b0f4e6ce71e0a325bc0e66acf079", size = 50780, upload-time = "2026-03-19T16:59:44.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/24/fc256107d23597fa33d319505ce77160fa1a2349c096d01901ffc7cb7fc4/nvidia_ml_py-13.595.45-py3-none-any.whl", hash = "sha256:b65a7977f503d56154b14d683710125ef93594adb63fbf7e559336e3318f1376", size = 51776, upload-time = "2026-03-19T16:59:43.603Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.3.20"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "omegaconf"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
+    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
+]
+
+[[package]]
+name = "openexr"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c7/d6bb16bd2cd2d9c1e7a76790801f3794648a31163f275cebd7b2022dc896/openexr-3.4.9.tar.gz", hash = "sha256:9262e186472f16b489c05467d075baf47de3ff408cce0227fc02f410da704e5c", size = 25582278, upload-time = "2026-04-03T22:41:05.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/7e/4ae2315a4b997bbc10c87147011fd6c6b6b6cd3ead7738ab85f3455f56a8/openexr-3.4.9-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:41eea246d607509809055ceaa8d43e260161f8a7c8b022bc1774025e64bdee82", size = 2145465, upload-time = "2026-04-03T22:39:42.754Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/bb/efddad81e728e88550340976975932ed04b24202dc463eb73d0457295b78/openexr-3.4.9-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:1589d4cef0efa7ea10662b8e85e3cde9b245f8cdd12a0acca3fcabffeae1e4d3", size = 1138519, upload-time = "2026-04-03T22:39:44.693Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b9/785217a6da61ebd4216fc025122e3c54147aee81117bab2c64add1cd1849/openexr-3.4.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:56d765598f9350c2b25a1726dd790528429f31b968d11e530bf6b27498c21683", size = 1010774, upload-time = "2026-04-03T22:39:46.185Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e3/2e087f01faba46b9fc0a8a7f4dc40973dd6b82cada614bc8336ef122817a/openexr-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f8107f4cdcb400305547c8e057a3b419f11752a16936d9a99e7d4c0cf125593", size = 1161618, upload-time = "2026-04-03T22:39:47.984Z" },
+    { url = "https://files.pythonhosted.org/packages/72/42/a5b87ff7a1e5ba3c1bda4c8eb8c8b199e7e7f9cafbeb478d0928571b2873/openexr-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b5a27e0acdb5e9ade0f161435d1362732f9fd4acf066622a993d11491359761", size = 1291867, upload-time = "2026-04-03T22:39:49.593Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a6/4ed19c2305f959e7dc5d46a024bf3db44d316e63c27e166387a3fa1afc09/openexr-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:032fdb8f78874b4fec21078a741acc8f414995c96296cd19a191ee6c4a05a857", size = 2149596, upload-time = "2026-04-03T22:39:51.275Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fb/c65602dc78c8f57bb0558af40546a4f905862e32a1735011b38126dd859f/openexr-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b54936434965a3ad6ed33d833644f42ef63d4f59fd117e217b8db8869f80560c", size = 2329797, upload-time = "2026-04-03T22:39:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/02/c4eea1963964a557693c27fd3e51eab369ca80f0783619b238b95c5756ee/openexr-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:bc9a960f37660324246da8a4137a67d457cbc068a16460e707a48a772539469b", size = 732875, upload-time = "2026-04-03T22:39:54.784Z" },
+    { url = "https://files.pythonhosted.org/packages/34/38/df33dc3ec7a22fe94bd927137cbedd2800ecb5c829f003258a78c8a81ea9/openexr-3.4.9-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:0ee041a1b70ade86d54c83d168e51e72353d5e857b90e117deab8080f055d196", size = 2148493, upload-time = "2026-04-03T22:39:56.284Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f2/3ed6b9c3e742c6200d8d5ee83ad9eea8035fe653794b0d0494ca50b73c70/openexr-3.4.9-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:a195d198f0c80bd5234f37315d86df5ee51753b3ea17ff43e9723640232a5445", size = 1139970, upload-time = "2026-04-03T22:39:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a9/84e764804f84450ed313305c6c1137f4046a25d6759f20da050ebf523f56/openexr-3.4.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:426398d8772e3a49c7d932bdf4aef5894d31b391bac3f015bd19345ef0a5f660", size = 1011970, upload-time = "2026-04-03T22:39:59.725Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/07/683568856389acca16972ab8190dcc46e736b9ffec035b069c6174494ee0/openexr-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fac9fd4e165461ac0138de48cf682f3730f3e35c76747d21aa85b3ebfda802bd", size = 1162879, upload-time = "2026-04-03T22:40:01.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/5a/d84c31ecf12e5f37917ac43bbe0ac982cb8593c573bc0548a35b13f96bba/openexr-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:865df41542a1cad1389849c1640ac592571764359f1d089bfe57dfc3709430fb", size = 1292944, upload-time = "2026-04-03T22:40:02.743Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/1b4d9f8949dd188980ea9af12f857496775260e00cab1965f5ca0ef186e4/openexr-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:345b346d4115590160998bbb6399b89906d3753a4cdaf52c16b381bda3f276d0", size = 2150454, upload-time = "2026-04-03T22:40:04.191Z" },
+    { url = "https://files.pythonhosted.org/packages/31/de/6a1e616e351d424831f7d1804e1f79595a70f8795ff63487dc81978b8316/openexr-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d7f5a44585daccae4e2787b2f7af59ac00838764f09a0a1ad5cd3451b520f76d", size = 2330749, upload-time = "2026-04-03T22:40:06.174Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/95/840b48252cf28b3430187581facc399154ace45b4a13ca4372ed0ee91347/openexr-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:f7fae5fe9164f6153c3ca3235440bba38b0c1f01a9fc5e86c63b2c76647f0678", size = 733537, upload-time = "2026-04-03T22:40:08.102Z" },
+    { url = "https://files.pythonhosted.org/packages/99/f5/724ffb39cc4bec7f8c205b041c0eab4fce219e4ca14c641324f2d32b35ed/openexr-3.4.9-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:3a590eec7d0088e7d15cb307f0b4cb04cdb11e3a6a455818cd2f00fe63a38286", size = 2152583, upload-time = "2026-04-03T22:40:09.601Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d2/e04d82d4e816e285de7f29e9e2496946d671aa8f8c640fd3cf681c799af0/openexr-3.4.9-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:fcbb5074a4f239f6d5c147671c09840cd06762aa1253c6a55ea5be2b1de13956", size = 1143106, upload-time = "2026-04-03T22:40:11.215Z" },
+    { url = "https://files.pythonhosted.org/packages/46/be/e86167c1588f3738b58728e1d4d33140f5dc168bf4ad5dd61bec457c54c3/openexr-3.4.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b0eb5bfdb076805f09d93cc1264aff62345b0174c8ca0be6be2e90b6788049d", size = 1017974, upload-time = "2026-04-03T22:40:13.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a6/1247078abf55c86056b3be1dee59c05b2b1c5abcedc2b353343fa8a99098/openexr-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9e7144b64e663abd441f96e2b3f1bcd5774d982d3eaab705f6dc6180361e3e01", size = 1162574, upload-time = "2026-04-03T22:40:14.52Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b6/d00a899567c779413d00e7fa60dc252075c8f645342802ffec3888d571c9/openexr-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ee08fb7e386e4f41f15b628479d20eeaf9b7145af6c57cfd1d20149c1cd93aef", size = 1292780, upload-time = "2026-04-03T22:40:16.481Z" },
+    { url = "https://files.pythonhosted.org/packages/87/52/4911f0e6f9b1e5a964ca8e82f3b108bd1b8c004fbb9a26e06db18a7a45c8/openexr-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f1e7f1e66d727278670903d83e9b432b593412969e741ecd6ba29895b4289944", size = 2151835, upload-time = "2026-04-03T22:40:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/6cc3cf1aae0361ffe394b683852b7029a794854183a5176dec2468f34729/openexr-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:93c52c495b39fec399a820d717073bde0a8e589b05eb68456993ad9199f418b1", size = 2333724, upload-time = "2026-04-03T22:40:20.422Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7e/4a86426c7036b5309b6262c7193f48261bc8d6aeac1bd7274b9e143dda16/openexr-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:392d90282cfd3185302455562434b5e627a0cf01f645892691712c6f576b8beb", size = 735151, upload-time = "2026-04-03T22:40:22.303Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f7/5d4403fd5562f91c02f76f852a707852a256436f2cf9c36246ca3c6edf51/openexr-3.4.9-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:639f612f6a7007dda6b87ad161223531f0006b231a2d07ef6d0c18ef8d877eef", size = 2152506, upload-time = "2026-04-03T22:40:24.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f9/a46113ce35579f1cbe910b43be9f53dea658369edf8d5cbb2bf30e95db2b/openexr-3.4.9-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:495f0b0cef6850d3810bb615f2363ee483809fc068f39d77d15106f76f9f24cb", size = 1142985, upload-time = "2026-04-03T22:40:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/33/95/be6cc1f595ff48b5750d3d387f58a13e0cfa8d6ba198b1a2188c71a96b9b/openexr-3.4.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7b59d5b29101a8ee59a183d2751dd99b8a6278c3dba2be3fef530ec2ddad02fd", size = 1017957, upload-time = "2026-04-03T22:40:27.464Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/96/f3abc015cced773df5ca003493591cb7330b6ad53207ab96126105d73c9d/openexr-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6f73e3d7ac89713008bf02356c9138e43b90a94b94c15d966a843285177b45bc", size = 1162861, upload-time = "2026-04-03T22:40:29.317Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/be/03728ca8e1a8eaa8bed27c72aab93de7d85eadf8b29e60b9eeb1482c854d/openexr-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5150ac0ddb328b49cfdbabc66cb2a2bd136bf45022f2de959461e4699dfb8a87", size = 1292825, upload-time = "2026-04-03T22:40:30.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/49/1eee081a599434b40803f794301fdebe4ff8554a7e52c3d15ae9d179f28c/openexr-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d8c1025479b71b4641ef872b2e0086c53a882bbb5bf58a0890760318d67a0802", size = 2151693, upload-time = "2026-04-03T22:40:32.609Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/91/4b85a65d4a1bd45023a1125a4b20d48171b14290a13da40e1d5f6d08d6d4/openexr-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:483d2ae18c6b7a4a7e148cc627a066dfdebc03bd80e115d75f403cffcafab3fe", size = 2333559, upload-time = "2026-04-03T22:40:34.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f9/04dfadf8eec3a1acb3aa4523c31273eec8cde74a7947929ff591f09e7e20/openexr-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:70f652c517fe38bcccd5a1146266e33e613c735e8cf6013659c0494bbe1485e2", size = 735105, upload-time = "2026-04-03T22:40:35.964Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "peft"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/48/147b3ea999560b40a34fd78724c7777aa9d18409c2250bdcaf9c4f2db7fc/peft-0.18.1.tar.gz", hash = "sha256:2dd0d6bfce936d1850e48aaddbd250941c5c02fc8ef3237cd8fd5aac35e0bae2", size = 635030, upload-time = "2026-01-09T13:08:01.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/14/b4e3f574acf349ae6f61f9c000a77f97a3b315b4bb6ad03791e79ae4a568/peft-0.18.1-py3-none-any.whl", hash = "sha256:0bf06847a3551e3019fc58c440cffc9a6b73e6e2962c95b52e224f77bbdb50f1", size = 556960, upload-time = "2026-01-09T13:07:55.865Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168, upload-time = "2026-04-01T14:42:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401, upload-time = "2026-04-01T14:42:54.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105, upload-time = "2026-04-01T14:42:59.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149, upload-time = "2026-04-01T14:43:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626, upload-time = "2026-04-01T14:43:08.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531, upload-time = "2026-04-01T14:43:10.743Z" },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479, upload-time = "2026-04-01T14:46:01.141Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "pims"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "slicerator" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "tifffile", version = "2026.4.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/02/5bf3639f5b77e9b183011c08541c5039ba3d04f5316c70312b48a8e003a9/pims-0.7.tar.gz", hash = "sha256:55907a4c301256086d2aa4e34a5361b9109f24e375c2071e1117b9491e82946b", size = 87779, upload-time = "2024-06-10T19:20:42.842Z" }
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyside6"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/95/f3f5a2799163b6658126d78a85bc1dec9eda88c75c26780556b26071a1d8/pyside6-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1f2735dc4f2bd4ec452ae50502c8a22128bba0aced35358a2bbc58384b820c6f", size = 571544, upload-time = "2026-03-23T12:47:20.263Z" },
+    { url = "https://files.pythonhosted.org/packages/da/89/9a1f521051714e6694ebbe2b979ded279845ec8e25cb309ca3960158d74f/pyside6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c642e2d25704ca746fd37f56feacf25c5aecc4cd40bef23d18eec81f87d9dc00", size = 571725, upload-time = "2026-03-23T12:47:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/f779d8bba00fcde31a7d7fb6b59347a70773c9cc8135592dea9972579877/pyside6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:267b344c73580ac938ca63c611881fb42a3922ebfe043e271005f4f06c372c4e", size = 571722, upload-time = "2026-03-23T12:47:22.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/150e01a026df3e9697310236821fa825319bb4b9d6137539cb25a3032968/pyside6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:9092cb002ca43c64006afb2e0d0f6f51aef17aa737c33a45e502326a081ddcbc", size = 577988, upload-time = "2026-03-23T12:47:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e7/55960f7c6b41d058e95cb4af02652c46c48702c506c8bbf12e99550e1fb3/pyside6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:b15f39acc2b8f46251a630acad0d97f9a0a0461f2baffcd66d7adfada8eb641e", size = 561372, upload-time = "2026-03-23T12:47:25.073Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/df/241f311c61a46b7b1195927da77b2537692ee3442aa9ccd87981164ff78d/pyside6_addons-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:d5eaa4643302e3a0fa94c5766234bee4073d7d5ab9c2b7fd222692a176faf182", size = 331554157, upload-time = "2026-03-23T12:40:40.497Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b9/e81172835ccc9d8b9792cc6bf7524a252a0db9a76ddd693de230402697f9/pyside6_addons-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ac6fe3d4ef4497dde3efc5e896b0acd53ff6c93be4bf485f045690f919419f35", size = 174948482, upload-time = "2026-03-23T12:41:05.379Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/426d9333782bf65ab2a20257d6b4b3af9b8d5d7a710da719865fab49d492/pyside6_addons-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:8ffb40222456078930816ebcac2f2511716d2acbc11716dd5acc5c365179a753", size = 170430798, upload-time = "2026-03-23T12:41:38.134Z" },
+    { url = "https://files.pythonhosted.org/packages/35/9a/46d271fedfabad8c6dce2ebb69bb593745487ed33753a56a47c3ba4fdb1c/pyside6_addons-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:413e6121c24f5ffdce376298059eddecff74aa6d638e94e0f6015b33d29b889e", size = 168723088, upload-time = "2026-03-23T12:42:00.668Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cd/1b28264f7dc9a642da2e4e7c02f67418d0949eb7ce329ae20869703c2630/pyside6_addons-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:aaaee83385977a0fe134b2f4fbfb92b45a880d5b656e4d90a708eef10b1b6de8", size = 35698324, upload-time = "2026-03-23T12:42:13.748Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/00/8a8583d3429c737cc20e61a43eba8ab1ec13ddb101e99802c2ffeedf3b41/pyside6_essentials-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:85d6ca87ef35fa6565d385ede72ae48420dd3f63113929d10fc800f6b0360e01", size = 108085251, upload-time = "2026-03-23T12:42:52.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a9/07c9e5c014b871c1b19caf8f994bcd50b345559b81f81671217b49559b67/pyside6_essentials-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:dc20e7afd5fc6fe51297db91cef997ce60844be578f7a49fc61b7ab9657a8849", size = 78316055, upload-time = "2026-03-23T12:43:04.19Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/35/f06b1b641d7600ec46374c16cd37c66fa4a22870326b4eb073a95471035f/pyside6_essentials-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:4854cb0a1b061e7a576d8fb7bb7cf9f49540d558b1acb7df0742a7afefe61e4e", size = 77380821, upload-time = "2026-03-23T12:43:24.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/ba95c6262836d2b286b4e05a9d16a5e870995d5d2503ac6adc6312208049/pyside6_essentials-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:3b3362882ad9389357a80504e600180006a957731fec05786fced7b038461fdf", size = 75793322, upload-time = "2026-03-23T12:43:35.575Z" },
+    { url = "https://files.pythonhosted.org/packages/53/27/d17f25e45820e633a70e6109b35991eda09a5e8000c2a306f0ab7538d48c/pyside6_essentials-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:81ca603dbf21bc39f89bb42db215c25ebe0c879a1a4c387625c321d2730ec187", size = 56337457, upload-time = "2026-03-23T12:43:43.573Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytorch-msssim"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/43/fd181aef46e96ed025f5056efa1c45e63c93d377fbe7ea784a21ce058d03/pytorch_msssim-1.0.0.tar.gz", hash = "sha256:53273f03ce5c435f706f49feb5110a8afe90b2519484b0fe0df9639670106d0b", size = 10113, upload-time = "2023-05-25T17:15:57.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/8c/856047f955acc30179e9255fdc488059ca22f0938519523d53494f7cfee8/pytorch_msssim-1.0.0-py3-none-any.whl", hash = "sha256:0b4b7bbf7035fe9dc8084244237aac13b1f104852c45b63a7e9fab4363bede54", size = 7744, upload-time = "2023-05-25T17:15:55.809Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/59/fd98f8fd54b3feaa76a855324c676c17668c5a1121ec91b7ec96b01bf865/regex-2026.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:74fa82dcc8143386c7c0392e18032009d1db715c25f4ba22d23dc2e04d02a20f", size = 489403, upload-time = "2026-04-03T20:52:39.742Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/64/d0f222f68e3579d50babf0e4fcc9c9639ef0587fecc00b15e1e46bfc32fa/regex-2026.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a85b620a388d6c9caa12189233109e236b3da3deffe4ff11b84ae84e218a274f", size = 291208, upload-time = "2026-04-03T20:52:42.943Z" },
+    { url = "https://files.pythonhosted.org/packages/16/7f/3fab9709b0b0060ba81a04b8a107b34147cd14b9c5551b772154d6505504/regex-2026.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2895506ebe32cc63eeed8f80e6eae453171cfccccab35b70dc3129abec35a5b8", size = 289214, upload-time = "2026-04-03T20:52:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bc/f5dcf04fd462139dcd75495c02eee22032ef741cfa151386a39c3f5fc9b5/regex-2026.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6780f008ee81381c737634e75c24e5a6569cc883c4f8e37a37917ee79efcafd9", size = 785505, upload-time = "2026-04-03T20:52:46.35Z" },
+    { url = "https://files.pythonhosted.org/packages/37/36/8a906e216d5b4de7ec3788c1d589b45db40c1c9580cd7b326835cfc976d4/regex-2026.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:88e9b048345c613f253bea4645b2fe7e579782b82cac99b1daad81e29cc2ed8e", size = 852129, upload-time = "2026-04-03T20:52:48.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/bb/bad2d79be0917a6ef31f5e0f161d9265cb56fd90a3ae1d2e8d991882a48b/regex-2026.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:be061028481186ba62a0f4c5f1cc1e3d5ab8bce70c89236ebe01023883bc903b", size = 899578, upload-time = "2026-04-03T20:52:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b9/7cd0ceb58cd99c70806241636640ae15b4a3fe62e22e9b99afa67a0d7965/regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2228c02b368d69b724c36e96d3d1da721561fb9cc7faa373d7bf65e07d75cb5", size = 793634, upload-time = "2026-04-03T20:52:53Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fb/c58e3ea40ed183806ccbac05c29a3e8c2f88c1d3a66ed27860d5cad7c62d/regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0540e5b733618a2f84e9cb3e812c8afa82e151ca8e19cf6c4e95c5a65198236f", size = 786210, upload-time = "2026-04-03T20:52:54.713Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a9/53790fc7a6c948a7be2bc7214fd9cabdd0d1ba561b0f401c91f4ff0357f0/regex-2026.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cf9b1b2e692d4877880388934ac746c99552ce6bf40792a767fd42c8c99f136d", size = 769930, upload-time = "2026-04-03T20:52:56.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/3c/29ca44729191c79f5476538cd0fa04fa2553b3c45508519ecea4c7afa8f6/regex-2026.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:011bb48bffc1b46553ac704c975b3348717f4e4aa7a67522b51906f99da1820c", size = 774892, upload-time = "2026-04-03T20:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/6ae74ef8a4cfead341c367e4eed45f71fb1aaba35827a775eed4f1ba4f74/regex-2026.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8512fcdb43f1bf18582698a478b5ab73f9c1667a5b7548761329ef410cd0a760", size = 848816, upload-time = "2026-04-03T20:53:00.684Z" },
+    { url = "https://files.pythonhosted.org/packages/53/9a/f7f2c1c6b610d7c6de1c3dc5951effd92c324b1fde761af2044b4721020f/regex-2026.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:867bddc63109a0276f5a31999e4c8e0eb7bbbad7d6166e28d969a2c1afeb97f9", size = 758363, upload-time = "2026-04-03T20:53:02.155Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/55/e5386d393bbf8b43c8b084703a46d635e7b2bdc6e0f5909a2619ea1125f1/regex-2026.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:1b9a00b83f3a40e09859c78920571dcb83293c8004079653dd22ec14bbfa98c7", size = 837122, upload-time = "2026-04-03T20:53:03.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/da/cc78710ea2e60b10bacfcc9beb18c67514200ab03597b3b2b319995785c2/regex-2026.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e355be718caf838aa089870259cf1776dc2a4aa980514af9d02c59544d9a8b22", size = 782140, upload-time = "2026-04-03T20:53:05.608Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/5f/c7bcba41529105d6c2ca7080ecab7184cd00bee2e1ad1fdea80e618704ea/regex-2026.4.4-cp310-cp310-win32.whl", hash = "sha256:33bfda9684646d323414df7abe5692c61d297dbb0530b28ec66442e768813c59", size = 266225, upload-time = "2026-04-03T20:53:07.342Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/26/a745729c2c49354ec4f4bce168f29da932ca01b4758227686cc16c7dde1b/regex-2026.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:0709f22a56798457ae317bcce42aacee33c680068a8f14097430d9f9ba364bee", size = 278393, upload-time = "2026-04-03T20:53:08.65Z" },
+    { url = "https://files.pythonhosted.org/packages/87/8b/4327eeb9dbb4b098ebecaf02e9f82b79b6077beeb54c43d9a0660cf7c44c/regex-2026.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:ee9627de8587c1a22201cb16d0296ab92b4df5cdcb5349f4e9744d61db7c7c98", size = 270470, upload-time = "2026-04-03T20:53:10.018Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7a/617356cbecdb452812a5d42f720d6d5096b360d4a4c1073af700ea140ad2/regex-2026.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4c36a85b00fadb85db9d9e90144af0a980e1a3d2ef9cd0f8a5bef88054657c6", size = 489415, upload-time = "2026-04-03T20:53:11.645Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e6/bf057227144d02e3ba758b66649e87531d744dda5f3254f48660f18ae9d8/regex-2026.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dcb5453ecf9cd58b562967badd1edbf092b0588a3af9e32ee3d05c985077ce87", size = 291205, upload-time = "2026-04-03T20:53:13.289Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3b/637181b787dd1a820ba1c712cee2b4144cd84a32dc776ca067b12b2d70c8/regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8", size = 289225, upload-time = "2026-04-03T20:53:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/05/21/bac05d806ed02cd4b39d9c8e5b5f9a2998c94c3a351b7792e80671fa5315/regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada", size = 792434, upload-time = "2026-04-03T20:53:17.414Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/17/c65d1d8ae90b772d5758eb4014e1e011bb2db353fc4455432e6cc9100df7/regex-2026.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d346fccdde28abba117cc9edc696b9518c3307fbfcb689e549d9b5979018c6d", size = 861730, upload-time = "2026-04-03T20:53:18.903Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/64/933321aa082a2c6ee2785f22776143ba89840189c20d3b6b1d12b6aae16b/regex-2026.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:415a994b536440f5011aa77e50a4274d15da3245e876e5c7f19da349caaedd87", size = 906495, upload-time = "2026-04-03T20:53:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4", size = 799810, upload-time = "2026-04-03T20:53:22.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ce/7605048f00e1379eba89d610c7d644d8f695dc9b26d3b6ecfa3132b872ff/regex-2026.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:312ec9dd1ae7d96abd8c5a36a552b2139931914407d26fba723f9e53c8186f86", size = 774242, upload-time = "2026-04-03T20:53:25.015Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/77/283e0d5023fde22cd9e86190d6d9beb21590a452b195ffe00274de470691/regex-2026.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a0d2b28aa1354c7cd7f71b7658c4326f7facac106edd7f40eda984424229fd59", size = 781257, upload-time = "2026-04-03T20:53:26.918Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fb/7f3b772be101373c8626ed34c5d727dcbb8abd42a7b1219bc25fd9a3cc04/regex-2026.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:349d7310eddff40429a099c08d995c6d4a4bfaf3ff40bd3b5e5cb5a5a3c7d453", size = 854490, upload-time = "2026-04-03T20:53:29.065Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/56547b80f34f4dd2986e1cdd63b1712932f63b6c4ce2f79c50a6cd79d1c2/regex-2026.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e7ab63e9fe45a9ec3417509e18116b367e89c9ceb6219222a3396fa30b147f80", size = 763544, upload-time = "2026-04-03T20:53:30.917Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/2f/ce060fdfea8eff34a8997603532e44cdb7d1f35e3bc253612a8707a90538/regex-2026.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fe896e07a5a2462308297e515c0054e9ec2dd18dfdc9427b19900b37dfe6f40b", size = 844442, upload-time = "2026-04-03T20:53:32.463Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/44/810cb113096a1dacbe82789fbfab2823f79d19b7f1271acecb7009ba9b88/regex-2026.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eb59c65069498dbae3c0ef07bbe224e1eaa079825a437fb47a479f0af11f774f", size = 789162, upload-time = "2026-04-03T20:53:34.039Z" },
+    { url = "https://files.pythonhosted.org/packages/20/96/9647dd7f2ecf6d9ce1fb04dfdb66910d094e10d8fe53e9c15096d8aa0bd2/regex-2026.4.4-cp311-cp311-win32.whl", hash = "sha256:2a5d273181b560ef8397c8825f2b9d57013de744da9e8257b8467e5da8599351", size = 266227, upload-time = "2026-04-03T20:53:35.601Z" },
+    { url = "https://files.pythonhosted.org/packages/33/80/74e13262460530c3097ff343a17de9a34d040a5dc4de9cf3a8241faab51c/regex-2026.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735", size = 278399, upload-time = "2026-04-03T20:53:37.021Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/39f19f47f19dcefa3403f09d13562ca1c0fd07ab54db2bc03148f3f6b46a/regex-2026.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:b5f9fb784824a042be3455b53d0b112655686fdb7a91f88f095f3fee1e2a2a54", size = 270473, upload-time = "2026-04-03T20:53:38.633Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52", size = 490434, upload-time = "2026-04-03T20:53:40.219Z" },
+    { url = "https://files.pythonhosted.org/packages/84/20/30041446cf6dc3e0eab344fc62770e84c23b6b68a3b657821f9f80cb69b4/regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb", size = 292061, upload-time = "2026-04-03T20:53:41.862Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76", size = 289628, upload-time = "2026-04-03T20:53:43.701Z" },
+    { url = "https://files.pythonhosted.org/packages/31/87/3accf55634caad8c0acab23f5135ef7d4a21c39f28c55c816ae012931408/regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be", size = 796651, upload-time = "2026-04-03T20:53:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0c/aaa2c83f34efedbf06f61cb1942c25f6cf1ee3b200f832c4d05f28306c2e/regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1", size = 865916, upload-time = "2026-04-03T20:53:47.064Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/f6/8c6924c865124643e8f37823eca845dc27ac509b2ee58123685e71cd0279/regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13", size = 912287, upload-time = "2026-04-03T20:53:49.422Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0e/a9f6f81013e0deaf559b25711623864970fe6a098314e374ccb1540a4152/regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9", size = 801126, upload-time = "2026-04-03T20:53:51.096Z" },
+    { url = "https://files.pythonhosted.org/packages/71/61/3a0cc8af2dc0c8deb48e644dd2521f173f7e6513c6e195aad9aa8dd77ac5/regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d", size = 776788, upload-time = "2026-04-03T20:53:52.889Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/8bb9cbf21ef7dee58e49b0fdb066a7aded146c823202e16494a36777594f/regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3", size = 785184, upload-time = "2026-04-03T20:53:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c2/d3e80e8137b25ee06c92627de4e4d98b94830e02b3e6f81f3d2e3f504cf5/regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0", size = 859913, upload-time = "2026-04-03T20:53:57.249Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/9d5d876157d969c804622456ef250017ac7a8f83e0e14f903b9e6df5ce95/regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043", size = 765732, upload-time = "2026-04-03T20:53:59.428Z" },
+    { url = "https://files.pythonhosted.org/packages/82/80/b568935b4421388561c8ed42aff77247285d3ae3bb2a6ca22af63bae805e/regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244", size = 852152, upload-time = "2026-04-03T20:54:01.505Z" },
+    { url = "https://files.pythonhosted.org/packages/39/29/f0f81217e21cd998245da047405366385d5c6072048038a3d33b37a79dc0/regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73", size = 789076, upload-time = "2026-04-03T20:54:03.323Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1d/1d957a61976ab9d4e767dd4f9d04b66cc0c41c5e36cf40e2d43688b5ae6f/regex-2026.4.4-cp312-cp312-win32.whl", hash = "sha256:04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f", size = 266700, upload-time = "2026-04-03T20:54:05.639Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/bf575d396aeb58ea13b06ef2adf624f65b70fafef6950a80fc3da9cae3bc/regex-2026.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b", size = 277768, upload-time = "2026-04-03T20:54:07.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/27/049df16ec6a6828ccd72add3c7f54b4df029669bea8e9817df6fff58be90/regex-2026.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983", size = 270568, upload-time = "2026-04-03T20:54:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943", size = 490273, upload-time = "2026-04-03T20:54:11.202Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f8/fe62afbcc3cf4ad4ac9adeaafd98aa747869ae12d3e8e2ac293d0593c435/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031", size = 291954, upload-time = "2026-04-03T20:54:13.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7", size = 289487, upload-time = "2026-04-03T20:54:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/f83b93f85e01168f1070f045a42d4c937b69fdb8dd7ae82d307253f7e36e/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17", size = 796646, upload-time = "2026-04-03T20:54:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/df/55/61a2e17bf0c4dc57e11caf8dd11771280d8aaa361785f9e3bc40d653f4a7/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17", size = 865904, upload-time = "2026-04-03T20:54:20.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/32/1ac8ed1b5a346b5993a3d256abe0a0f03b0b73c8cc88d928537368ac65b6/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae", size = 912304, upload-time = "2026-04-03T20:54:22.403Z" },
+    { url = "https://files.pythonhosted.org/packages/26/47/2ee5c613ab546f0eddebf9905d23e07beb933416b1246c2d8791d01979b4/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e", size = 801126, upload-time = "2026-04-03T20:54:24.308Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cd/41dacd129ca9fd20bd7d02f83e0fad83e034ac8a084ec369c90f55ef37e2/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d", size = 776772, upload-time = "2026-04-03T20:54:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5af0b588174cb5f46041fa7dd64d3fd5cd2fe51f18766703d1edc387f324/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27", size = 785228, upload-time = "2026-04-03T20:54:28.387Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3b/f5a72b7045bd59575fc33bf1345f156fcfd5a8484aea6ad84b12c5a82114/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf", size = 860032, upload-time = "2026-04-03T20:54:30.641Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a4/72a317003d6fcd7a573584a85f59f525dfe8f67e355ca74eb6b53d66a5e2/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0", size = 765714, upload-time = "2026-04-03T20:54:32.789Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1e/5672e16f34dbbcb2560cc7e6a2fbb26dfa8b270711e730101da4423d3973/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa", size = 852078, upload-time = "2026-04-03T20:54:34.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/c813f0af7c6cc7ed7b9558bac2e5120b60ad0fa48f813e4d4bd55446f214/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b", size = 789181, upload-time = "2026-04-03T20:54:36.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62", size = 266690, upload-time = "2026-04-03T20:54:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81", size = 277733, upload-time = "2026-04-03T20:54:40.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427", size = 270565, upload-time = "2026-04-03T20:54:41.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c", size = 494126, upload-time = "2026-04-03T20:54:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/4b/c132a4f4fe18ad3340d89fcb56235132b69559136036b845be3c073142ed/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141", size = 293882, upload-time = "2026-04-03T20:54:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717", size = 292334, upload-time = "2026-04-03T20:54:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f6/dd38146af1392dac33db7074ab331cec23cced3759167735c42c5460a243/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07", size = 811691, upload-time = "2026-04-03T20:54:49.074Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/dc54c2e69f5eeec50601054998ec3690d5344277e782bd717e49867c1d29/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca", size = 871227, upload-time = "2026-04-03T20:54:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/af/cb16bd5dc61621e27df919a4449bbb7e5a1034c34d307e0a706e9cc0f3e3/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520", size = 917435, upload-time = "2026-04-03T20:54:52.994Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/8b260897f22996b666edd9402861668f45a2ca259f665ac029e6104a2d7d/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883", size = 816358, upload-time = "2026-04-03T20:54:54.884Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/60/775f7f72a510ef238254906c2f3d737fc80b16ca85f07d20e318d2eea894/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b", size = 785549, upload-time = "2026-04-03T20:54:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/58/42/34d289b3627c03cf381e44da534a0021664188fa49ba41513da0b4ec6776/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1", size = 801364, upload-time = "2026-04-03T20:54:58.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/20/f6ecf319b382a8f1ab529e898b222c3f30600fcede7834733c26279e7465/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b", size = 866221, upload-time = "2026-04-03T20:55:00.88Z" },
+    { url = "https://files.pythonhosted.org/packages/92/6a/9f16d3609d549bd96d7a0b2aee1625d7512ba6a03efc01652149ef88e74d/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff", size = 772530, upload-time = "2026-04-03T20:55:03.213Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f6/aa9768bc96a4c361ac96419fbaf2dcdc33970bb813df3ba9b09d5d7b6d96/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb", size = 856989, upload-time = "2026-04-03T20:55:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/c671db3556be2473ae3e4bb7a297c518d281452871501221251ea4ecba57/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4", size = 803241, upload-time = "2026-04-03T20:55:07.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa", size = 269921, upload-time = "2026-04-03T20:55:09.62Z" },
+    { url = "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0", size = 281240, upload-time = "2026-04-03T20:55:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe", size = 272440, upload-time = "2026-04-03T20:55:13.365Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
+]
+
+[[package]]
+name = "sam-2"
+version = "1.0"
+source = { git = "https://github.com/facebookresearch/sam2.git#2b90b9f5ceec907a1c18123530e92e794ad901a4" }
+dependencies = [
+    { name = "hydra-core" },
+    { name = "iopath" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+]
+
+[[package]]
+name = "scikit-image"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "imageio", marker = "python_full_version < '3.11'" },
+    { name = "lazy-loader", marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/cb/016c63f16065c2d333c8ed0337e18a5cdf9bc32d402e4f26b0db362eb0e2/scikit_image-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d3278f586793176599df6a4cf48cb6beadae35c31e58dc01a98023af3dc31c78", size = 13988922, upload-time = "2025-02-18T18:04:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ca/ff4731289cbed63c94a0c9a5b672976603118de78ed21910d9060c82e859/scikit_image-0.25.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:5c311069899ce757d7dbf1d03e32acb38bb06153236ae77fcd820fd62044c063", size = 13192698, upload-time = "2025-02-18T18:04:15.362Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6d/a2aadb1be6d8e149199bb9b540ccde9e9622826e1ab42fe01de4c35ab918/scikit_image-0.25.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be455aa7039a6afa54e84f9e38293733a2622b8c2fb3362b822d459cc5605e99", size = 14153634, upload-time = "2025-02-18T18:04:18.496Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/916e7d9ee4721031b2f625db54b11d8379bd51707afaa3e5a29aecf10bc4/scikit_image-0.25.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4c464b90e978d137330be433df4e76d92ad3c5f46a22f159520ce0fdbea8a09", size = 14767545, upload-time = "2025-02-18T18:04:22.556Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ee/c53a009e3997dda9d285402f19226fbd17b5b3cb215da391c4ed084a1424/scikit_image-0.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:60516257c5a2d2f74387c502aa2f15a0ef3498fbeaa749f730ab18f0a40fd054", size = 12812908, upload-time = "2025-02-18T18:04:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/97/3051c68b782ee3f1fb7f8f5bb7d535cf8cb92e8aae18fa9c1cdf7e15150d/scikit_image-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f4bac9196fb80d37567316581c6060763b0f4893d3aca34a9ede3825bc035b17", size = 14003057, upload-time = "2025-02-18T18:04:30.395Z" },
+    { url = "https://files.pythonhosted.org/packages/19/23/257fc696c562639826065514d551b7b9b969520bd902c3a8e2fcff5b9e17/scikit_image-0.25.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:d989d64ff92e0c6c0f2018c7495a5b20e2451839299a018e0e5108b2680f71e0", size = 13180335, upload-time = "2025-02-18T18:04:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/14/0c4a02cb27ca8b1e836886b9ec7c9149de03053650e9e2ed0625f248dd92/scikit_image-0.25.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2cfc96b27afe9a05bc92f8c6235321d3a66499995675b27415e0d0c76625173", size = 14144783, upload-time = "2025-02-18T18:04:36.594Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9b/9fb556463a34d9842491d72a421942c8baff4281025859c84fcdb5e7e602/scikit_image-0.25.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24cc986e1f4187a12aa319f777b36008764e856e5013666a4a83f8df083c2641", size = 14785376, upload-time = "2025-02-18T18:04:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/b57c500ee85885df5f2188f8bb70398481393a69de44a00d6f1d055f103c/scikit_image-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:b4f6b61fc2db6340696afe3db6b26e0356911529f5f6aee8c322aa5157490c9b", size = 12791698, upload-time = "2025-02-18T18:04:42.868Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8c/5df82881284459f6eec796a5ac2a0a304bb3384eec2e73f35cfdfcfbf20c/scikit_image-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8db8dd03663112783221bf01ccfc9512d1cc50ac9b5b0fe8f4023967564719fb", size = 13986000, upload-time = "2025-02-18T18:04:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e6/93bebe1abcdce9513ffec01d8af02528b4c41fb3c1e46336d70b9ed4ef0d/scikit_image-0.25.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:483bd8cc10c3d8a7a37fae36dfa5b21e239bd4ee121d91cad1f81bba10cfb0ed", size = 13235893, upload-time = "2025-02-18T18:04:51.049Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/eda616e33f67129e5979a9eb33c710013caa3aa8a921991e6cc0b22cea33/scikit_image-0.25.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d1e80107bcf2bf1291acfc0bf0425dceb8890abe9f38d8e94e23497cbf7ee0d", size = 14178389, upload-time = "2025-02-18T18:04:54.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b5/b75527c0f9532dd8a93e8e7cd8e62e547b9f207d4c11e24f0006e8646b36/scikit_image-0.25.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a17e17eb8562660cc0d31bb55643a4da996a81944b82c54805c91b3fe66f4824", size = 15003435, upload-time = "2025-02-18T18:04:57.586Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/49beb08ebccda3c21e871b607c1cb2f258c3fa0d2f609fed0a5ba741b92d/scikit_image-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:bdd2b8c1de0849964dbc54037f36b4e9420157e67e45a8709a80d727f52c7da2", size = 12899474, upload-time = "2025-02-18T18:05:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/7c/9814dd1c637f7a0e44342985a76f95a55dd04be60154247679fd96c7169f/scikit_image-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7efa888130f6c548ec0439b1a7ed7295bc10105458a421e9bf739b457730b6da", size = 13921841, upload-time = "2025-02-18T18:05:03.963Z" },
+    { url = "https://files.pythonhosted.org/packages/84/06/66a2e7661d6f526740c309e9717d3bd07b473661d5cdddef4dd978edab25/scikit_image-0.25.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dd8011efe69c3641920614d550f5505f83658fe33581e49bed86feab43a180fc", size = 13196862, upload-time = "2025-02-18T18:05:06.986Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/63/3368902ed79305f74c2ca8c297dfeb4307269cbe6402412668e322837143/scikit_image-0.25.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28182a9d3e2ce3c2e251383bdda68f8d88d9fff1a3ebe1eb61206595c9773341", size = 14117785, upload-time = "2025-02-18T18:05:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9b/c3da56a145f52cd61a68b8465d6a29d9503bc45bc993bb45e84371c97d94/scikit_image-0.25.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8abd3c805ce6944b941cfed0406d88faeb19bab3ed3d4b50187af55cf24d147", size = 14977119, upload-time = "2025-02-18T18:05:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/97/5fcf332e1753831abb99a2525180d3fb0d70918d461ebda9873f66dcc12f/scikit_image-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:64785a8acefee460ec49a354706db0b09d1f325674107d7fa3eadb663fb56d6f", size = 12885116, upload-time = "2025-02-18T18:05:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/75e9f17e3670b5ed93c32456fda823333c6279b144cd93e2c03aa06aa472/scikit_image-0.25.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:330d061bd107d12f8d68f1d611ae27b3b813b8cdb0300a71d07b1379178dd4cd", size = 13862801, upload-time = "2025-02-18T18:05:20.783Z" },
+]
+
+[[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "imageio", marker = "python_full_version >= '3.11'" },
+    { name = "lazy-loader", marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "tifffile", version = "2026.4.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/16/8a407688b607f86f81f8c649bf0d68a2a6d67375f18c2d660aba20f5b648/scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0", size = 12355510, upload-time = "2025-12-20T17:10:31.628Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/7efc088ececb6f6868fd4475e16cfafc11f242ce9ab5fc3557d78b5da0d4/scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd", size = 12056334, upload-time = "2025-12-20T17:10:34.559Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/bc7fb91fb5ff65ef42346c8b7ee8b09b04eabf89235ab7dbfdfd96cbd1ea/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea6207d9e9d21c3f464efe733121c0504e494dbdc7728649ff3e23c3c5a4953", size = 13297768, upload-time = "2025-12-20T17:10:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2a/e71c1a7d90e70da67b88ccc609bd6ae54798d5847369b15d3a8052232f9d/scikit_image-0.26.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74aa5518ccea28121f57a95374581d3b979839adc25bb03f289b1bc9b99c58af", size = 13711217, upload-time = "2025-12-20T17:10:40.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/59/9637ee12c23726266b91296791465218973ce1ad3e4c56fc81e4d8e7d6e1/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c244656de905e195a904e36dbc18585e06ecf67d90f0482cbde63d7f9ad59d", size = 14337782, upload-time = "2025-12-20T17:10:43.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5c/a3e1e0860f9294663f540c117e4bf83d55e5b47c281d475cc06227e88411/scikit_image-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21a818ee6ca2f2131b9e04d8eb7637b5c18773ebe7b399ad23dcc5afaa226d2d", size = 14805997, upload-time = "2025-12-20T17:10:45.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c6/2eeacf173da041a9e388975f54e5c49df750757fcfc3ee293cdbbae1ea0a/scikit_image-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:9490360c8d3f9a7e85c8de87daf7c0c66507960cf4947bb9610d1751928721c7", size = 11878486, upload-time = "2025-12-20T17:10:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a4/a852c4949b9058d585e762a66bf7e9a2cd3be4795cd940413dfbfbb0ce79/scikit_image-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:0baa0108d2d027f34d748e84e592b78acc23e965a5de0e4bb03cf371de5c0581", size = 11346518, upload-time = "2025-12-20T17:10:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ab/5cc9f80f28f6a7dff646c5756e559823614a42b1939d86dd0ed550470210/scipy-1.15.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:993439ce220d25e3696d1b23b233dd010169b62f6456488567e830654ee37a6b", size = 38714255, upload-time = "2025-05-08T16:05:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035, upload-time = "2025-05-08T16:05:20.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499, upload-time = "2025-05-08T16:05:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/f3aaddccf3588bb4aea70ba35328c204cadd89517a1612ecfda5b2dd9d7a/scipy-1.15.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:6db907c7368e3092e24919b5e31c76998b0ce1684d51a90943cb0ed1b4ffd6c1", size = 25152602, upload-time = "2025-05-08T16:05:29.313Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/1032cdb565f146109212153339f9cb8b993701e9fe56b1c97699eee12586/scipy-1.15.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721d6b4ef5dc82ca8968c25b111e307083d7ca9091bc38163fb89243e85e3889", size = 35503415, upload-time = "2025-05-08T16:05:34.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/37/89f19c8c05505d0601ed5650156e50eb881ae3918786c8fd7262b4ee66d3/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39cb9c62e471b1bb3750066ecc3a3f3052b37751c7c3dfd0fd7e48900ed52982", size = 37652622, upload-time = "2025-05-08T16:05:40.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/be59513aa9695519b18e1851bb9e487de66f2d31f835201f1b42f5d4d475/scipy-1.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:795c46999bae845966368a3c013e0e00947932d68e235702b5c3f6ea799aa8c9", size = 37244796, upload-time = "2025-05-08T16:05:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c0/4f5f3eeccc235632aab79b27a74a9130c6c35df358129f7ac8b29f562ac7/scipy-1.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18aaacb735ab38b38db42cb01f6b92a2d0d4b6aabefeb07f02849e47f8fb3594", size = 40047684, upload-time = "2025-05-08T16:05:54.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a7/0ddaf514ce8a8714f6ed243a2b391b41dbb65251affe21ee3077ec45ea9a/scipy-1.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:ae48a786a28412d744c62fd7816a4118ef97e5be0bee968ce8f0a2fba7acf3bb", size = 41246504, upload-time = "2025-05-08T16:06:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/ec27848c9baae6e0d6573eda6e01a602e5649ee72c27c3a8aad673ebecfd/scipy-1.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c620736bcc334782e24d173c0fdbb7590a0a436d2fdf39310a8902505008759", size = 38728256, upload-time = "2025-05-08T16:06:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/1aef2184948728b4b6e21267d53b3339762c285a46a274ebb7863c9e4742/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7e11270a000969409d37ed399585ee530b9ef6aa99d50c019de4cb01e8e54e62", size = 30109540, upload-time = "2025-05-08T16:07:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d8/59e452c0a255ec352bd0a833537a3bc1bfb679944c4938ab375b0a6b3a3e/scipy-1.15.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8c9ed3ba2c8a2ce098163a9bdb26f891746d02136995df25227a20e71c396ebb", size = 22383115, upload-time = "2025-05-08T16:07:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/456f56bbbfccf696263b47095291040655e3cbaf05d063bdc7c7517f32ac/scipy-1.15.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0bdd905264c0c9cfa74a4772cdb2070171790381a5c4d312c973382fc6eaf730", size = 25163884, upload-time = "2025-05-08T16:07:14.091Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/66/a9618b6a435a0f0c0b8a6d0a2efb32d4ec5a85f023c2b79d39512040355b/scipy-1.15.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79167bba085c31f38603e11a267d862957cbb3ce018d8b38f79ac043bc92d825", size = 35174018, upload-time = "2025-05-08T16:07:19.427Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/c5b6734a50ad4882432b6bb7c02baf757f5b2f256041da5df242e2d7e6b6/scipy-1.15.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9deabd6d547aee2c9a81dee6cc96c6d7e9a9b1953f74850c179f91fdc729cb7", size = 37269716, upload-time = "2025-05-08T16:07:25.712Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0a/eac00ff741f23bcabd352731ed9b8995a0a60ef57f5fd788d611d43d69a1/scipy-1.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dde4fc32993071ac0c7dd2d82569e544f0bdaff66269cb475e0f369adad13f11", size = 36872342, upload-time = "2025-05-08T16:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/4379be86dd74b6ad81551689107360d9a3e18f24d20767a2d5b9253a3f0a/scipy-1.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f77f853d584e72e874d87357ad70f44b437331507d1c311457bed8ed2b956126", size = 39670869, upload-time = "2025-05-08T16:07:38.002Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/892ad2862ba54f084ffe8cc4a22667eaf9c2bcec6d2bff1d15713c6c0703/scipy-1.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:b90ab29d0c37ec9bf55424c064312930ca5f4bde15ee8619ee44e69319aab163", size = 40988851, upload-time = "2025-05-08T16:08:33.671Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e9/7a879c137f7e55b30d75d90ce3eb468197646bc7b443ac036ae3fe109055/scipy-1.15.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3ac07623267feb3ae308487c260ac684b32ea35fd81e12845039952f558047b8", size = 38863011, upload-time = "2025-05-08T16:07:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d1/226a806bbd69f62ce5ef5f3ffadc35286e9fbc802f606a07eb83bf2359de/scipy-1.15.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6487aa99c2a3d509a5227d9a5e889ff05830a06b2ce08ec30df6d79db5fcd5c5", size = 30266407, upload-time = "2025-05-08T16:07:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9b/f32d1d6093ab9eeabbd839b0f7619c62e46cc4b7b6dbf05b6e615bbd4400/scipy-1.15.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:50f9e62461c95d933d5c5ef4a1f2ebf9a2b4e83b0db374cb3f1de104d935922e", size = 22540030, upload-time = "2025-05-08T16:07:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/29/c278f699b095c1a884f29fda126340fcc201461ee8bfea5c8bdb1c7c958b/scipy-1.15.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:14ed70039d182f411ffc74789a16df3835e05dc469b898233a245cdfd7f162cb", size = 25218709, upload-time = "2025-05-08T16:07:58.506Z" },
+    { url = "https://files.pythonhosted.org/packages/24/18/9e5374b617aba742a990581373cd6b68a2945d65cc588482749ef2e64467/scipy-1.15.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a769105537aa07a69468a0eefcd121be52006db61cdd8cac8a0e68980bbb723", size = 34809045, upload-time = "2025-05-08T16:08:03.929Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fe/9c4361e7ba2927074360856db6135ef4904d505e9b3afbbcb073c4008328/scipy-1.15.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9db984639887e3dffb3928d118145ffe40eff2fa40cb241a306ec57c219ebbbb", size = 36703062, upload-time = "2025-05-08T16:08:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132, upload-time = "2025-05-08T16:08:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503, upload-time = "2025-05-08T16:08:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097, upload-time = "2025-05-08T16:08:27.627Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/1d/b56b7b694fbc871496435488d1f41c5068de546334850d722756511cef65/shiboken6-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:d88e8a1eb705f2b9ad21db08a61ae1dc0c773e5cd86a069de0754c4cf1f9b43b", size = 476085, upload-time = "2026-03-23T12:47:05.724Z" },
+    { url = "https://files.pythonhosted.org/packages/65/cb/4bb0c76011166230daa7c0074aeb3fdb3935c83ac1fef3789b85fcd1a8fc/shiboken6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ad54e64f8192ddbdff0c54ac82b89edcd62ed623f502ea21c960541d19514053", size = 271055, upload-time = "2026-03-23T12:47:07.349Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/96/771a6e2b530f725303d16d78a321fa4876b98b4f3615c9851880df8c1a43/shiboken6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a10dc7718104ea2dc15d5b0b96909b77162ce1c76fcc6968e6df692b947a00e9", size = 267456, upload-time = "2026-03-23T12:47:08.689Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f7/44c0c42c3f5f29dec457fd46ea0552174bcb8aa75becf03bbd90308ba07b/shiboken6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:483ff78a73c7b3189ca924abc694318084f078bcfeaffa68e32024ff2d025ee1", size = 1222132, upload-time = "2026-03-23T12:47:10.143Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/99/6e5ee21db2d6af84bbbd7d871d441dafeb069c6de5667b1aa49891a77c66/shiboken6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:3bd76cf56105ab2d62ecaff630366f11264f69b88d488f10f048da9a065781f4", size = 1783186, upload-time = "2026-03-23T12:47:11.832Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slicerator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/52/f38586b82b2935f8b59a09b0a79c545a22ed062e728c9418bafeb51f61e0/slicerator-1.1.0.tar.gz", hash = "sha256:44010a7f5cd87680c07213b5cabe81d1fb71252962943e5373ee7d14605d6046", size = 38283, upload-time = "2022-04-07T18:54:08.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/ae/fa6cd331b364ad2bbc31652d025f5747d89cbb75576733dfdf8efe3e4d62/slicerator-1.1.0-py3-none-any.whl", hash = "sha256:167668d48c6d3a5ba0bd3d54b2688e81ee267dc20aef299e547d711e6f3c441a", size = 10274, upload-time = "2022-04-07T18:54:07.029Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2025.5.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/06/bd0a6097da704a7a7c34a94cfd771c3ea3c2f405dd214e790d22c93f6be1/tifffile-2025.5.10-py3-none-any.whl", hash = "sha256:e37147123c0542d67bc37ba5cdd67e12ea6fbe6e86c52bee037a9eb6a064e5ad", size = 226533, upload-time = "2025-05-10T19:22:27.279Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.4.11"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+]
+
+[[package]]
+name = "timm"
+version = "1.0.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/9d/0ea45640be447445c8664ce2b10c74f763b0b0b9ed11620d41a4d4baa10c/timm-1.0.24.tar.gz", hash = "sha256:c7b909f43fe2ef8fe62c505e270cd4f1af230dfbc37f2ee93e3608492b9d9a40", size = 2412239, upload-time = "2026-01-07T00:26:17.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/dd/c1f5b0890f7b5db661bde0864b41cb0275be76851047e5f7e085fe0b455a/timm-1.0.24-py3-none-any.whl", hash = "sha256:8301ac783410c6ad72c73c49326af6d71a9e4d1558238552796e825c2464913f", size = 2560563, upload-time = "2026-01-07T00:26:13.956Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/56/9577683b23072075ed2e40d725c52c2019d71a972fab8e083763da8e707e/torch-2.9.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:1cc208435f6c379f9b8fdfd5ceb5be1e3b72a6bdf1cb46c0d2812aa73472db9e", size = 104207681, upload-time = "2025-11-12T15:19:56.48Z" },
+    { url = "https://files.pythonhosted.org/packages/38/45/be5a74f221df8f4b609b78ff79dc789b0cc9017624544ac4dd1c03973150/torch-2.9.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:9fd35c68b3679378c11f5eb73220fdcb4e6f4592295277fbb657d31fd053237c", size = 899794036, upload-time = "2025-11-12T15:21:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/67/95/a581e8a382596b69385a44bab2733f1273d45c842f5d4a504c0edc3133b6/torch-2.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:2af70e3be4a13becba4655d6cc07dcfec7ae844db6ac38d6c1dafeb245d17d65", size = 110969861, upload-time = "2025-11-12T15:21:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/51/1756dc128d2bf6ea4e0a915cb89ea5e730315ff33d60c1ff56fd626ba3eb/torch-2.9.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:a83b0e84cc375e3318a808d032510dde99d696a85fe9473fc8575612b63ae951", size = 74452222, upload-time = "2025-11-12T15:20:46.223Z" },
+    { url = "https://files.pythonhosted.org/packages/15/db/c064112ac0089af3d2f7a2b5bfbabf4aa407a78b74f87889e524b91c5402/torch-2.9.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:62b3fd888277946918cba4478cf849303da5359f0fb4e3bfb86b0533ba2eaf8d", size = 104220430, upload-time = "2025-11-12T15:20:31.705Z" },
+    { url = "https://files.pythonhosted.org/packages/56/be/76eaa36c9cd032d3b01b001e2c5a05943df75f26211f68fae79e62f87734/torch-2.9.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d033ff0ac3f5400df862a51bdde9bad83561f3739ea0046e68f5401ebfa67c1b", size = 899821446, upload-time = "2025-11-12T15:20:15.544Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cc/7a2949e38dfe3244c4df21f0e1c27bce8aedd6c604a587dd44fc21017cb4/torch-2.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:0d06b30a9207b7c3516a9e0102114024755a07045f0c1d2f2a56b1819ac06bcb", size = 110973074, upload-time = "2025-11-12T15:21:39.958Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/7d251155a783fb2c1bb6837b2b7023c622a2070a0a72726ca1df47e7ea34/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:52347912d868653e1528b47cafaf79b285b98be3f4f35d5955389b1b95224475", size = 74463887, upload-time = "2025-11-12T15:20:36.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/27/07c645c7673e73e53ded71705045d6cb5bae94c4b021b03aa8d03eee90ab/torch-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da5f6f4d7f4940a173e5572791af238cb0b9e21b1aab592bd8b26da4c99f1cd6", size = 104126592, upload-time = "2025-11-12T15:20:41.62Z" },
+    { url = "https://files.pythonhosted.org/packages/19/17/e377a460603132b00760511299fceba4102bd95db1a0ee788da21298ccff/torch-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:27331cd902fb4322252657f3902adf1c4f6acad9dcad81d8df3ae14c7c4f07c4", size = 899742281, upload-time = "2025-11-12T15:22:17.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1a/64f5769025db846a82567fa5b7d21dba4558a7234ee631712ee4771c436c/torch-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:81a285002d7b8cfd3fdf1b98aa8df138d41f1a8334fd9ea37511517cedf43083", size = 110940568, upload-time = "2025-11-12T15:21:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ab/07739fd776618e5882661d04c43f5b5586323e2f6a2d7d84aac20d8f20bd/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:c0d25d1d8e531b8343bea0ed811d5d528958f1dcbd37e7245bc686273177ad7e", size = 74479191, upload-time = "2025-11-12T15:21:25.816Z" },
+    { url = "https://files.pythonhosted.org/packages/20/60/8fc5e828d050bddfab469b3fe78e5ab9a7e53dda9c3bdc6a43d17ce99e63/torch-2.9.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c29455d2b910b98738131990394da3e50eea8291dfeb4b12de71ecf1fdeb21cb", size = 104135743, upload-time = "2025-11-12T15:21:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/6d3f80e6918213babddb2a37b46dbb14c15b14c5f473e347869a51f40e1f/torch-2.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:524de44cd13931208ba2c4bde9ec7741fd4ae6bfd06409a604fc32f6520c2bc9", size = 899749493, upload-time = "2025-11-12T15:24:36.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/47/c7843d69d6de8938c1cbb1eba426b1d48ddf375f101473d3e31a5fc52b74/torch-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:545844cc16b3f91e08ce3b40e9c2d77012dd33a48d505aed34b7740ed627a1b2", size = 110944162, upload-time = "2025-11-12T15:21:53.151Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0e/2a37247957e72c12151b33a01e4df651d9d155dd74d8cfcbfad15a79b44a/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5be4bf7496f1e3ffb1dd44b672adb1ac3f081f204c5ca81eba6442f5f634df8e", size = 74830751, upload-time = "2025-11-12T15:21:43.792Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/7a18745edcd7b9ca2381aa03353647bca8aace91683c4975f19ac233809d/torch-2.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:30a3e170a84894f3652434b56d59a64a2c11366b0ed5776fab33c2439396bf9a", size = 104142929, upload-time = "2025-11-12T15:21:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dd/f1c0d879f2863ef209e18823a988dc7a1bf40470750e3ebe927efdb9407f/torch-2.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8301a7b431e51764629208d0edaa4f9e4c33e6df0f2f90b90e261d623df6a4e2", size = 899748978, upload-time = "2025-11-12T15:23:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9f/6986b83a53b4d043e36f3f898b798ab51f7f20fdf1a9b01a2720f445043d/torch-2.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2e1c42c0ae92bf803a4b2409fdfed85e30f9027a66887f5e7dcdbc014c7531db", size = 111176995, upload-time = "2025-11-12T15:22:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/40/60/71c698b466dd01e65d0e9514b5405faae200c52a76901baf6906856f17e4/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:2c14b3da5df416cf9cb5efab83aa3056f5b8cd8620b8fde81b4987ecab730587", size = 74480347, upload-time = "2025-11-12T15:21:57.648Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/09/d51aadf8591138e08b74c64a6eb783630c7a31ca2634416277115a9c3a2b/torchvision-0.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ded5e625788572e4e1c4d155d1bbc48805c113794100d70e19c76e39e4d53465", size = 1891441, upload-time = "2025-11-12T15:25:01.687Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/a35df863e7c153aad82af7505abd8264a5b510306689712ef86bea862822/torchvision-0.24.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:54ed17c3d30e718e08d8da3fd5b30ea44b0311317e55647cb97077a29ecbc25b", size = 2386226, upload-time = "2025-11-12T15:25:05.449Z" },
+    { url = "https://files.pythonhosted.org/packages/49/20/f2d7cd1eea052887c1083afff0b8df5228ec93b53e03759f20b1a3c6d22a/torchvision-0.24.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f476da4e085b7307aaab6f540219617d46d5926aeda24be33e1359771c83778f", size = 8046093, upload-time = "2025-11-12T15:25:09.425Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cf/0ff4007c09903199307da5f53a192ff5d62b45447069e9ef3a19bdc5ff12/torchvision-0.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:fbdbdae5e540b868a681240b7dbd6473986c862445ee8a138680a6a97d6c34ff", size = 3696202, upload-time = "2025-11-12T15:25:10.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/69/30f5f03752aa1a7c23931d2519b31e557f3f10af5089d787cddf3b903ecf/torchvision-0.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:056c525dc875f18fe8e9c27079ada166a7b2755cea5a2199b0bc7f1f8364e600", size = 1891436, upload-time = "2025-11-12T15:25:04.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/69/49aae86edb75fe16460b59a191fcc0f568c2378f780bb063850db0fe007a/torchvision-0.24.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1e39619de698e2821d71976c92c8a9e50cdfd1e993507dfb340f2688bfdd8283", size = 2387757, upload-time = "2025-11-12T15:25:06.795Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c9/1dfc3db98797b326f1d0c3f3bb61c83b167a813fc7eab6fcd2edb8c7eb9d/torchvision-0.24.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a0f106663e60332aa4fcb1ca2159ef8c3f2ed266b0e6df88de261048a840e0df", size = 8047682, upload-time = "2025-11-12T15:25:21.125Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/bb/cfc6a6f6ccc84a534ed1fdf029ae5716dd6ff04e57ed9dc2dab38bf652d5/torchvision-0.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:a9308cdd37d8a42e14a3e7fd9d271830c7fecb150dd929b642f3c1460514599a", size = 4037588, upload-time = "2025-11-12T15:25:14.402Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/18e2c6b9538a045f60718a0c5a058908ccb24f88fde8e6f0fc12d5ff7bd3/torchvision-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e48bf6a8ec95872eb45763f06499f87bd2fb246b9b96cb00aae260fda2f96193", size = 1891433, upload-time = "2025-11-12T15:25:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/43/600e5cfb0643d10d633124f5982d7abc2170dfd7ce985584ff16edab3e76/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7fb7590c737ebe3e1c077ad60c0e5e2e56bb26e7bccc3b9d04dbfc34fd09f050", size = 2386737, upload-time = "2025-11-12T15:25:08.288Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b1/db2941526ecddd84884132e2742a55c9311296a6a38627f9e2627f5ac889/torchvision-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66a98471fc18cad9064123106d810a75f57f0838eee20edc56233fd8484b0cc7", size = 8049868, upload-time = "2025-11-12T15:25:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/69/98/16e583f59f86cd59949f59d52bfa8fc286f86341a229a9d15cbe7a694f0c/torchvision-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:4aa6cb806eb8541e92c9b313e96192c6b826e9eb0042720e2fa250d021079952", size = 4302006, upload-time = "2025-11-12T15:25:16.184Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/97/ab40550f482577f2788304c27220e8ba02c63313bd74cf2f8920526aac20/torchvision-0.24.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8a6696db7fb71eadb2c6a48602106e136c785642e598eb1533e0b27744f2cce6", size = 1891435, upload-time = "2025-11-12T15:25:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/30/65/ac0a3f9be6abdbe4e1d82c915d7e20de97e7fd0e9a277970508b015309f3/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:db2125c46f9cb25dc740be831ce3ce99303cfe60439249a41b04fd9f373be671", size = 2338718, upload-time = "2025-11-12T15:25:26.19Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b5/5bba24ff9d325181508501ed7f0c3de8ed3dd2edca0784d48b144b6c5252/torchvision-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f035f0cacd1f44a8ff6cb7ca3627d84c54d685055961d73a1a9fb9827a5414c8", size = 8049661, upload-time = "2025-11-12T15:25:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ec/54a96ae9ab6a0dd66d4bba27771f892e36478a9c3489fa56e51c70abcc4d/torchvision-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:16274823b93048e0a29d83415166a2e9e0bf4e1b432668357b657612a4802864", size = 4319808, upload-time = "2025-11-12T15:25:17.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f3/a90a389a7e547f3eb8821b13f96ea7c0563cdefbbbb60a10e08dda9720ff/torchvision-0.24.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e3f96208b4bef54cd60e415545f5200346a65024e04f29a26cd0006dbf9e8e66", size = 2005342, upload-time = "2025-11-12T15:25:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/fe/ff27d2ed1b524078164bea1062f23d2618a5fc3208e247d6153c18c91a76/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f231f6a4f2aa6522713326d0d2563538fa72d613741ae364f9913027fa52ea35", size = 2341708, upload-time = "2025-11-12T15:25:25.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b9/d6c903495cbdfd2533b3ef6f7b5643ff589ea062f8feb5c206ee79b9d9e5/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1540a9e7f8cf55fe17554482f5a125a7e426347b71de07327d5de6bfd8d17caa", size = 8177239, upload-time = "2025-11-12T15:25:18.554Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2b/ba02e4261369c3798310483028495cf507e6cb3f394f42e4796981ecf3a7/torchvision-0.24.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d83e16d70ea85d2f196d678bfb702c36be7a655b003abed84e465988b6128938", size = 4251604, upload-time = "2025-11-12T15:25:34.069Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/35/cd5b0d1288e65d2c12db4ce84c1ec1074f7ee9bced040de6c9d69e70d620/transformers-5.5.3.tar.gz", hash = "sha256:3f60128e840b40d352655903552e1eed4f94ed49369a4d43e1bc067bd32d3f50", size = 8226047, upload-time = "2026-04-09T15:52:56.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/0b/f8524551ab2d896dfaca74ddb70a4453d515bbf4ab5451c100c7788ae155/transformers-5.5.3-py3-none-any.whl", hash = "sha256:e48f3ec31dd96505e96e66b63a1e43e1ad7a65749e108d9227caaf51051cdb02", size = 10236257, upload-time = "2026-04-09T15:52:52.866Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/6e/676ab5019b4dde8b9b7bab71245102fc02778ef3df48218b298686b9ffd6/triton-3.5.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5fc53d849f879911ea13f4a877243afc513187bc7ee92d1f2c0f1ba3169e3c94", size = 170320692, upload-time = "2025-11-11T17:40:46.074Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/72/ec90c3519eaf168f22cb1757ad412f3a2add4782ad3a92861c9ad135d886/triton-3.5.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61413522a48add32302353fdbaaf92daaaab06f6b5e3229940d21b5207f47579", size = 170425802, upload-time = "2025-11-11T17:40:53.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+]
+
+[[package]]
+name = "triton-windows"
+version = "3.5.1.post24"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a8/35e461275ed0fc5a72893dc5041dcb6292e3fe3a512f39ab7c5589aaaf34/triton_windows-3.5.1.post24-cp310-cp310-win_amd64.whl", hash = "sha256:43f318f0106ea052b92483fefa4e83da8421682863cc64677da4a52628031390", size = 46467269, upload-time = "2026-01-04T13:43:31.976Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a4/7d1756131cb45ee9e6c048598b992925418c871697a15d58ad34b4983a8f/triton_windows-3.5.1.post24-cp311-cp311-win_amd64.whl", hash = "sha256:258eb8f5ded66bfa0265f320744349d143d190e57ca1ea05f3a315f06003cdb8", size = 46468560, upload-time = "2026-01-04T13:43:38.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/eb/3114b23cebe11ff768ae1444dea426ec9b28e5ce17e7a2babcb639a3447e/triton_windows-3.5.1.post24-cp312-cp312-win_amd64.whl", hash = "sha256:2aef99d060f0345244494c682e97b389f7198c42247a4d493abc314dcc7129cb", size = 46473404, upload-time = "2026-01-04T13:43:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/36/ec7645dc89e300497b8ec64e371cc8752cf252faa3d52ac71a6c305fc92c/triton_windows-3.5.1.post24-cp313-cp313-win_amd64.whl", hash = "sha256:cba5b96d37e19c46ed5d0fed79f426fa5e074ced4e8f77b93ddbe33b1250a3c4", size = 46471224, upload-time = "2026-01-04T13:43:52.336Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]


### PR DESCRIPTION
Related to #92.

## Summary

Adds **optional AMD GPU (ROCm) support** via `docker/Dockerfile.rocm`:

- **`rocm-runtime`** (default build target): `uv run python main.py`.
- **`rocm-vnc`**: same baked environment plus noVNC / x11vnc / filebrowser / supervisord (parity with the default `docker/Dockerfile` UX).

ROCm PyTorch + **`pytorch-triton-rocm`** are applied **only inside the image** (`uv pip install … --reinstall` after `uv sync`). **No** `rocm` optional extra in `pyproject.toml`.

Also includes **`device_utils.setup_rocm_env()`** (HIP detection, `HSA_OVERRIDE_GFX_VERSION`, stderr logging before `setup_logging`), **`main._try_setup_rocm_env()`**, **mocked ROCm tests**, **Compose profile `rocm`**, **`.github/workflows/rocm-ci.yml`**, **`device_utils` in wheel/sdist** via hatch `force-include`, **`torch-backend = "auto"`** under **`[tool.uv.pip]`**, a **Ruff** workflow (**`ruff.yml`**) + **`[tool.ruff]`**, **pinned filebrowser** `get.sh` in both Dockerfiles, **`.gitignore`** fix so `tests/test_*.py` under `tests/` are tracked, and docs under **`docs/ROCm_Setup.md`** / **`docs/ROCm_PR_handoff.md`**.

## How to test

```bash
uv sync --extra dev
uv run ruff check .
uv run ruff format --check .
uv run pytest tests/test_rocm_setup.py -m rocm -v --tb=short --noconftest
```

Docker (optional; large pull):

```bash
docker build -f docker/Dockerfile.rocm --target rocm-runtime -t ez-corridorkey-rocm .
docker build -f docker/Dockerfile.rocm --target rocm-vnc -t ez-corridorkey-rocm-vnc .
```

## Docs

- `docs/ROCm_Setup.md`
- `docs/ROCm_PR_handoff.md`

**Note:** The contributor does not have AMD hardware; ROCm paths are designed for review and validation by someone with a suitable GPU.
