### PR TITLE
fix: Mac MPS GVM black alpha, EXR import, flaky test

### DIFF
--- a/gvm_core/gvm/pipelines/pipeline_gvm.py
+++ b/gvm_core/gvm/pipelines/pipeline_gvm.py
@@ -147,7 +147,9 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
     ):
 
         assert ensemble_size >= 1
-        self.vae.to(dtype=torch.float16)
+        # MPS float16 GroupNorm produces NaN; use float32 for VAE on Apple Silicon
+        vae_dtype = torch.float32 if image.device.type == 'mps' else torch.float16
+        self.vae.to(dtype=vae_dtype)
         class_embedding = None
         
         # (1, N, 3, H, W)

--- a/gvm_core/gvm/pipelines/pipeline_gvm.py
+++ b/gvm_core/gvm/pipelines/pipeline_gvm.py
@@ -147,9 +147,6 @@ class GVMPipeline(DiffusionPipeline, GVMLoraLoader):
     ):
 
         assert ensemble_size >= 1
-        # MPS float16 GroupNorm produces NaN; use float32 for VAE on Apple Silicon
-        vae_dtype = torch.float32 if image.device.type == 'mps' else torch.float16
-        self.vae.to(dtype=vae_dtype)
         class_embedding = None
         
         # (1, N, 3, H, W)

--- a/gvm_core/wrapper.py
+++ b/gvm_core/wrapper.py
@@ -87,7 +87,9 @@ class GVMProcessor:
                  device="cuda",
                  seed=None):
         self.device = torch.device(device)
-        
+        # MPS float16 GroupNorm / attention produce NaN; run full pipeline in float32
+        self._dtype = torch.float32 if self.device.type == 'mps' else torch.float16
+
         # Resolve default weights path from installed data dir first, then the
         # bundled module dir, finally falling back to the HuggingFace repo ID.
         if model_base is None:
@@ -106,7 +108,7 @@ class GVMProcessor:
         seed_all(seed)
         
         logger.info(f"Loading GVM models from {model_base}...")
-        self.vae = AutoencoderKLTemporalDecoder.from_pretrained(model_base, subfolder="vae", torch_dtype=torch.float16)
+        self.vae = AutoencoderKLTemporalDecoder.from_pretrained(model_base, subfolder="vae", torch_dtype=self._dtype)
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(model_base, subfolder="scheduler")
         
         unet_folder = unet_base if unet_base is not None else model_base
@@ -114,7 +116,7 @@ class GVMProcessor:
             unet_folder, 
             subfolder="unet", 
             class_embed_type=None,
-            torch_dtype=torch.float16
+            torch_dtype=self._dtype
         )
 
         self.pipe = GVMPipeline(vae=self.vae, unet=self.unet, scheduler=self.scheduler)
@@ -126,20 +128,29 @@ class GVMProcessor:
             elif lora_base:
                 self.pipe.load_lora_weights(lora_base)
                 
-        self.pipe = self.pipe.to(self.device, dtype=torch.float16)
+        self.pipe = self.pipe.to(self.device, dtype=self._dtype)
+
+        # MPS SDPA triggers Metal matmul assertion at non-trivial resolutions;
+        # fall back to vanilla attention (AttnProcessor) on Apple Silicon.
+        if self.device.type == 'mps':
+            from diffusers.models.attention_processor import AttnProcessor
+            self.unet.set_attn_processor(AttnProcessor())
+            self.vae.set_attn_processor(AttnProcessor())
+
         logger.info("Models loaded.")
 
     def to(self, device, **kwargs):
         """Move all internal models to *device* (enables VRAM offloading)."""
         device = torch.device(device)
         self.device = device
+        self._dtype = torch.float32 if device.type == 'mps' else torch.float16
         if self.pipe is not None:
-            self.pipe = self.pipe.to(device, **kwargs)
+            self.pipe = self.pipe.to(device, dtype=self._dtype, **kwargs)
         # vae/unet are owned by pipe, but move explicitly in case of ref drift
         if self.vae is not None:
-            self.vae = self.vae.to(device)
+            self.vae = self.vae.to(device, dtype=self._dtype)
         if self.unet is not None:
-            self.unet = self.unet.to(device)
+            self.unet = self.unet.to(device, dtype=self._dtype)
         return self
 
     def process_sequence(self, input_path, output_dir,
@@ -313,7 +324,7 @@ class GVMProcessor:
             # Inference
             with torch.no_grad():
                 pipe_out = self.pipe(
-                    batch.to(self.device, dtype=torch.float16),
+                    batch.to(self.device, dtype=self._dtype),
                     num_frames=num_frames_per_batch,
                     num_overlap_frames=num_overlap_frames,
                     num_interp_frames=num_interp_frames,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -431,7 +431,7 @@ class TestWriteManifest:
     def test_manifest_overwrites_existing(self):
         svc = CorridorKeyService()
         cfg = OutputConfig()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         with tempfile.TemporaryDirectory() as tmpdir:
             # Write twice — second should overwrite
             svc._write_manifest(tmpdir, cfg, params)
@@ -445,7 +445,7 @@ class TestWriteManifest:
         """Manifest write failure is non-fatal (logs warning, continues)."""
         svc = CorridorKeyService()
         cfg = OutputConfig()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         # Write to non-existent path — should not raise
         svc._write_manifest("/nonexistent/path/that/doesnt/exist", cfg, params)
 
@@ -633,7 +633,7 @@ class TestRunInference:
 
     def test_happy_path(self, sample_clip, tmp_clip_dir):
         svc, mock_engine = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         cfg = OutputConfig(
             fg_format="png", matte_format="png",
             comp_format="png", processed_format="png",
@@ -645,7 +645,7 @@ class TestRunInference:
 
     def test_resume_skips_stems(self, sample_clip, tmp_clip_dir):
         svc, mock_engine = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         input_files = sample_clip.input_asset.get_frame_files()
         first_stem = os.path.splitext(input_files[0])[0]
         results = svc.run_inference(
@@ -660,7 +660,7 @@ class TestRunInference:
 
     def test_cancellation_raises(self, sample_clip):
         svc, _ = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         job = GPUJob(JobType.INFERENCE, "test_clip")
         job.request_cancel()
 
@@ -672,7 +672,7 @@ class TestRunInference:
     def test_frame_read_error_continues(self, sample_clip, tmp_clip_dir):
         """FrameReadError on a frame → skip that frame, continue others."""
         svc, mock_engine = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
 
         # Patch _read_input_frame to fail on first call, succeed on others
         original_read = svc._read_input_frame
@@ -701,7 +701,7 @@ class TestRunInference:
         """Codex: engine.process_frame raising should propagate (fail-fast)."""
         svc, mock_engine = self._setup_service_with_mock_engine()
         mock_engine.process_frame.side_effect = RuntimeError("GPU OOM")
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
 
         # Should propagate — not caught by the per-frame handler
         with pytest.raises(RuntimeError, match="GPU OOM"):
@@ -712,7 +712,7 @@ class TestRunInference:
     def test_progress_callback_cadence(self, sample_clip, tmp_clip_dir):
         """Codex: progress fires every 5th frame + final, not per-frame."""
         svc, _ = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         calls = []
         results = svc.run_inference(
             sample_clip, params,
@@ -727,7 +727,7 @@ class TestRunInference:
 
     def test_state_transition_to_complete(self, sample_clip, tmp_clip_dir):
         svc, _ = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         assert sample_clip.state == ClipState.READY
         svc.run_inference(sample_clip, params,
                           output_config=OutputConfig(fg_format="png", matte_format="png",
@@ -737,7 +737,7 @@ class TestRunInference:
     def test_zero_frame_clip_no_complete(self):
         """Codex: zero-frame clip should not transition to COMPLETE (0==0 passes)."""
         svc, _ = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             clip_root = os.path.join(tmpdir, "empty_clip")
@@ -764,7 +764,7 @@ class TestRunInference:
         svc = CorridorKeyService()
         clip = ClipEntry("test", "/tmp", state=ClipState.READY)
         with pytest.raises(CorridorKeyError, match="missing input or alpha"):
-            svc.run_inference(clip, InferenceParams())
+            svc.run_inference(clip, InferenceParams(screen_color="green"))
 
     def test_video_captures_released(self, sample_clip, tmp_clip_dir):
         """Video captures should be released in finally block."""
@@ -787,7 +787,7 @@ class TestRunInference:
 
         mock_engine.process_frame.side_effect = cancel_after_first
 
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
         with pytest.raises(JobCancelledError):
             svc.run_inference(sample_clip, params, job=job,
                               output_config=OutputConfig(fg_format="png", matte_format="png",
@@ -796,7 +796,7 @@ class TestRunInference:
 
     def test_frame_range_uses_stem_matched_partial_alpha_sequence(self):
         svc, mock_engine = self._setup_service_with_mock_engine()
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             frames_dir = os.path.join(tmpdir, "Frames")
@@ -865,14 +865,14 @@ class TestReprocessSingleFrame:
             "alpha": np.ones((4, 4, 1), dtype=np.float32),
         }
         svc._engine_pool = [mock_engine]
-        result = svc.reprocess_single_frame(sample_clip, InferenceParams(), 0)
+        result = svc.reprocess_single_frame(sample_clip, InferenceParams(screen_color="green"), 0)
         assert result is not None
         assert "fg" in result
 
     def test_missing_assets_returns_none(self):
         svc = CorridorKeyService()
         clip = ClipEntry("test", "/tmp")
-        result = svc.reprocess_single_frame(clip, InferenceParams(), 0)
+        result = svc.reprocess_single_frame(clip, InferenceParams(screen_color="green"), 0)
         assert result is None
 
     def test_cancelled_returns_none(self, sample_clip):
@@ -881,14 +881,14 @@ class TestReprocessSingleFrame:
         svc._engine_pool = [MagicMock()]
         job = GPUJob(JobType.PREVIEW_REPROCESS, "test")
         job.request_cancel()
-        result = svc.reprocess_single_frame(sample_clip, InferenceParams(), 0, job=job)
+        result = svc.reprocess_single_frame(sample_clip, InferenceParams(screen_color="green"), 0, job=job)
         assert result is None
 
     def test_out_of_range_returns_none(self, sample_clip):
         svc = CorridorKeyService()
         svc._active_model = _ActiveModel.INFERENCE
         svc._engine_pool = [MagicMock()]
-        result = svc.reprocess_single_frame(sample_clip, InferenceParams(), 9999)
+        result = svc.reprocess_single_frame(sample_clip, InferenceParams(screen_color="green"), 9999)
         assert result is None
 
     def test_reprocess_forwards_status_during_engine_warmup(self, sample_clip):
@@ -914,7 +914,7 @@ class TestReprocessSingleFrame:
         ), patch("backend.service.read_mask_frame", return_value=fake_mask):
             result = svc.reprocess_single_frame(
                 sample_clip,
-                InferenceParams(),
+                InferenceParams(screen_color="green"),
                 0,
                 on_status=statuses.append,
             )
@@ -1062,7 +1062,7 @@ class TestReprocessSingleFrame:
             ):
                 result = svc.reprocess_single_frame(
                     clip,
-                    InferenceParams(),
+                    InferenceParams(screen_color="green"),
                     3,
                 )
 

--- a/tests/test_service_concurrency.py
+++ b/tests/test_service_concurrency.py
@@ -44,7 +44,7 @@ class TestGPULockSerialization:
         engine, call_log = _make_slow_engine(0.05)
         svc._engine_pool = [engine]
         svc._active_model = _ActiveModel.INFERENCE
-        params = InferenceParams()
+        params = InferenceParams(screen_color="green")
 
         results = [None, None]
         errors = [None, None]

--- a/ui/main_window_mixins/alpha_import_mixin.py
+++ b/ui/main_window_mixins/alpha_import_mixin.py
@@ -6,6 +6,7 @@ import os
 import shutil
 
 import cv2
+import numpy as np
 from PySide6.QtWidgets import QMessageBox, QFileDialog
 
 from . import _tr
@@ -210,7 +211,21 @@ class AlphaImportMixin:
                         imported_count += 1
                         continue
 
-                    img = cv2.imread(src_path, cv2.IMREAD_GRAYSCALE)
+                    if src_ext == ".exr":
+                        img = cv2.imread(
+                            src_path,
+                            cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED,
+                        )
+                        if img is not None:
+                            if img.ndim == 3:
+                                img = img[:, :, 0]
+                            if img.dtype != np.uint8:
+                                img = np.clip(
+                                    img.astype(np.float32), 0.0, 1.0,
+                                )
+                                img = (img * 255.0).astype(np.uint8)
+                    else:
+                        img = cv2.imread(src_path, cv2.IMREAD_GRAYSCALE)
                     if img is None:
                         logger.warning("Failed to import alpha image: %s", src_path)
                         continue


### PR DESCRIPTION
## Summary

- GVM black alpha on Mac: float16 UNet produces NaN on MPS GroupNorm/attention, and SDPA AttnProcessor2_0 triggers Metal matmul dtype assertion. Fixed by running full GVM pipeline in float32 with vanilla AttnProcessor on Apple Silicon. Also removed a redundant vae.to(dtype=) call that triggered the same Metal assertion even when dtype was already float32.
- EXR alpha import black on Mac: cv2.IMREAD_GRAYSCALE truncated float32 EXR data to uint8 zeros. Fixed with IMREAD_ANYDEPTH | IMREAD_UNCHANGED + float-to-uint8 normalization.
- Flaky concurrency test: default screen_color=auto ran detect_screen_color on random 4x4 test pixels, sometimes producing a color mismatch that nuked the mock engine pool and triggered real model loading (>5s timeout). Fixed with explicit screen_color=green.

## Changed files

- gvm_core/wrapper.py - float32 dtype + vanilla AttnProcessor on MPS
- gvm_core/gvm/pipelines/pipeline_gvm.py - remove redundant vae.to(dtype=)
- ui/main_window_mixins/alpha_import_mixin.py - EXR alpha import fix
- tests/test_service.py, tests/test_service_concurrency.py - explicit screen_color