### PR TITLE
fix: pin opencv-python-headless <5 to keep OpenEXR support (#180)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "torch==2.9.1",
     "torchvision==0.24.1",
     "numpy",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.10,<5",  # 5.0 wheels dropped OpenEXR (#180)
     "OpenEXR>=3.4",
     "timm==1.0.24",
     "av",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 torch==2.9.1
 torchvision==0.24.1
 numpy
-opencv-python-headless
+# Pinned <5: opencv 5.0 wheels dropped OpenEXR support, breaking all EXR frame reads (#180)
+opencv-python-headless>=4.10,<5
 OpenEXR>=3.4
 timm==1.0.24
 av


### PR DESCRIPTION
## Problem

opencv-python-headless 5.0.0.93 (released 2026-07-02) ships wheels built without OpenEXR (`cv2.getBuildInformation()` reports `OpenEXR: NO`). `cv2.imread` returns None for every EXR file, even with `OPENCV_IO_ENABLE_OPENEXR=1`. Since all extracted frames are stored as EXR, any fresh source install from 2026-07-02 onward fails with `failed to read frame` on preview and every inference job.

Fixes #180.

## Fix

☼ Pin `opencv-python-headless>=4.10,<5` in requirements.txt and pyproject.toml (4.13.0.92 is the last wheel with OpenEXR built in)

## Recovery for affected installs

Running 3-update.bat / 3-update.sh after this merge pulls the pin and the dependency step downgrades opencv automatically. Frozen .exe installs bundle 4.13 and were never affected.

## Verification

Reproduced in a scratch venv: 5.0.0.93 fails to read both DWAB and ZIP16 EXR (returns None); 4.13.0.92 reads both correctly.