### PR TITLE
v2.1.1: non-ASCII project paths and first-run language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to EZ-CorridorKey are documented here.
 
 ---
 
+## [2.1.1] - 2026-06-17 - Non-ASCII paths, first-run language
+
+### Fixed
+
+- **Projects with non-ASCII folder names now work.** Projects whose path contains Cyrillic, CJK, Arabic, Hindi, or accented Latin characters showed blank input/output previews and produced no output, because OpenCV cannot open such paths on Windows. All image and video reads and writes now go through a Unicode-safe layer. ASCII paths are unchanged, so existing projects produce byte-identical output.
+- **First-run language now matches the Preferences menu.** When the app detected your system language on first launch (for example Russian), the interface switched but the language dropdown still showed English. The detected language is now saved on first run, so the menu reflects the active language. Manually chosen languages are never overwritten.
+
+---
+
 ## [2.1.0] - 2026-06-12 - Batch Pipeline, 14-language UI, fixes
 
 > **Python macOS support ends with this release.** Starting with 2.1.1+, all macOS effort moves to a fully native Mac application, coming to the App Store shortly. Subscribe on [YouTube](https://www.youtube.com/@edenaion) for release updates.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EZ-CorridorKey **v2.1.0**
+# EZ-CorridorKey **v2.1.1**
 
-[![Release](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Release](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Stars](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)
@@ -9,7 +9,7 @@
 
 <p><img alt="🇺🇸 English" src="https://img.shields.io/static/v1?label=%F0%9F%87%BA%F0%9F%87%B8&message=English&color=FFF203&labelColor=141300&style=flat-square"> <a href="docs/i18n/README.fr.md"><img alt="🇫🇷 Français" src="https://img.shields.io/static/v1?label=%F0%9F%87%AB%F0%9F%87%B7&message=Fran%C3%A7ais&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.de.md"><img alt="🇩🇪 Deutsch" src="https://img.shields.io/static/v1?label=%F0%9F%87%A9%F0%9F%87%AA&message=Deutsch&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.es.md"><img alt="🇪🇸 Español" src="https://img.shields.io/static/v1?label=%F0%9F%87%AA%F0%9F%87%B8&message=Espa%C3%B1ol&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.it.md"><img alt="🇮🇹 Italiano" src="https://img.shields.io/static/v1?label=%F0%9F%87%AE%F0%9F%87%B9&message=Italiano&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.pt.md"><img alt="🇧🇷 Português (Brasil)" src="https://img.shields.io/static/v1?label=%F0%9F%87%A7%F0%9F%87%B7&message=Portugu%C3%AAs%20%28Brasil%29&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.ja.md"><img alt="🇯🇵 日本語" src="https://img.shields.io/static/v1?label=%F0%9F%87%AF%F0%9F%87%B5&message=%E6%97%A5%E6%9C%AC%E8%AA%9E&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.ko.md"><img alt="🇰🇷 한국어" src="https://img.shields.io/static/v1?label=%F0%9F%87%B0%F0%9F%87%B7&message=%ED%95%9C%EA%B5%AD%EC%96%B4&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.zh.md"><img alt="🇨🇳 简体中文" src="https://img.shields.io/static/v1?label=%F0%9F%87%A8%F0%9F%87%B3&message=%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.ru.md"><img alt="🇷🇺 Русский" src="https://img.shields.io/static/v1?label=%F0%9F%87%B7%F0%9F%87%BA&message=%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.pl.md"><img alt="🇵🇱 Polski" src="https://img.shields.io/static/v1?label=%F0%9F%87%B5%F0%9F%87%B1&message=Polski&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.tr.md"><img alt="🇹🇷 Türkçe" src="https://img.shields.io/static/v1?label=%F0%9F%87%B9%F0%9F%87%B7&message=T%C3%BCrk%C3%A7e&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.hi.md"><img alt="🇮🇳 हिन्दी" src="https://img.shields.io/static/v1?label=%F0%9F%87%AE%F0%9F%87%B3&message=%E0%A4%B9%E0%A4%BF%E0%A4%A8%E0%A5%8D%E0%A4%A6%E0%A5%80&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.id.md"><img alt="🇮🇩 Bahasa Indonesia" src="https://img.shields.io/static/v1?label=%F0%9F%87%AE%F0%9F%87%A9&message=Bahasa%20Indonesia&color=454430&labelColor=0E0D00&style=flat-square"></a> <a href="docs/i18n/README.vi.md"><img alt="🇻🇳 Tiếng Việt" src="https://img.shields.io/static/v1?label=%F0%9F%87%BB%F0%9F%87%B3&message=Ti%E1%BA%BFng%20Vi%E1%BB%87t&color=454430&labelColor=0E0D00&style=flat-square"></a></p>
 
-> **Latest release: [v2.1.0](https://github.com/edenaion/EZ-CorridorKey/releases/tag/v2.1.0):** UI in 15 languages, Batch Pipeline folder processing, built-in MLX engine for Apple Silicon, tandem viewer pan/zoom. See the [full changelog](CHANGELOG.md).
+> **Latest release: [v2.1.1](https://github.com/edenaion/EZ-CorridorKey/releases/tag/v2.1.1):** UI in 15 languages, Batch Pipeline folder processing, built-in MLX engine for Apple Silicon, tandem viewer pan/zoom. See the [full changelog](CHANGELOG.md).
 
 A full desktop GUI for [Niko Pueringer's CorridorKey](https://github.com/nikopueringer/CorridorKey) — the AI chroma keyer by Corridor Digital that physically unmixes foreground from background, preserving hair, motion blur, and translucency.
 
@@ -92,7 +92,7 @@ The installer includes everything — Python runtime, AI models, GPU libraries �
 **Updating:**
 
 - **Windows Desktop App Installer users:** The app checks for updates automatically. When a new version is available, click the update button in the app. It downloads a lightweight patch and relaunches.
-- **macOS Desktop App users:** the in-app updater offers 2.1.0, but the macOS side of 2.1.0 is untested as a whole. Update at your own risk. The recommended path is staying on v2.0.0 and waiting for the fully native Mac app, coming to the App Store soon (see the macOS note at the top).
+- **macOS Desktop App users:** the in-app updater offers 2.1.1, but the macOS side of 2.1.1 is untested as a whole. Update at your own risk. The recommended path is staying on v2.0.0 and waiting for the fully native Mac app, coming to the App Store soon (see the macOS note at the top).
 - **CLI users:** Double-click `3-update.bat` (Windows) or run `./3-update.sh` (macOS/Linux). This pulls the latest code via git, or downloads a ZIP if git isn't available.
 
 > **Note:** The update ZIP on GitHub Releases (`EZ-CorridorKey-windows-x64.zip`) is for Windows Desktop App Installer users only. It patches an existing installation. CLI users should continue using `3-update.bat` / `3-update.sh`.
@@ -486,7 +486,7 @@ Mode is auto-detected from available VRAM. Override with `CORRIDORKEY_OPT_MODE=s
 
 ### macOS (Apple Silicon)
 
-> Applies to v2.0.0 and source installs. 2.1.0 ships no Mac installer, and the macOS side of 2.1.0 is untested as a whole (see the macOS note at the top).
+> Applies to v2.0.0 and source installs. 2.1.1 ships no Mac installer, and the macOS side of 2.1.1 is untested as a whole (see the macOS note at the top).
 
 |             | Minimum       | Recommended                                      |
 | ----------- | ------------- | ------------------------------------------------ |
@@ -539,7 +539,7 @@ Each release includes a `SHA256SUMS.txt` file listing the SHA-256 hash of every 
 
 ```powershell
 # In the download folder (Shift + right-click > "Open PowerShell window here")
-Get-FileHash .\EZ-CorridorKey-2.1.0-Windows-x64-Setup.exe -Algorithm SHA256
+Get-FileHash .\EZ-CorridorKey-2.1.1-Windows-x64-Setup.exe -Algorithm SHA256
 # Open SHA256SUMS.txt, find the line ending in that filename, compare the hash.
 # The two strings must match exactly. If they differ, do not run the file, download it again.
 ```
@@ -549,7 +549,7 @@ Get-FileHash .\EZ-CorridorKey-2.1.0-Windows-x64-Setup.exe -Algorithm SHA256
 ```bash
 cd ~/Downloads   # wherever you saved the files
 shasum -a 256 -c SHA256SUMS.txt --ignore-missing
-# Expect: EZ-CorridorKey-2.1.0-macOS-arm64.dmg: OK
+# Expect: EZ-CorridorKey-2.1.1-macOS-arm64.dmg: OK
 # If it says FAILED, the file is corrupted or tampered with, download it again.
 ```
 

--- a/backend/clip_state.py
+++ b/backend/clip_state.py
@@ -134,22 +134,27 @@ class ClipAsset:
         try:
             if self.asset_type == 'video':
                 import cv2
-                cap = cv2.VideoCapture(self.path)
-                if cap.isOpened():
-                    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-                    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                from .frame_io import open_video
+                cap = open_video(self.path)
+                try:
+                    if cap.isOpened():
+                        w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                        h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                        if w > 0 and h > 0:
+                            self._dimensions = (w, h)
+                            return self._dimensions
+                finally:
                     cap.release()
-                    if w > 0 and h > 0:
-                        self._dimensions = (w, h)
-                        return self._dimensions
             elif self.asset_type == 'sequence':
                 files = self.get_frame_files()
                 if not files:
                     return None
                 first = os.path.join(self.path, files[0])
-                # Use cv2.imread with IMREAD_UNCHANGED to support EXR/PNG/TIFF.
+                # imread_unicode with IMREAD_UNCHANGED to support EXR/PNG/TIFF
+                # and non-ASCII paths.
                 import cv2
-                img = cv2.imread(first, cv2.IMREAD_UNCHANGED)
+                from .frame_io import imread_unicode
+                img = imread_unicode(first, cv2.IMREAD_UNCHANGED)
                 if img is not None:
                     h, w = img.shape[:2]
                     self._dimensions = (int(w), int(h))
@@ -168,10 +173,13 @@ class ClipAsset:
         elif self.asset_type == 'video':
             try:
                 import cv2
-                cap = cv2.VideoCapture(self.path)
-                if cap.isOpened():
-                    self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                cap.release()
+                from .frame_io import open_video
+                cap = open_video(self.path)
+                try:
+                    if cap.isOpened():
+                        self.frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                finally:
+                    cap.release()
             except Exception as e:
                 logger.debug(f"Video frame count detection failed for {self.path}: {e}")
                 self.frame_count = 0

--- a/backend/ffmpeg_tools/extraction.py
+++ b/backend/ffmpeg_tools/extraction.py
@@ -127,7 +127,8 @@ def _recompress_one_exr(args: tuple) -> bool:
         import numpy as np
         import OpenEXR
         import Imath
-        img = cv2.imread(src, cv2.IMREAD_UNCHANGED)
+        from backend.frame_io import imread_unicode
+        img = imread_unicode(src, cv2.IMREAD_UNCHANGED)
         if img is None:
             return False
         HALF = Imath.Channel(Imath.PixelType(Imath.PixelType.HALF))
@@ -232,7 +233,13 @@ def recompress_one(args):
     try:
         os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
         import cv2, numpy as np, OpenEXR, Imath
-        img = cv2.imread(src, cv2.IMREAD_UNCHANGED)
+        # Unicode-safe read: cv2.imread fails on non-ASCII paths on Windows.
+        # This standalone script cannot import the backend.frame_io facade, so
+        # the imdecode(np.fromfile(...)) pattern is inlined here.
+        try:
+            img = cv2.imdecode(np.fromfile(src, dtype=np.uint8), cv2.IMREAD_UNCHANGED)
+        except (OSError, ValueError):
+            img = None
         if img is None:
             return False
         HALF = Imath.Channel(Imath.PixelType(Imath.PixelType.HALF))

--- a/backend/frame_io.py
+++ b/backend/frame_io.py
@@ -10,8 +10,11 @@ _load_frames_for_videomama, _load_mask_frames_for_videomama).
 """
 from __future__ import annotations
 
+import atexit
 import logging
 import os
+import shutil
+import tempfile
 from typing import Callable, Optional
 
 # Enable OpenEXR support in OpenCV before cv2 is imported.
@@ -140,6 +143,133 @@ def write_exr_dwab(path: str, img: np.ndarray) -> bool:
     return write_exr(path, img, compression="dwab")
 
 
+def _is_ascii(path: str) -> bool:
+    """True if every character in the path is ASCII (safe for cv2's narrow API)."""
+    try:
+        path.encode("ascii")
+        return True
+    except UnicodeEncodeError:
+        return False
+
+
+def imread_unicode(path: str, flags: int = cv2.IMREAD_COLOR) -> Optional[np.ndarray]:
+    """Read an image from disk, safe for non-ASCII paths on Windows.
+
+    cv2.imread uses a narrow (ANSI codepage) file API on Windows and returns
+    None for any path containing characters outside that codepage (accented
+    Latin, Cyrillic, CJK, Arabic, etc.). ASCII paths take the original
+    cv2.imread route unchanged (byte-identical pixels, no extra read); non-ASCII
+    paths decode from an in-memory buffer read through numpy's unicode-aware
+    file API. cv2.imread and cv2.imdecode share the same codecs, so the decoded
+    array is identical for every format and flag combination.
+
+    Args:
+        path: Image file path. May contain any Unicode characters.
+        flags: cv2 IMREAD_* flags, forwarded verbatim to the decoder.
+
+    Returns:
+        Decoded ndarray, or None if the file is missing/unreadable/undecodable
+        (matching cv2.imread's None-on-failure contract).
+    """
+    if _is_ascii(path):
+        return cv2.imread(path, flags)
+    try:
+        data = np.fromfile(path, dtype=np.uint8)
+    except (OSError, ValueError):
+        return None
+    if data.size == 0:
+        return None
+    return cv2.imdecode(data, flags)
+
+
+# ── Unicode-safe video opening ──────────────────────────────────────────────
+# Some OpenCV builds open non-ASCII video paths fine (modern FFmpeg backend);
+# older builds fail. When the plain open fails we stage the file at an ASCII
+# path. Staged hardlinks/copies are deduped per source and cleaned at exit.
+_stage_dir: Optional[str] = None
+_staged: dict[str, str] = {}
+
+
+def _short_path_windows(path: str) -> Optional[str]:
+    """Return the Windows 8.3 short-path alias for an existing file, or None.
+
+    The 8.3 alias is pure ASCII, so cv2's narrow file API can open it. Only
+    available on Windows volumes with 8.3 generation enabled.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        get_short = ctypes.windll.kernel32.GetShortPathNameW
+        get_short.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+        get_short.restype = wintypes.DWORD
+        buf = ctypes.create_unicode_buffer(32768)
+        n = get_short(path, buf, len(buf))
+        if n and buf.value and _is_ascii(buf.value):
+            return buf.value
+    except Exception:
+        pass
+    return None
+
+
+def _cleanup_staged() -> None:
+    if _stage_dir and os.path.isdir(_stage_dir):
+        shutil.rmtree(_stage_dir, ignore_errors=True)
+
+
+def _stage_ascii(path: str) -> str:
+    """Stage a file at an ASCII temp path via hardlink (else copy); deduped.
+
+    Returns the staged ASCII path, or the original path if staging fails.
+    """
+    global _stage_dir
+    existing = _staged.get(path)
+    if existing and os.path.isfile(existing):
+        return existing
+    if _stage_dir is None:
+        _stage_dir = tempfile.mkdtemp(prefix="ck_uvid_")
+        atexit.register(_cleanup_staged)
+    dst = os.path.join(_stage_dir, f"v{len(_staged):04d}{os.path.splitext(path)[1]}")
+    try:
+        os.link(path, dst)  # cheap: no data copy on the same volume
+    except OSError:
+        try:
+            shutil.copy2(path, dst)
+        except OSError:
+            return path
+    _staged[path] = dst
+    return dst
+
+
+def open_video(path: str) -> cv2.VideoCapture:
+    """Open a video, safe for non-ASCII paths across all OpenCV builds.
+
+    Plain VideoCapture works for ASCII paths and for modern OpenCV builds whose
+    FFmpeg backend is wide-path aware. When it fails on a non-ASCII path (older
+    builds), fall back to a Windows 8.3 short-path alias, then to a
+    hardlink/copy at an ASCII temp path. Returns a normal VideoCapture, so
+    callers keep their existing isOpened()/release() handling unchanged.
+    """
+    cap = cv2.VideoCapture(path)
+    if cap.isOpened() or _is_ascii(path):
+        return cap
+    cap.release()
+
+    short = _short_path_windows(path)
+    if short and short != path:
+        cap = cv2.VideoCapture(short)
+        if cap.isOpened():
+            return cap
+        cap.release()
+
+    staged = _stage_ascii(path)
+    if staged != path:
+        return cv2.VideoCapture(staged)
+    return cv2.VideoCapture(path)
+
+
 def imwrite_unicode(path: str, img: np.ndarray, params: Optional[list] = None) -> bool:
     """Write an image to disk via cv2.imencode, safe for unicode paths.
 
@@ -183,7 +313,7 @@ def recompress_exr(src_path: str, dst_path: str, compression: str = "dwab") -> b
     Returns:
         True on success, False on failure.
     """
-    img = cv2.imread(src_path, cv2.IMREAD_UNCHANGED)
+    img = imread_unicode(src_path, cv2.IMREAD_UNCHANGED)
     if img is None:
         logger.warning(f"Failed to read EXR for recompression: {src_path}")
         return False
@@ -205,7 +335,7 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> Optional[np
     is_exr = fpath.lower().endswith('.exr')
 
     if is_exr:
-        img = cv2.imread(fpath, cv2.IMREAD_UNCHANGED)
+        img = imread_unicode(fpath, cv2.IMREAD_UNCHANGED)
         if img is None:
             return None
         # Strip alpha channel from BGRA EXR
@@ -217,7 +347,7 @@ def read_image_frame(fpath: str, gamma_correct_exr: bool = False) -> Optional[np
             result = _linear_to_srgb(result)
         return result
     else:
-        img = cv2.imread(fpath)
+        img = imread_unicode(fpath)
         if img is None:
             return None
         img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
@@ -236,7 +366,7 @@ def read_video_frame_at(
     Returns:
         float32 array [H, W, 3] in RGB order, or None if seek/read fails.
     """
-    cap = cv2.VideoCapture(video_path)
+    cap = open_video(video_path)
     try:
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
         ret, frame = cap.read()
@@ -264,7 +394,7 @@ def read_video_frames(
         List of processed frames.
     """
     frames: list[np.ndarray] = []
-    cap = cv2.VideoCapture(video_path)
+    cap = open_video(video_path)
     try:
         while True:
             ret, frame = cap.read()
@@ -293,7 +423,7 @@ def read_mask_frame(fpath: str, clip_name: str = "", frame_index: int = 0) -> Op
     Returns:
         float32 array [H, W] in [0, 1], or None if read fails.
     """
-    mask_in = cv2.imread(fpath, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED)
+    mask_in = imread_unicode(fpath, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED)
     if mask_in is None:
         return None
     # dtype normalization MUST happen before channel extraction, because
@@ -341,7 +471,7 @@ def read_video_mask_at(
     Returns:
         float32 array [H, W] in [0, 1], or None if seek/read fails.
     """
-    cap = cv2.VideoCapture(video_path)
+    cap = open_video(video_path)
     try:
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
         ret, frame = cap.read()

--- a/backend/service/frame_ops.py
+++ b/backend/service/frame_ops.py
@@ -18,6 +18,7 @@ from ..frame_io import (
     _linear_to_srgb,
     _srgb_to_linear,
     decode_video_mask_frame,
+    imread_unicode,
     read_video_frame_at,
     read_video_frames,
 )
@@ -235,7 +236,7 @@ class FrameOpsMixin:
             if not mask_files:
                 return None
             first_mask_path = os.path.join(clip.mask_asset.path, mask_files[0])
-            mask = cv2.imread(first_mask_path, cv2.IMREAD_GRAYSCALE)
+            mask = imread_unicode(first_mask_path, cv2.IMREAD_GRAYSCALE)
             if mask is None:
                 return None
             # Binarize
@@ -287,7 +288,7 @@ class FrameOpsMixin:
         masks = []
         for fname in asset.get_frame_files():
             fpath = os.path.join(asset.path, fname)
-            mask = cv2.imread(fpath, cv2.IMREAD_GRAYSCALE)
+            mask = imread_unicode(fpath, cv2.IMREAD_GRAYSCALE)
             if mask is None:
                 continue
             _, binary = cv2.threshold(mask, 10, 255, cv2.THRESH_BINARY)

--- a/backend/service/inference.py
+++ b/backend/service/inference.py
@@ -17,7 +17,7 @@ from ..errors import (
     JobCancelledError,
     WriteFailureError,
 )
-from ..frame_io import read_video_frame_at, read_video_mask_at
+from ..frame_io import open_video, read_video_frame_at, read_video_mask_at
 from ..job_queue import GPUJob
 from ..validators import ensure_output_dirs, validate_frame_counts
 from .inference_parallel import ParallelInferenceMixin
@@ -161,12 +161,12 @@ class InferenceMixin(ParallelInferenceMixin):
         alpha_files: list[str] = []
 
         if clip.input_asset.asset_type == 'video':
-            input_cap = cv2.VideoCapture(clip.input_asset.path)
+            input_cap = open_video(clip.input_asset.path)
         else:
             input_files = clip.input_asset.get_frame_files()
 
         if clip.alpha_asset.asset_type == 'video':
-            alpha_cap = cv2.VideoCapture(clip.alpha_asset.path)
+            alpha_cap = open_video(clip.alpha_asset.path)
         else:
             alpha_files = clip.alpha_asset.get_frame_files()
         alpha_stem_lookup = (

--- a/backend/service/inference_parallel.py
+++ b/backend/service/inference_parallel.py
@@ -16,6 +16,7 @@ from ..errors import (
     JobCancelledError,
     WriteFailureError,
 )
+from ..frame_io import open_video
 from ..job_queue import GPUJob
 from ..validators import ensure_output_dirs, validate_frame_counts
 
@@ -133,12 +134,12 @@ class ParallelInferenceMixin:
 
             try:
                 if clip.input_asset.asset_type == 'video':
-                    input_cap = cv2.VideoCapture(clip.input_asset.path)
+                    input_cap = open_video(clip.input_asset.path)
                 else:
                     input_files = clip.input_asset.get_frame_files()
 
                 if clip.alpha_asset.asset_type == 'video':
-                    alpha_cap = cv2.VideoCapture(clip.alpha_asset.path)
+                    alpha_cap = open_video(clip.alpha_asset.path)
                 else:
                     alpha_files = clip.alpha_asset.get_frame_files()
                 alpha_stem_lookup = (

--- a/backend/service/pipelines_auto.py
+++ b/backend/service/pipelines_auto.py
@@ -240,6 +240,7 @@ class AutoPipelinesMixin:
         import numpy as _np
         from concurrent.futures import ThreadPoolExecutor, Future
         from CorridorKeyModule.core.chroma_key import chroma_key_matte
+        from ..frame_io import imread_unicode as _imread, imwrite_unicode as _imwrite
 
         if clip.input_asset is None:
             raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for chroma key")
@@ -280,9 +281,9 @@ class AutoPipelinesMixin:
             fpath = os.path.join(input_dir, fname)
             is_exr = fname.lower().endswith(".exr")
             if is_exr:
-                bgr = _cv2.imread(fpath, _cv2.IMREAD_ANYCOLOR | _cv2.IMREAD_ANYDEPTH)
+                bgr = _imread(fpath, _cv2.IMREAD_ANYCOLOR | _cv2.IMREAD_ANYDEPTH)
             else:
-                bgr = _cv2.imread(fpath, _cv2.IMREAD_COLOR)
+                bgr = _imread(fpath, _cv2.IMREAD_COLOR)
             if bgr is None:
                 logger.warning(f"Chroma key: could not read {fpath}, skipping")
                 return fname, None
@@ -293,7 +294,7 @@ class AutoPipelinesMixin:
 
         # ── Write helper (runs in write ThreadPool) ──
         def _write_matte(out_path: str, matte: _np.ndarray) -> None:
-            _cv2.imwrite(out_path, matte)
+            _imwrite(out_path, matte)
 
         _PREFETCH = 4
         _WRITE_WORKERS = 4
@@ -390,6 +391,7 @@ class AutoPipelinesMixin:
         import cv2 as _cv2
         import numpy as _np
         from concurrent.futures import ThreadPoolExecutor, Future
+        from ..frame_io import imread_unicode as _imread, imwrite_unicode as _imwrite
 
         if clip.input_asset is None:
             raise CorridorKeyError(f"Clip '{clip.name}' missing input asset for Apple Vision")
@@ -423,9 +425,9 @@ class AutoPipelinesMixin:
             fpath = os.path.join(input_dir, fname)
             is_exr = fname.lower().endswith(".exr")
             if is_exr:
-                bgr = _cv2.imread(fpath, _cv2.IMREAD_ANYCOLOR | _cv2.IMREAD_ANYDEPTH)
+                bgr = _imread(fpath, _cv2.IMREAD_ANYCOLOR | _cv2.IMREAD_ANYDEPTH)
             else:
-                bgr = _cv2.imread(fpath, _cv2.IMREAD_COLOR)
+                bgr = _imread(fpath, _cv2.IMREAD_COLOR)
             if bgr is None:
                 logger.warning(f"Apple Vision: could not read {fpath}, skipping")
                 return fname, None
@@ -436,7 +438,7 @@ class AutoPipelinesMixin:
 
         # Write helper
         def _write_matte(out_path: str, matte: _np.ndarray) -> None:
-            _cv2.imwrite(out_path, matte)
+            _imwrite(out_path, matte)
 
         _PREFETCH = 4
         _WRITE_WORKERS = 4

--- a/backend/service/pipelines_guided.py
+++ b/backend/service/pipelines_guided.py
@@ -22,6 +22,7 @@ from ..errors import (
     JobCancelledError,
     WriteFailureError,
 )
+from ..frame_io import imread_unicode, imwrite_unicode
 from .helpers import BASE_DIR
 from .model_manager import _ActiveModel
 
@@ -159,7 +160,7 @@ class GuidedPipelinesMixin:
             stem = os.path.splitext(fname)[0]
             stems.append(stem)
             out_path = os.path.join(mask_dir, f"{stem}.png")
-            if not cv2.imwrite(out_path, mask):
+            if not imwrite_unicode(out_path, mask):
                 raise WriteFailureError(clip.name, len(stems) - 1, out_path)
 
         self._write_mask_track_manifest(
@@ -375,7 +376,7 @@ class GuidedPipelinesMixin:
             for i, fname in enumerate(mask_files):
                 _check_cancel("mask load")
                 fpath = os.path.join(clip.mask_asset.path, fname)
-                m = cv2.imread(fpath, cv2.IMREAD_GRAYSCALE)
+                m = imread_unicode(fpath, cv2.IMREAD_GRAYSCALE)
                 if m is not None:
                     _, binary = cv2.threshold(m, 10, 255, cv2.THRESH_BINARY)
                     stem = os.path.splitext(fname)[0]
@@ -456,7 +457,7 @@ class GuidedPipelinesMixin:
                 else:
                     out_name = f"frame_{frames_written:06d}.png"
                 out_path = os.path.join(alpha_dir, out_name)
-                if not cv2.imwrite(out_path, out_bgr):
+                if not imwrite_unicode(out_path, out_bgr):
                     raise WriteFailureError(clip.name, frames_written, out_path)
                 frames_written += 1
             logger.debug(f"Clip '{clip.name}' chunk {chunk_idx}: {len(chunk_output)} frames in {time.monotonic() - t_chunk:.3f}s")

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Release](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Release](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Sterne](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Lizenz](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Versión](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Versión](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Estrellas](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Licencia](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Version](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Version](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Étoiles](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Licence](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![रिलीज़](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![रिलीज़](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![स्टार](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![लाइसेंस](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.id.md
+++ b/docs/i18n/README.id.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Rilis](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Rilis](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Bintang](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Lisensi](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.it.md
+++ b/docs/i18n/README.it.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Release](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Release](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Stelle](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Licenza](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![リリース](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![リリース](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![スター](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![ライセンス](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![릴리스](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![릴리스](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![스타](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![라이선스](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.pl.md
+++ b/docs/i18n/README.pl.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Wydanie](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Wydanie](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Gwiazdki](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Licencja](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.pt.md
+++ b/docs/i18n/README.pt.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Lançamento](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Lançamento](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Estrelas](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Licença](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Релиз](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Релиз](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Звезды](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Лицензия](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Sürüm](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Sürüm](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Yıldızlar](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Lisans](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.vi.md
+++ b/docs/i18n/README.vi.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![Bản phát hành](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![Bản phát hành](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![Sao](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![Giấy phép](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -2,7 +2,7 @@
 
 # EZ-CorridorKey **v2.0.0**
 
-[![发布](https://img.shields.io/badge/Release-v2.1.0-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
+[![发布](https://img.shields.io/badge/Release-v2.1.1-FFF203?style=flat-square&labelColor=141300)](https://github.com/edenaion/EZ-CorridorKey/releases/latest)
 [![星标](https://img.shields.io/github/stars/edenaion/EZ-CorridorKey?style=flat-square&labelColor=141300&color=FFF203)](https://github.com/edenaion/EZ-CorridorKey/stargazers)
 [![许可证](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-FFF203?style=flat-square&labelColor=141300)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 [![Discord](https://img.shields.io/badge/Discord-EZSCAPE-5865F2?style=flat-square&labelColor=000000&logo=discord&logoColor=50FF80)](https://discord.gg/TyxNjcWeF3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "corridorkey"
-version = "2.1.0"
+version = "2.1.1"
 description = "AI Chroma Keyer by Corridor Digital"
 license = {text = "CC-BY-NC-SA-4.0"}
 requires-python = ">=3.10,<3.14"

--- a/tests/test_frame_io.py
+++ b/tests/test_frame_io.py
@@ -113,6 +113,9 @@ class TestVideoMaskRead:
             def __init__(self, path):
                 self.path = path
 
+            def isOpened(self):
+                return True
+
             def set(self, *_args):
                 return True
 

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -1,0 +1,109 @@
+"""Tests for first-run language detection persisting to preferences (#168).
+
+On first launch with no saved preference, apply_language detects the system
+language and applies it. It must also persist the effective language so the
+Preferences dropdown reflects what is actually active, instead of defaulting
+to English while the UI is in another language.
+"""
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PySide6", reason="PySide6 not installed")
+
+from PySide6.QtCore import QCoreApplication, QLocale, QSettings
+from PySide6.QtWidgets import QApplication
+
+from ui.app import apply_language
+
+
+class _FakeLocale:
+    """Stand-in for QLocale.system() with a controlled name()."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+
+@pytest.fixture
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+    # Remove any translator these tests installed. The QApplication is a
+    # process-wide singleton, so a leaked non-English translator would make
+    # later tests that assert on English strings (tooltips, labels) fail.
+    tr = getattr(app, "_corridorkey_translator", None)
+    if tr is not None:
+        app.removeTranslator(tr)
+        app._corridorkey_translator = None
+
+
+@pytest.fixture
+def isolated_settings():
+    """Route QSettings to a throwaway org/app store, restored afterwards."""
+    prev_org = QCoreApplication.organizationName()
+    prev_app = QCoreApplication.applicationName()
+    QCoreApplication.setOrganizationName("EZSCAPE-test")
+    QCoreApplication.setApplicationName("CK-langtest")
+    s = QSettings()
+    s.clear()
+    s.sync()
+    yield s
+    s.clear()
+    s.sync()
+    QCoreApplication.setOrganizationName(prev_org)
+    QCoreApplication.setApplicationName(prev_app)
+
+
+def _fake_system(monkeypatch, name: str):
+    monkeypatch.setattr(QLocale, "system", staticmethod(lambda: _FakeLocale(name)))
+
+
+def test_first_run_persists_detected_system_language(qapp, isolated_settings, monkeypatch):
+    _fake_system(monkeypatch, "ru_RU")
+    assert isolated_settings.value("ui/language", "", type=str) == ""
+
+    assert apply_language(qapp) is True
+
+    assert isolated_settings.value("ui/language", "", type=str) == "ru"
+
+
+def test_first_run_unsupported_language_persists_english(qapp, isolated_settings, monkeypatch):
+    _fake_system(monkeypatch, "zz_ZZ")  # no catalogue ships for this
+
+    apply_language(qapp)
+
+    assert isolated_settings.value("ui/language", "", type=str) == "en"
+
+
+def test_first_run_english_system_persists_english(qapp, isolated_settings, monkeypatch):
+    _fake_system(monkeypatch, "en_US")
+
+    assert apply_language(qapp) is True
+
+    assert isolated_settings.value("ui/language", "", type=str) == "en"
+
+
+def test_saved_preference_is_not_overwritten_by_system(qapp, isolated_settings, monkeypatch):
+    isolated_settings.setValue("ui/language", "en")
+    isolated_settings.sync()
+    _fake_system(monkeypatch, "ru_RU")
+
+    apply_language(qapp)
+
+    # Saved English preference must win over a Russian system locale.
+    assert isolated_settings.value("ui/language", "", type=str) == "en"
+
+
+def test_explicit_language_argument_does_not_persist(qapp, isolated_settings, monkeypatch):
+    _fake_system(monkeypatch, "ru_RU")
+
+    # Preferences passes an explicit code; apply_language must not write it
+    # (the Preferences dialog stores its own value).
+    apply_language(qapp, "fr")
+
+    assert isolated_settings.value("ui/language", "", type=str) == ""

--- a/tests/test_main_window_color_space.py
+++ b/tests/test_main_window_color_space.py
@@ -211,6 +211,9 @@ def test_import_alpha_video_as_sequence_writes_pngs_named_like_input_frames(tmp_
         def __init__(self, _path):
             self._index = 0
 
+        def isOpened(self):
+            return True
+
         def read(self):
             if self._index >= len(frames):
                 return False, None

--- a/tests/test_no_raw_cv2_file_io.py
+++ b/tests/test_no_raw_cv2_file_io.py
@@ -1,0 +1,80 @@
+"""Guard: no raw cv2 file I/O outside the unicode-safe facade.
+
+cv2.imread / cv2.imwrite / cv2.VideoCapture / cv2.VideoWriter use a narrow
+(ANSI codepage) file API on Windows and silently fail on non-ASCII paths. All
+image/video disk access must route through backend.frame_io (imread_unicode,
+imwrite_unicode, open_video). This test parses the AST of every module under
+backend/ and ui/ and fails if any raw cv2 file call survives, so the fix can
+never silently regress when new code is added.
+
+AST parsing (not text grep) means cv2 calls inside comments, docstrings, or
+string literals are correctly ignored.
+"""
+import ast
+import os
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCAN_DIRS = ["backend", "ui"]
+
+# cv2 functions that take a filesystem path and break on non-ASCII paths.
+BANNED_ATTRS = {"imread", "imwrite", "VideoCapture", "VideoWriter"}
+
+# The facade itself is the single allowed home for raw cv2 file calls.
+ALLOWED_FILES = {os.path.normpath("backend/frame_io.py")}
+
+
+def _python_files():
+    for scan in SCAN_DIRS:
+        base = os.path.join(REPO_ROOT, scan)
+        for root, dirs, files in os.walk(base):
+            dirs[:] = [d for d in dirs if d not in ("__pycache__", "_BACKUPS")]
+            for fname in files:
+                if fname.endswith(".py"):
+                    yield os.path.join(root, fname)
+
+
+def _cv2_aliases(tree: ast.AST) -> set[str]:
+    """Collect every local name bound to the cv2 module in a parsed file."""
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "cv2":
+                    aliases.add(alias.asname or "cv2")
+    return aliases
+
+
+def _violations_in(path: str) -> list[tuple[int, str]]:
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=path)
+    aliases = _cv2_aliases(tree)
+    if not aliases:
+        return []
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in BANNED_ATTRS
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in aliases
+        ):
+            hits.append((node.lineno, f"{node.func.value.id}.{node.func.attr}"))
+    return hits
+
+
+def test_no_raw_cv2_file_io():
+    offenders: list[str] = []
+    for path in _python_files():
+        rel = os.path.normpath(os.path.relpath(path, REPO_ROOT))
+        if rel in ALLOWED_FILES:
+            continue
+        for lineno, call in _violations_in(path):
+            offenders.append(f"{rel}:{lineno}  {call}(...)")
+    assert not offenders, (
+        "Raw cv2 file I/O found outside backend/frame_io. Route these through "
+        "imread_unicode / imwrite_unicode / open_video so non-ASCII paths work:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_unicode_paths.py
+++ b/tests/test_unicode_paths.py
@@ -1,0 +1,143 @@
+"""Round-trip tests for the unicode-safe media I/O facade.
+
+cv2.imread / cv2.imwrite use a narrow (ANSI codepage) file API on Windows and
+fail on any path containing characters outside that codepage. The facade
+(backend.frame_io.imread_unicode / imwrite_unicode / open_video) routes ASCII
+paths to the original cv2 calls (byte-identical) and non-ASCII paths through an
+in-memory buffer. These tests assert correctness across the scripts used by the
+14 shipped UI languages plus a few extra edge cases (RTL, emoji, spaces).
+"""
+import os
+import shutil
+import tempfile
+
+os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
+
+import cv2
+import numpy as np
+import pytest
+
+from backend.frame_io import imread_unicode, imwrite_unicode, open_video
+
+# One sample folder/file name per script we must support. Keyed by a readable
+# label; the value lands in both a directory name and a file stem so both the
+# parent path and the leaf are exercised.
+SCRIPT_SAMPLES = {
+    "spanish": "niña_corazón",
+    "french": "café_éàü",
+    "german": "Grüße_Straße_öä",
+    "portuguese": "ação_são",
+    "russian": "Свадебное_цветное",
+    "ukrainian": "Привіт_їжак",
+    "chinese": "婚礼_视频",
+    "japanese": "日本語のフレーム",
+    "korean": "결혼식_영상",
+    "arabic": "حفل_زفاف",
+    "hindi": "नमस्ते_फ्रेम",
+    "thai": "งานแต่งงาน",
+    "spaces": "my project name",
+    "emoji": "wedding_🎬_clip",
+}
+
+
+@pytest.fixture
+def workdir():
+    d = tempfile.mkdtemp(prefix="ck_unicode_test_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _nested(workdir: str, name: str, ext: str) -> str:
+    """Build a non-ASCII directory + non-ASCII file stem path."""
+    sub = os.path.join(workdir, name)
+    os.makedirs(sub, exist_ok=True)
+    return os.path.join(sub, f"{name}{ext}")
+
+
+@pytest.mark.parametrize("label,name", list(SCRIPT_SAMPLES.items()))
+def test_ldr_png_roundtrip(workdir, label, name):
+    """8-bit BGR PNG round-trips byte-exact through a non-ASCII path."""
+    img = (np.random.rand(8, 8, 3) * 255).astype(np.uint8)
+    path = _nested(workdir, name, ".png")
+    assert imwrite_unicode(path, img), f"write failed for {label}"
+    assert os.path.isfile(path)
+    got = imread_unicode(path, cv2.IMREAD_COLOR)
+    assert got is not None, f"read returned None for {label}"
+    assert np.array_equal(got, img), f"pixels differ for {label}"
+
+
+@pytest.mark.parametrize("label,name", list(SCRIPT_SAMPLES.items()))
+def test_exr_float_roundtrip(workdir, label, name):
+    """Half-float EXR (the app's primary format) preserves values > 1.0."""
+    img = np.random.rand(8, 8, 3).astype(np.float32)
+    img[0, 0] = [5.0, 0.5, 1234.0]  # values > 1 must survive (no clamp to uint8)
+    path = _nested(workdir, name, ".exr")
+    ok = imwrite_unicode(
+        path, img, [cv2.IMWRITE_EXR_TYPE, cv2.IMWRITE_EXR_TYPE_HALF]
+    )
+    assert ok, f"EXR write failed for {label}"
+    got = imread_unicode(path, cv2.IMREAD_UNCHANGED)
+    assert got is not None, f"EXR read returned None for {label}"
+    assert got.dtype == np.float32, f"EXR dtype not float for {label}"
+    # Half precision: compare with a tolerance that fits float16 rounding.
+    assert got[0, 0, 0] == pytest.approx(5.0, rel=1e-2)
+    assert got[0, 0, 2] == pytest.approx(1234.0, rel=1e-2)
+
+
+@pytest.mark.parametrize("label,name", list(SCRIPT_SAMPLES.items()))
+def test_16bit_png_mask_roundtrip(workdir, label, name):
+    """16-bit PNG mattes keep uint16 precision through a non-ASCII path."""
+    mask = (np.random.rand(8, 8) * 65535).astype(np.uint16)
+    path = _nested(workdir, name, ".png")
+    assert imwrite_unicode(path, mask)
+    got = imread_unicode(path, cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED)
+    assert got is not None and got.dtype == np.uint16
+    assert np.array_equal(got, mask), f"16-bit mask differs for {label}"
+
+
+def test_ascii_fast_path_identical_to_cv2(workdir):
+    """ASCII paths must produce byte-identical results to raw cv2.imread."""
+    img = (np.random.rand(16, 16, 3) * 255).astype(np.uint8)
+    path = os.path.join(workdir, "ascii_frame.png")
+    imwrite_unicode(path, img)
+    assert np.array_equal(
+        imread_unicode(path, cv2.IMREAD_COLOR),
+        cv2.imread(path, cv2.IMREAD_COLOR),
+    )
+
+
+def test_missing_file_returns_none(workdir):
+    """Matches cv2.imread's None-on-failure contract for missing files."""
+    assert imread_unicode(os.path.join(workdir, "Свадебное_missing.png")) is None
+    assert imread_unicode(os.path.join(workdir, "ascii_missing.png")) is None
+
+
+@pytest.mark.parametrize("label,name", list(SCRIPT_SAMPLES.items()))
+def test_open_video_non_ascii(workdir, label, name):
+    """open_video can read a frame from a video at a non-ASCII path.
+
+    Generates a tiny clip via cv2.VideoWriter at an ASCII temp path (writers
+    have the same narrow-path limitation), then copies it to the non-ASCII path
+    under test and opens it through the facade.
+    """
+    ascii_src = os.path.join(workdir, "src.mp4")
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(ascii_src, fourcc, 10.0, (32, 32))
+    if not writer.isOpened():
+        pytest.skip("cv2.VideoWriter unavailable in this build")
+    for _ in range(5):
+        writer.write((np.random.rand(32, 32, 3) * 255).astype(np.uint8))
+    writer.release()
+    if not os.path.isfile(ascii_src) or os.path.getsize(ascii_src) == 0:
+        pytest.skip("video encoding produced no file")
+
+    dst = _nested(workdir, name, ".mp4")
+    shutil.copy2(ascii_src, dst)
+    cap = open_video(dst)
+    try:
+        assert cap.isOpened(), f"open_video failed for {label}"
+        ret, frame = cap.read()
+        assert ret and frame is not None, f"frame read failed for {label}"
+        assert frame.shape == (32, 32, 3)
+    finally:
+        cap.release()

--- a/ui/app.py
+++ b/ui/app.py
@@ -143,11 +143,22 @@ def apply_language(app: QApplication, lang: str | None = None) -> bool:
     """
     from PySide6.QtCore import QSettings
 
+    settings = QSettings()
+    auto_resolved = False
     if lang is None:
-        settings = QSettings()
         lang = settings.value("ui/language", "", type=str)
         if not lang:
+            # First run, no saved preference: detect the system language and
+            # persist whatever ends up applied, so the Preferences dropdown
+            # reflects the active language instead of defaulting to English
+            # (issue #168). Only the auto path persists; explicit calls from
+            # Preferences store their own value.
             lang = QLocale.system().name().split("_")[0]  # e.g. "fr" from "fr_FR"
+            auto_resolved = True
+
+    def _persist(effective: str) -> None:
+        if auto_resolved:
+            settings.setValue("ui/language", effective)
 
     # Drop the active translator (no-op on startup)
     old = getattr(app, "_corridorkey_translator", None)
@@ -156,6 +167,7 @@ def apply_language(app: QApplication, lang: str | None = None) -> bool:
         app._corridorkey_translator = None
 
     if lang == "en":
+        _persist("en")
         return True  # English is the source language, no translation needed
 
     if getattr(sys, "frozen", False):
@@ -166,6 +178,7 @@ def apply_language(app: QApplication, lang: str | None = None) -> bool:
     qm_file = os.path.join(translations_dir, f"corridorkey_{lang}.qm")
     if not os.path.isfile(qm_file):
         logger.debug("No translation file for '%s' at %s", lang, qm_file)
+        _persist("en")  # unsupported system language; UI stays English
         return False
 
     translator = QTranslator(app)
@@ -174,8 +187,10 @@ def apply_language(app: QApplication, lang: str | None = None) -> bool:
         # Store ref on app to prevent garbage collection
         app._corridorkey_translator = translator
         logger.info("Loaded translation: %s", lang)
+        _persist(lang)
         return True
     logger.warning("Failed to load translation file: %s", qm_file)
+    _persist("en")  # load failed; UI is English
     return False
 
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -41,6 +41,7 @@ from backend import (
     PipelineRoute, classify_pipeline_route, mask_sequence_is_videomama_ready,
 )
 from backend.project import VIDEO_FILE_FILTER, is_video_file
+from backend.frame_io import open_video, imwrite_unicode
 
 from ui.models.clip_model import ClipListModel
 from ui.preview.frame_index import ViewMode
@@ -146,7 +147,7 @@ def _import_alpha_video_as_sequence(
 ) -> int:
     """Decode an alpha video into AlphaHint/*.png named to match input stems."""
     os.makedirs(alpha_dir, exist_ok=True)
-    cap = cv2.VideoCapture(video_path)
+    cap = open_video(video_path)
     imported_count = 0
     try:
         for input_name in input_files:
@@ -163,7 +164,7 @@ def _import_alpha_video_as_sequence(
                 mask_u8 = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             if mask_u8.dtype != np.uint8:
                 mask_u8 = (np.clip(mask_u8, 0.0, 1.0) * 255.0).astype(np.uint8)
-            if cv2.imwrite(dst_path, mask_u8):
+            if imwrite_unicode(dst_path, mask_u8):
                 imported_count += 1
             else:
                 logger.warning("Failed to write imported alpha video frame: %s", dst_path)

--- a/ui/main_window_mixins/alpha_import_mixin.py
+++ b/ui/main_window_mixins/alpha_import_mixin.py
@@ -15,6 +15,7 @@ from . import _tr
 
 from backend import ClipAsset, ClipState
 from backend.project import VIDEO_FILE_FILTER, is_video_file
+from backend.frame_io import imread_unicode, imwrite_unicode
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,7 @@ class AlphaImportMixin:
 
                     if not import_as_vmama_mask and src_ext == ".exr":
                         # Preserve float EXR alpha hints instead of quantizing to PNG.
-                        img = cv2.imread(
+                        img = imread_unicode(
                             src_path,
                             cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED,
                         )
@@ -242,7 +243,7 @@ class AlphaImportMixin:
                         continue
 
                     if src_ext == ".exr":
-                        img = cv2.imread(
+                        img = imread_unicode(
                             src_path,
                             cv2.IMREAD_ANYDEPTH | cv2.IMREAD_UNCHANGED,
                         )
@@ -255,7 +256,7 @@ class AlphaImportMixin:
                                 )
                                 img = (img * 255.0).astype(np.uint8)
                     else:
-                        img = cv2.imread(src_path, cv2.IMREAD_GRAYSCALE)
+                        img = imread_unicode(src_path, cv2.IMREAD_GRAYSCALE)
                     if img is None:
                         logger.warning("Failed to import alpha image: %s", src_path)
                         continue
@@ -265,7 +266,7 @@ class AlphaImportMixin:
                     if import_as_vmama_mask:
                         _, img = cv2.threshold(img, 127, 255, cv2.THRESH_BINARY)
 
-                    if cv2.imwrite(dst_path, img):
+                    if imwrite_unicode(dst_path, img):
                         imported_count += 1
                     else:
                         logger.warning("Failed to write alpha image: %s", dst_path)

--- a/ui/main_window_mixins/chroma_key_mixin.py
+++ b/ui/main_window_mixins/chroma_key_mixin.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import QMessageBox
 from . import _tr
 
 from backend import ClipState, JobType
+from backend.frame_io import imread_unicode
 from ui.workers.job_helpers import create_job_snapshot
 
 logger = logging.getLogger(__name__)
@@ -162,11 +163,11 @@ class ChromaKeyMixin:
         # Read frame (handle EXR float data properly)
         is_exr = input_path.lower().endswith(".exr")
         if is_exr:
-            frame_bgr = cv2.imread(input_path, cv2.IMREAD_ANYCOLOR | cv2.IMREAD_ANYDEPTH)
+            frame_bgr = imread_unicode(input_path, cv2.IMREAD_ANYCOLOR | cv2.IMREAD_ANYDEPTH)
         else:
-            frame_bgr = cv2.imread(input_path, cv2.IMREAD_COLOR)
+            frame_bgr = imread_unicode(input_path, cv2.IMREAD_COLOR)
         if frame_bgr is None:
-            logger.warning(f"Chroma key preview: cv2.imread failed for {input_path}")
+            logger.warning(f"Chroma key preview: imread failed for {input_path}")
             return
         frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
         # EXR comes as float32 in 0-1 range; convert to uint8 for display

--- a/ui/preview/display_transform.py
+++ b/ui/preview/display_transform.py
@@ -24,6 +24,7 @@ import numpy as np
 from PySide6.QtGui import QImage
 
 from .frame_index import ViewMode
+from backend.frame_io import imread_unicode, open_video
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ def _decode_ldr(
     input_exr_is_linear: bool = False,
 ) -> QImage | None:
     """Decode an 8-bit image (PNG/JPG/etc) to QImage."""
-    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    img = imread_unicode(path, cv2.IMREAD_COLOR)
     if img is None:
         return None
     if mode == ViewMode.INPUT and input_exr_is_linear:
@@ -119,7 +120,7 @@ def _decode_ldr(
 
 def _decode_exr(path: str, mode: ViewMode, *, input_exr_is_linear: bool = False) -> QImage | None:
     """Decode an EXR file with mode-specific display transform."""
-    img = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+    img = imread_unicode(path, cv2.IMREAD_UNCHANGED)
     if img is None:
         return None
 
@@ -269,7 +270,7 @@ def decode_video_frame(
             return _QIMAGE_CACHE[key]
 
     try:
-        cap = cv2.VideoCapture(video_path)
+        cap = open_video(video_path)
         if not cap.isOpened():
             return None
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)

--- a/ui/preview/frame_index.py
+++ b/ui/preview/frame_index.py
@@ -195,20 +195,33 @@ def build_frame_index(
     # Build ordered stem list using natural sort
     index.stems = natsorted(list(all_stems))
 
-    # For video input with no image stems, generate stems from frame count
+    # For video input with no image stems, generate stems from frame count.
+    # ffprobe first (unicode-safe via subprocess argv, no VideoCapture needed);
+    # fall back to the unicode-safe video opener if ffprobe yields nothing
+    # (some containers like mkv/webm omit nb_frames).
     if ViewMode.INPUT in index.video_modes and not index.stems:
         vpath = index.video_modes[ViewMode.INPUT]
+        count = 0
         try:
-            import cv2
-            cap = cv2.VideoCapture(vpath)
-            if cap.isOpened():
-                count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                cap.release()
-                if count > 0:
-                    # Generate synthetic stem names for video-only clips
-                    index.stems = [f"frame_{i:06d}" for i in range(count)]
+            from backend.ffmpeg_tools.probe import probe_video
+            count = int(probe_video(vpath).get("frame_count", 0) or 0)
         except Exception:
-            pass
+            count = 0
+        if count <= 0:
+            try:
+                import cv2
+                from backend.frame_io import open_video
+                cap = open_video(vpath)
+                try:
+                    if cap.isOpened():
+                        count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                finally:
+                    cap.release()
+            except Exception:
+                count = 0
+        if count > 0:
+            # Generate synthetic stem names for video-only clips
+            index.stems = [f"frame_{i:06d}" for i in range(count)]
 
     # For video input, mark all stems as available (seekable)
     if ViewMode.INPUT in index.video_modes:

--- a/ui/widgets/annotation_overlay.py
+++ b/ui/widgets/annotation_overlay.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 import cv2
 import numpy as np
 
+from backend.frame_io import imwrite_unicode
+
 from PySide6.QtCore import Qt, QPointF, QRectF
 from PySide6.QtGui import QPainter, QPen, QColor
 
@@ -189,7 +191,7 @@ class AnnotationModel:
                 mask = np.zeros((height, width), dtype=np.uint8)
 
             out_path = os.path.join(mask_dir, f"{stem}.png")
-            cv2.imwrite(out_path, mask)
+            imwrite_unicode(out_path, mask)
 
         logger.info(
             f"Exported {len(frame_stems)} mask frames to {mask_dir} "

--- a/ui/workers/gpu_job_worker.py
+++ b/ui/workers/gpu_job_worker.py
@@ -35,6 +35,7 @@ from backend import (
     JobType,
 )
 from backend.job_queue import JobStatus
+from backend.frame_io import imread_unicode, imwrite_unicode
 from backend.errors import JobCancelledError, CorridorKeyError
 
 # Re-export create_job_snapshot for backward compatibility
@@ -559,7 +560,7 @@ class GPUJobWorker(QThread):
                 return
 
             latest = os.path.join(comp_dir, comp_files[-1])
-            img = cv2.imread(latest)
+            img = imread_unicode(latest)
             if img is None:
                 return
 
@@ -570,7 +571,7 @@ class GPUJobWorker(QThread):
                 img = cv2.resize(img, (960, int(h * scale)), interpolation=cv2.INTER_AREA)
 
             preview_path = os.path.join(self._preview_dir, f"preview_{job_id}.png")
-            cv2.imwrite(preview_path, img)
+            imwrite_unicode(preview_path, img)
 
             self.preview_ready.emit(job_id, clip.name, frame_index, preview_path)
         except Exception as e:


### PR DESCRIPTION
Patch release rolling up two reported bugs.

## ☼ #167 Non-ASCII project paths

Projects whose folder name contains Cyrillic, CJK, Arabic, Hindi, or accented Latin characters showed blank input/output previews and produced no output. OpenCV's `cv2.imread`/`cv2.imwrite` use a narrow (ANSI codepage) file API on Windows and fail on any path outside that codepage.

☼ New unicode-safe media I/O facade in `backend/frame_io.py`: `imread_unicode` (`cv2.imdecode` over `np.fromfile`) and `open_video` (plain capture, then Windows 8.3 short-path, then ASCII hardlink/copy), alongside the existing `imwrite_unicode`.
☼ All 61 image and video disk calls across `backend/` and `ui/` route through the facade. ASCII paths keep the original `cv2` calls, so output is byte-identical for existing projects.
☼ Video frame counts now resolve via ffprobe with an `open_video` fallback. Two `VideoCapture` handle leaks in clip probing fixed.
☼ Proven byte-exact for the app's primary EXR half-float format, 16-bit PNG mattes, and 8-bit LDR.

## ☼ #168 First-run language

When the app detected the system language on first launch (for example Russian), the interface switched but the Preferences dropdown still showed English, and detection re-ran on every launch.

☼ `apply_language` now persists the effective language on the first-run auto-detect path. Explicit choices from Preferences are never overwritten.

## ☼ Tests

☼ AST guard test fails the build if any raw `cv2.imread`/`imwrite`/`VideoCapture` appears outside the facade.
☼ Round-trip test across 14 UI-language scripts (EXR, 16-bit PNG, LDR, video).
☼ Language detection tests: detect-and-persist, unsupported-locale fallback, saved-preference precedence.
☼ Full suite: 687 passed, 2 skipped.

Version bumped to 2.1.1 (pyproject, README, 14 i18n badges, CHANGELOG). About dialog reads the version at runtime.