### PR TITLE
Fix #184: pin verified FFmpeg build and validate extracted frames

### DIFF
--- a/backend/ffmpeg_tools/discovery.py
+++ b/backend/ffmpeg_tools/discovery.py
@@ -5,7 +5,6 @@ and provides repair/install functionality per platform.
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
@@ -28,92 +27,47 @@ _LOCAL_FFMPEG_BIN = os.path.join(_REPO_ROOT, "tools", "ffmpeg", "bin")
 
 # Repair pulls a Windows build from BtbN/FFmpeg-Builds. We deliberately avoid the
 # "master" nightly: nightlies remove deprecated options (the -vsync removal broke
-# imports in issue #175). BtbN ships stable n-builds in the same rolling release,
-# e.g. ffmpeg-n8.1-latest-win64-gpl-8.1.zip. We resolve the newest stable n-build
-# from the releases API, and fall back to a fixed ordered list if the API is
-# unreachable (rate-limited, offline, etc.).
-_BTBN_LATEST_API = "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest"
-_BTBN_DOWNLOAD_BASE = (
-    "https://github.com/BtbN/FFmpeg-Builds/releases/latest/download/"
+# imports in issue #175).
+#
+# PINNED to an exact dated autobuild, never a rolling tag. The rolling
+# "latest" stable asset burned us in issue #184: FFmpeg release/8.1 picked up
+# a vf_scale_cuda/hwcontext_cuda rework on 2026-06-29 (post n8.1.2 tag) with a
+# race that corrupts random frames when decoding with -hwaccel cuda (invalid
+# zlib chunks inside ZIP16 EXR output). Every BtbN rolling build from
+# 2026-06-30 onward ships it. The dated autobuild release below is immutable
+# and contains the tag-exact n8.1.2 build, verified clean against the issue
+# #184 reproduction clip.
+#
+# When bumping this pin: extract a known clip with -hwaccel cuda and verify
+# every EXR frame reads back (see issue #184), then update both constants AND
+# _KNOWN_BAD_BUILD_RE below.
+_BTBN_PINNED_ASSET = "ffmpeg-n8.1.2-win64-gpl-8.1.zip"
+_BTBN_PINNED_URL = (
+    "https://github.com/BtbN/FFmpeg-Builds/releases/download/"
+    "autobuild-2026-06-27-13-21/" + _BTBN_PINNED_ASSET
 )
-# Stable win64 gpl asset, e.g. "ffmpeg-n8.1-latest-win64-gpl-8.1.zip".
-# Excludes master, -shared, lgpl, win32 and winarm64 by construction.
-_BTBN_STABLE_ASSET_RE = re.compile(
-    r"^ffmpeg-n(?P<ver>\d+(?:\.\d+)*)-latest-win64-gpl-(?P<ver2>\d+(?:\.\d+)*)\.zip$"
-)
-# Ordered fallback (newest first) used only when the API call fails.
-_BTBN_FALLBACK_ASSETS = (
-    "ffmpeg-n8.1-latest-win64-gpl-8.1.zip",
-    "ffmpeg-n7.1-latest-win64-gpl-7.1.zip",
-)
 
-
-def _version_tuple(ver: str) -> tuple[int, ...]:
-    """Parse a dotted version like '8.1' or '10.0' into an int tuple for sorting.
-
-    String sorting would rank 'n8.1' above 'n10.0'; numeric tuples fix that.
-    """
-    parts: list[int] = []
-    for piece in ver.split("."):
-        try:
-            parts.append(int(piece))
-        except ValueError:
-            parts.append(0)
-    return tuple(parts)
-
-
-def _select_stable_btbn_asset(assets: list[dict]) -> tuple[str, str] | None:
-    """Pick the newest stable win64-gpl asset from a BtbN release 'assets' list.
-
-    Returns (asset_name, download_url) for the highest version, or None if no
-    stable asset matches.
-    """
-    candidates: list[tuple[tuple[int, ...], str, str]] = []
-    for asset in assets:
-        name = asset.get("name", "")
-        match = _BTBN_STABLE_ASSET_RE.match(name)
-        if not match:
-            continue
-        url = asset.get("browser_download_url")
-        if not url:
-            continue
-        candidates.append((_version_tuple(match.group("ver")), name, url))
-    if not candidates:
-        return None
-    candidates.sort(key=lambda c: c[0])
-    _, name, url = candidates[-1]
-    return name, url
+# Installed builds known to corrupt EXR frames (issue #184): any post-tag
+# n8.1.2 rolling build (suffix "-N-g<hash>") carries the 2026-06-29 CUDA
+# commits. Tag-exact n8.1.2 builds do not match. Deliberately conservative:
+# even if upstream later fixes the race on release/8.1, a post-tag rolling
+# build remains unverifiable by us — users get pointed at Repair, which
+# installs the pinned verified build. Revisit alongside the pin above.
+_KNOWN_BAD_BUILD_RE = re.compile(r"\bn8\.1\.2-\d+-g[0-9a-f]+", re.IGNORECASE)
 
 
 def _resolve_windows_ffmpeg_asset(
     ssl_ctx: ssl.SSLContext | None,
 ) -> tuple[str, str]:
-    """Resolve (asset_name, download_url) for the newest stable BtbN n-build.
+    """Return (asset_name, download_url) for the pinned verified BtbN build.
 
-    Queries the BtbN releases API; on any failure, falls back to the first entry
-    in the fixed ordered list pointed at releases/latest/download/.
+    Always the immutable dated autobuild pinned above — never a rolling
+    "latest" tag, whose contents change under us (issue #184 frame
+    corruption). The ssl_ctx parameter is kept for signature compatibility
+    with the download step.
     """
-    try:
-        req = urllib.request.Request(
-            _BTBN_LATEST_API, headers={"User-Agent": "CorridorKey"}
-        )
-        with urllib.request.urlopen(req, timeout=30, context=ssl_ctx) as resp:
-            release = json.loads(resp.read().decode("utf-8"))
-        picked = _select_stable_btbn_asset(release.get("assets", []))
-        if picked:
-            logger.info("Repair FFmpeg: selected stable BtbN asset %s", picked[0])
-            return picked
-        logger.warning(
-            "Repair FFmpeg: no stable n-build asset found in BtbN latest release; "
-            "using fallback."
-        )
-    except Exception as exc:
-        logger.warning(
-            "Repair FFmpeg: BtbN releases API lookup failed (%s); using fallback.",
-            exc,
-        )
-    name = _BTBN_FALLBACK_ASSETS[0]
-    return name, _BTBN_DOWNLOAD_BASE + name
+    logger.info("Repair FFmpeg: using pinned verified build %s", _BTBN_PINNED_ASSET)
+    return _BTBN_PINNED_ASSET, _BTBN_PINNED_URL
 
 # QSettings key for user-configured FFmpeg directory
 _QSETTINGS_FFMPEG_DIR = "tools/ffmpeg_custom_dir"
@@ -233,6 +187,9 @@ class FFmpegValidationResult:
     ffprobe_path: str | None = None
     ffmpeg_version: FFmpegVersionInfo | None = None
     ffprobe_version: FFmpegVersionInfo | None = None
+    # True when the installed build is on the known frame-corruption list
+    # (issue #184) — the UI shows a dedicated "run Repair FFmpeg" warning.
+    known_bad: bool = False
 
 
 def _local_ffmpeg_binary(name: str) -> str | None:
@@ -366,6 +323,21 @@ def validate_ffmpeg_install(require_probe: bool = True) -> FFmpegValidationResul
             ffmpeg_path=ffmpeg,
             ffprobe_path=ffprobe,
             ffmpeg_version=ffmpeg_version,
+        )
+
+    if _KNOWN_BAD_BUILD_RE.search(ffmpeg_version.first_line):
+        return FFmpegValidationResult(
+            ok=False,
+            message=(
+                "This FFmpeg build has a known frame-corruption bug with "
+                "NVIDIA hardware decoding (random frames written as unreadable "
+                f"EXR files). Detected {ffmpeg_version.first_line}. "
+                "Run Repair FFmpeg to install a verified build."
+            ),
+            ffmpeg_path=ffmpeg,
+            ffprobe_path=ffprobe,
+            ffmpeg_version=ffmpeg_version,
+            known_bad=True,
         )
 
     ffprobe_version: FFmpegVersionInfo | None = None

--- a/backend/ffmpeg_tools/discovery.py
+++ b/backend/ffmpeg_tools/discovery.py
@@ -340,6 +340,26 @@ def validate_ffmpeg_install(require_probe: bool = True) -> FFmpegValidationResul
             known_bad=True,
         )
 
+    # Master/git nightlies are unverifiable, and recent ones carry the same
+    # frame-corruption race (issue #184: the reporter's install held a July
+    # master nightly delivered by the 2.1.0-era Repair; nothing since ever
+    # flagged it). Flag every dev build so those installs get walked to
+    # Repair, which replaces them with the pinned verified build.
+    if ffmpeg_version.is_dev_build:
+        return FFmpegValidationResult(
+            ok=False,
+            message=(
+                "This FFmpeg build is a development nightly with a known "
+                "frame-corruption bug risk (random frames written as "
+                f"unreadable EXR files). Detected {ffmpeg_version.first_line}. "
+                "Run Repair FFmpeg to install a verified build."
+            ),
+            ffmpeg_path=ffmpeg,
+            ffprobe_path=ffprobe,
+            ffmpeg_version=ffmpeg_version,
+            known_bad=True,
+        )
+
     ffprobe_version: FFmpegVersionInfo | None = None
     if require_probe and ffprobe:
         try:

--- a/backend/ffmpeg_tools/extraction.py
+++ b/backend/ffmpeg_tools/extraction.py
@@ -38,6 +38,89 @@ _HWACCEL_PRIORITY: dict[str, list[tuple[str, list[str]]]] = {
 
 _cached_hwaccel: list[str] | None = None  # cached result of detect_hwaccel()
 
+# ---------------------------------------------------------------------------
+# Adaptive EXR encoder threading — commit-headroom aware
+# ---------------------------------------------------------------------------
+# FFmpeg's EXR encoder is frame-threaded: N threads hold N complete frames
+# in flight. Measured on the pinned build with a 4K clip (issue #184 bench):
+# ~435 MB of committed memory per thread (~52 bytes/pixel/thread) plus
+# ~2 GB pipeline base. With threads=auto a 32-core machine commits ~15.6 GB
+# for one 4K import, which fails with "Cannot allocate memory" (-12) on any
+# machine whose commit headroom is smaller — a loaded 16 GB laptop can never
+# import 4K at auto threads. Cap threads to what the machine can actually
+# promise, and leave fast machines at full speed.
+_ENC_BYTES_PER_PIXEL_PER_THREAD = 52
+_ENC_COMMIT_SAFETY = 0.5    # use at most half the free commit headroom
+_ENC_MIN_THREADS = 2
+_ENC_MAX_THREADS = 64
+
+
+def _free_commit_bytes() -> int | None:
+    """Free Windows commit charge (limit - total), or None if unavailable.
+
+    Commit is the constraint malloc actually hits — physical RAM can look
+    free while the commit ledger is full (issue #184 QA finding).
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        class PERFORMANCE_INFORMATION(ctypes.Structure):
+            _fields_ = [
+                ("cb", ctypes.c_uint32),
+                ("CommitTotal", ctypes.c_size_t),
+                ("CommitLimit", ctypes.c_size_t),
+                ("CommitPeak", ctypes.c_size_t),
+                ("PhysicalTotal", ctypes.c_size_t),
+                ("PhysicalAvailable", ctypes.c_size_t),
+                ("SystemCache", ctypes.c_size_t),
+                ("KernelTotal", ctypes.c_size_t),
+                ("KernelPaged", ctypes.c_size_t),
+                ("KernelNonpaged", ctypes.c_size_t),
+                ("PageSize", ctypes.c_size_t),
+                ("HandleCount", ctypes.c_uint32),
+                ("ProcessCount", ctypes.c_uint32),
+                ("ThreadCount", ctypes.c_uint32),
+            ]
+
+        info = PERFORMANCE_INFORMATION()
+        info.cb = ctypes.sizeof(info)
+        if not ctypes.windll.psapi.GetPerformanceInfo(
+            ctypes.byref(info), info.cb
+        ):
+            return None
+        return (info.CommitLimit - info.CommitTotal) * info.PageSize
+    except Exception:
+        return None
+
+
+def adaptive_encoder_threads(width: int, height: int) -> list[str]:
+    """Return ["-threads:v", N] when commit headroom demands a cap, else [].
+
+    Empty list means FFmpeg picks its default (one thread per core), which
+    is correct whenever the machine can afford it.
+    """
+    if width <= 0 or height <= 0:
+        return []
+    free = _free_commit_bytes()
+    if free is None:
+        return []
+    cores = os.cpu_count() or 4
+    per_thread = _ENC_BYTES_PER_PIXEL_PER_THREAD * width * height
+    if per_thread <= 0:
+        return []
+    afford = int((free * _ENC_COMMIT_SAFETY) / per_thread)
+    threads = max(_ENC_MIN_THREADS, min(afford, cores, _ENC_MAX_THREADS))
+    if threads >= cores:
+        return []  # machine can afford full auto threading
+    logger.info(
+        f"EXR encoder threads capped at {threads} "
+        f"(free commit {free / 1e9:.1f} GB, "
+        f"~{per_thread / 1e6:.0f} MB/thread at {width}x{height})"
+    )
+    return ["-threads:v", str(threads)]
+
 
 def detect_hwaccel(ffmpeg: str | None = None) -> list[str]:
     """Detect the best FFmpeg hardware accelerator for this platform.
@@ -556,6 +639,13 @@ def extract_frames(
     # Falls back to software decode if none available
     hwaccel_flags = detect_hwaccel(ffmpeg)
 
+    # Cap EXR encoder threads when commit headroom can't afford
+    # one full frame buffer per core (issue #184 bench).
+    enc_thread_args = adaptive_encoder_threads(
+        (video_info or {}).get("width", 0),
+        (video_info or {}).get("height", 0),
+    )
+
     def _build_cmd(hw_flags: list[str],
                    extra_out_args: list[str] | None = None) -> list[str]:
         out_args = extra_out_args or []
@@ -673,7 +763,7 @@ def extract_frames(
         return proc.returncode, "\n".join(stderr_tail[-15:])
 
     last_frame = start_frame
-    returncode, stderr_out = _run_ffmpeg(hwaccel_flags)
+    returncode, stderr_out = _run_ffmpeg(hwaccel_flags, enc_thread_args)
 
     # If hardware decode failed, retry with software decode
     if returncode != 0 and hwaccel_flags and not (cancel_event and cancel_event.is_set()):
@@ -688,9 +778,18 @@ def extract_frames(
                 os.remove(os.path.join(out_dir, f))
         start_frame = 0
         last_frame = 0
-        returncode, stderr_out = _run_ffmpeg([])  # empty = software decode
+        # empty hw flags = software decode
+        returncode, stderr_out = _run_ffmpeg([], enc_thread_args)
 
     if returncode != 0 and not (cancel_event and cancel_event.is_set()):
+        # Out-of-memory gets a human message: the raw FFmpeg error reads as
+        # a broken app, but the cause is commit exhaustion on the machine
+        # (issue #184 QA finding).
+        if stderr_out and "cannot allocate memory" in stderr_out.lower():
+            raise RuntimeError(
+                "Not enough free memory to import this clip. "
+                "Close other applications and run the extraction again."
+            )
         # Extract a meaningful error message from FFmpeg stderr
         err_detail = ""
         if stderr_out:

--- a/backend/ffmpeg_tools/extraction.py
+++ b/backend/ffmpeg_tools/extraction.py
@@ -87,7 +87,7 @@ def _recompress_to_dwab(
     out_dir: str,
     on_progress: Optional[Callable[[int, int], None]] = None,
     cancel_event: Optional[threading.Event] = None,
-) -> None:
+) -> list[str]:
     """Recompress FFmpeg ZIP16 EXR files to DWAB in-place.
 
     NOTE: This always uses DWAB intentionally — it's an internal storage
@@ -99,23 +99,26 @@ def _recompress_to_dwab(
     with spawn start method (requires freeze_support() in main.py).
     In dev mode, spawns a standalone subprocess for full GIL bypass.
     Both paths keep the parent process (and its Qt event loop) completely free.
+
+    Returns the list of frame filenames that could not be read back and
+    recompressed (unreadable = corrupt FFmpeg output, see issue #184).
+    The .dwab_done marker is only written when every frame succeeded.
     """
     marker = os.path.join(out_dir, ".dwab_done")
     if os.path.isfile(marker):
-        return
+        return []
 
     exr_files = sorted([f for f in os.listdir(out_dir)
                         if f.lower().endswith('.exr')])
     total = len(exr_files)
     if total == 0:
-        return
+        return []
 
     if getattr(sys, "frozen", False):
-        _recompress_multiprocess(out_dir, exr_files, total, marker,
-                                 on_progress, cancel_event)
-    else:
-        _recompress_subprocess(out_dir, exr_files, total, marker,
-                               on_progress, cancel_event)
+        return _recompress_multiprocess(out_dir, exr_files, total, marker,
+                                        on_progress, cancel_event)
+    return _recompress_subprocess(out_dir, exr_files, total, marker,
+                                  on_progress, cancel_event)
 
 
 def _recompress_one_exr(args: tuple) -> bool:
@@ -169,6 +172,51 @@ def _recompress_one_exr(args: tuple) -> bool:
         return False
 
 
+def _recompress_sequential(
+    out_dir: str,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+    cancel_event: Optional[threading.Event] = None,
+) -> list[str]:
+    """DWAB recompress in-process, one frame at a time — no worker pool.
+
+    Fallback for the safe-mode retry in extract_frames: slower than the
+    pooled paths, but immune to pool-level failures (BrokenProcessPool from
+    AV kills, OOM, worker crashes). Returns filenames that failed to read.
+    """
+    marker = os.path.join(out_dir, ".dwab_done")
+    if os.path.isfile(marker):
+        return []
+
+    exr_files = sorted([f for f in os.listdir(out_dir)
+                        if f.lower().endswith('.exr')])
+    total = len(exr_files)
+    if total == 0:
+        return []
+
+    logger.info(f"Recompressing {total} EXR frames to DWAB (sequential)...")
+    failed: list[str] = []
+    for done, fname in enumerate(exr_files, 1):
+        if cancel_event and cancel_event.is_set():
+            logger.info("DWAB recompression cancelled")
+            return []
+        src = os.path.join(out_dir, fname)
+        if not _recompress_one_exr((src, src + ".tmp")):
+            failed.append(fname)
+        if on_progress:
+            on_progress(done, total)
+
+    if failed:
+        failed.sort()
+        logger.warning(f"DWAB recompression (sequential): {len(failed)}/{total} "
+                       f"frame(s) unreadable (corrupt): {failed[:5]}")
+        return failed
+
+    with open(marker, 'w') as f:
+        f.write("done")
+    logger.info(f"DWAB recompression complete: {total} frames")
+    return []
+
+
 def _recompress_multiprocess(
     out_dir: str,
     exr_files: list[str],
@@ -176,12 +224,14 @@ def _recompress_multiprocess(
     marker: str,
     on_progress: Optional[Callable[[int, int], None]] = None,
     cancel_event: Optional[threading.Event] = None,
-) -> None:
+) -> list[str]:
     """DWAB recompress using ProcessPoolExecutor (frozen builds).
 
     Uses multiprocessing with spawn start method so each worker is a real
     child process — no GIL contention with the parent Qt event loop.
     Requires multiprocessing.freeze_support() in main.py (already present).
+
+    Returns filenames of frames that failed to read back (corrupt).
     """
     import multiprocessing
     from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -189,6 +239,7 @@ def _recompress_multiprocess(
     logger.info(f"Recompressing {total} EXR frames to DWAB (multiprocess)...")
     workers = max(1, min((os.cpu_count() or 4) // 2, 16))
     done = 0
+    failed: list[str] = []
 
     ctx = multiprocessing.get_context("spawn")
     work = [(os.path.join(out_dir, f), os.path.join(out_dir, f + ".tmp"))
@@ -200,15 +251,32 @@ def _recompress_multiprocess(
             if cancel_event and cancel_event.is_set():
                 pool.shutdown(wait=False, cancel_futures=True)
                 logger.info("DWAB recompression cancelled")
-                return
-            fut.result()
+                return []
+            # A worker terminated abruptly (BrokenProcessPool: AV kill, OOM,
+            # native crash) must not abort the whole pass — mark the item
+            # failed so the safe-mode retry in extract_frames can heal it.
+            try:
+                ok = fut.result()
+            except Exception as exc:
+                logger.warning(f"DWAB worker failed for "
+                               f"{os.path.basename(futs[fut][0])}: {exc}")
+                ok = False
+            if not ok:
+                failed.append(os.path.basename(futs[fut][0]))
             done += 1
             if on_progress:
                 on_progress(done, total)
 
+    if failed:
+        failed.sort()
+        logger.warning(f"DWAB recompression: {len(failed)}/{total} frame(s) "
+                       f"unreadable (corrupt): {failed[:5]}")
+        return failed
+
     with open(marker, 'w') as f:
         f.write("done")
     logger.info(f"DWAB recompression complete: {total} frames")
+    return []
 
 
 def _recompress_subprocess(
@@ -218,8 +286,11 @@ def _recompress_subprocess(
     marker: str,
     on_progress: Optional[Callable[[int, int], None]] = None,
     cancel_event: Optional[threading.Event] = None,
-) -> None:
-    """DWAB recompress using a subprocess with ProcessPoolExecutor (dev mode)."""
+) -> list[str]:
+    """DWAB recompress using a subprocess with ProcessPoolExecutor (dev mode).
+
+    Returns filenames of frames that failed to read back (corrupt).
+    """
     python = sys.executable
 
     script_content = r'''
@@ -292,7 +363,14 @@ if __name__ == "__main__":
     with ProcessPoolExecutor(max_workers=workers) as pool:
         futs = {pool.submit(recompress_one, item): item for item in work}
         for fut in as_completed(futs):
-            fut.result()
+            # Worker died abruptly (BrokenProcessPool etc.) -> mark item
+            # failed instead of aborting the whole pass.
+            try:
+                ok = fut.result()
+            except Exception:
+                ok = False
+            if not ok:
+                print(f"FAILED {os.path.basename(futs[fut][0])}", flush=True)
             done += 1
             print(f"PROGRESS {done} {total}", flush=True)
     print("DONE", flush=True)
@@ -324,6 +402,7 @@ if __name__ == "__main__":
     reader_thread = threading.Thread(target=_reader, daemon=True)
     reader_thread.start()
 
+    failed: list[str] = []
     try:
         while True:
             if cancel_event and cancel_event.is_set():
@@ -333,7 +412,7 @@ if __name__ == "__main__":
                 except subprocess.TimeoutExpired:
                     pass
                 logger.info("DWAB recompression cancelled")
-                return
+                return []
 
             try:
                 line = line_q.get(timeout=0.2)
@@ -351,6 +430,8 @@ if __name__ == "__main__":
                     done_n, total_n = int(parts[1]), int(parts[2])
                     if on_progress:
                         on_progress(done_n, total_n)
+            elif line.startswith("FAILED "):
+                failed.append(line.split(maxsplit=1)[1])
             elif line == "DONE":
                 break
 
@@ -358,7 +439,11 @@ if __name__ == "__main__":
     except subprocess.TimeoutExpired:
         proc.kill()
         logger.error("DWAB recompression subprocess timed out")
-        return
+        # The pass did not complete, so no frame is verified — report every
+        # frame as suspect so extract_frames runs the safe-mode retry
+        # (which re-validates with the pool-free sequential pass) instead of
+        # treating a crashed recompress as clean.
+        return list(exr_files)
     finally:
         try:
             os.remove(script_path)
@@ -367,13 +452,23 @@ if __name__ == "__main__":
 
     if proc.returncode != 0:
         stderr_out = proc.stderr.read() if proc.stderr else ""
+        # Log the TAIL of stderr — the actual exception sits at the bottom
+        # of a Python traceback, a head-slice hides it.
         logger.error(f"DWAB recompression failed (code {proc.returncode}): "
-                     f"{stderr_out[:500]}")
-        return
+                     f"{stderr_out[-2000:]}")
+        # Same as the timeout path: incomplete pass = nothing verified.
+        return list(exr_files)
+
+    if failed:
+        failed.sort()
+        logger.warning(f"DWAB recompression: {len(failed)}/{total} frame(s) "
+                       f"unreadable (corrupt): {failed[:5]}")
+        return failed
 
     with open(marker, 'w') as f:
         f.write("done")
     logger.info(f"DWAB recompression complete: {total} frames")
+    return []
 
 
 def extract_frames(
@@ -461,7 +556,9 @@ def extract_frames(
     # Falls back to software decode if none available
     hwaccel_flags = detect_hwaccel(ffmpeg)
 
-    def _build_cmd(hw_flags: list[str]) -> list[str]:
+    def _build_cmd(hw_flags: list[str],
+                   extra_out_args: list[str] | None = None) -> list[str]:
+        out_args = extra_out_args or []
         if start_frame > 0 and total_frames > 0:
             if video_info is None:
                 _vi = probe_video(video_path)
@@ -482,6 +579,7 @@ def extract_frames(
                 # and our minimum is FFmpeg 7, so it is always available.
                 "-fps_mode:v", "passthrough",
                 *exr_args,
+                *out_args,
                 out_dir + "/" + pattern,
                 "-y",
             ]
@@ -493,15 +591,17 @@ def extract_frames(
             # See note above: -fps_mode:v passthrough replaces removed -vsync.
             "-fps_mode:v", "passthrough",
             *exr_args,
+            *out_args,
             out_dir + "/" + pattern,
             "-y",
         ]
 
-    def _run_ffmpeg(hw_flags: list[str]) -> tuple[int, str]:
+    def _run_ffmpeg(hw_flags: list[str],
+                    extra_out_args: list[str] | None = None) -> tuple[int, str]:
         """Run FFmpeg extraction. Returns (return_code, last_stderr_lines)."""
         nonlocal last_frame
 
-        cmd = _build_cmd(hw_flags)
+        cmd = _build_cmd(hw_flags, extra_out_args)
         hwaccel_label = hw_flags[1] if hw_flags else "software"
         logger.info(f"Extracting frames (EXR half-float, decode={hwaccel_label}): "
                     f"{video_path} -> {out_dir} (start_frame={start_frame})")
@@ -579,11 +679,15 @@ def extract_frames(
     if returncode != 0 and hwaccel_flags and not (cancel_event and cancel_event.is_set()):
         logger.warning(f"Hardware decode failed (code {returncode}), "
                        f"retrying with software decode...")
-        # Clean up any partial frames from the failed attempt
+        # Clean up any partial frames from the failed attempt. ALL frames are
+        # deleted (including any pre-existing resume prefix), so the retry
+        # must restart from frame 0 — leaving start_frame > 0 here would
+        # seek past the beginning and permanently drop the prefix frames.
         for f in os.listdir(out_dir):
             if f.lower().endswith('.exr'):
                 os.remove(os.path.join(out_dir, f))
-        last_frame = start_frame
+        start_frame = 0
+        last_frame = 0
         returncode, stderr_out = _run_ffmpeg([])  # empty = software decode
 
     if returncode != 0 and not (cancel_event and cancel_event.is_set()):
@@ -607,8 +711,50 @@ def extract_frames(
                      if f.lower().endswith('.exr')])
     logger.info(f"Extracted {extracted} EXR frames (ZIP16)")
 
-    # Pass 2: Recompress ZIP16 -> DWAB
+    # Pass 2: Recompress ZIP16 -> DWAB. The recompress workers read every
+    # frame back, so this pass doubles as an integrity check on FFmpeg's
+    # output — corrupt frames fail to read and are reported back here.
     if extracted > 0 and not (cancel_event and cancel_event.is_set()):
-        _recompress_to_dwab(out_dir, on_recompress_progress, cancel_event)
+        corrupt = _recompress_to_dwab(out_dir, on_recompress_progress,
+                                      cancel_event)
+
+        # Corrupt frames = FFmpeg wrote unreadable EXR data (issue #184:
+        # a race in the hwaccel-decode + threaded-EXR-encode pipeline emits
+        # invalid zlib chunks inside ZIP16 EXRs on some machines). Wipe and
+        # re-extract once with both race suspects disabled — software decode
+        # AND a single encoder thread — then re-validate. Much slower, but it
+        # only runs when the fast path provably produced corrupt output.
+        # Fail loudly rather than let inference trip over unreadable frames
+        # mid-job later.
+        retried = False
+        if corrupt and not (cancel_event and cancel_event.is_set()):
+            logger.warning(
+                f"{len(corrupt)} corrupt frame(s) in FFmpeg output "
+                f"(e.g. {corrupt[0]}) — re-extracting with software decode, "
+                f"single-threaded encode...")
+            for f in os.listdir(out_dir):
+                if f.lower().endswith('.exr'):
+                    os.remove(os.path.join(out_dir, f))
+            start_frame = 0
+            last_frame = 0
+            retried = True
+            returncode, stderr_out = _run_ffmpeg([], ["-threads:v", "1"])
+            if returncode != 0 and not (cancel_event and cancel_event.is_set()):
+                raise RuntimeError(
+                    f"FFmpeg safe-mode retry failed (code {returncode})")
+            extracted = len([f for f in os.listdir(out_dir)
+                             if f.lower().endswith('.exr')])
+            # Sequential recompress: immune to worker-pool failures, so a
+            # broken pool can't mask the state of the re-extracted frames.
+            corrupt = _recompress_sequential(out_dir, on_recompress_progress,
+                                             cancel_event)
+        if corrupt and not (cancel_event and cancel_event.is_set()):
+            raise RuntimeError(
+                f"Extraction produced {len(corrupt)} unreadable frame(s) "
+                f"even after safe-mode retry (e.g. {corrupt[0]}). "
+                f"Run Repair FFmpeg in Preferences and re-import the clip.")
+        if retried and not corrupt:
+            logger.info("Safe-mode re-extraction succeeded: all frames "
+                        "readable")
 
     return extracted

--- a/tests/test_ffmpeg_tools.py
+++ b/tests/test_ffmpeg_tools.py
@@ -301,6 +301,9 @@ class TestCorruptFrameRetry:
         })
         monkeypatch.setattr(_extraction, "_recompress_to_dwab", fake_recompress)
         monkeypatch.setattr(_extraction.subprocess, "Popen", fake_popen)
+        # Hermetic: adaptive threading must not depend on this machine's
+        # live commit headroom during unrelated tests.
+        monkeypatch.setattr(_extraction, "_free_commit_bytes", lambda: None)
         return commands
 
     def test_corrupt_frames_trigger_software_retry(self, monkeypatch, tmp_path):
@@ -424,6 +427,130 @@ class TestCorruptFrameRetry:
         assert "-ss" not in commands[1], "software retry must not seek"
         sn = commands[1].index("-start_number")
         assert commands[1][sn + 1] == "0", "software retry must restart at 0"
+
+
+class TestAdaptiveEncoderThreads:
+    """Issue #184: EXR encode is frame-threaded (~52 B/px/thread measured);
+    cap threads to commit headroom so 4K imports survive loaded machines."""
+
+    def test_no_cap_when_headroom_large(self, monkeypatch):
+        monkeypatch.setattr(_extraction, "_free_commit_bytes",
+                            lambda: 64 * 1024**3)
+        monkeypatch.setattr(_extraction.os, "cpu_count", lambda: 16)
+        assert _extraction.adaptive_encoder_threads(3840, 2160) == []
+
+    def test_caps_when_headroom_small(self, monkeypatch):
+        # 4 GB free, 4K: afford = 4GB*0.5 / (52*3840*2160 B ~ 431 MB) = 4
+        monkeypatch.setattr(_extraction, "_free_commit_bytes",
+                            lambda: 4 * 1024**3)
+        monkeypatch.setattr(_extraction.os, "cpu_count", lambda: 32)
+        args = _extraction.adaptive_encoder_threads(3840, 2160)
+        assert args[0] == "-threads:v"
+        assert 2 <= int(args[1]) < 32
+
+    def test_floor_of_two_threads(self, monkeypatch):
+        monkeypatch.setattr(_extraction, "_free_commit_bytes",
+                            lambda: 256 * 1024**2)  # 256 MB free
+        monkeypatch.setattr(_extraction.os, "cpu_count", lambda: 8)
+        args = _extraction.adaptive_encoder_threads(3840, 2160)
+        assert args == ["-threads:v", "2"]
+
+    def test_no_probe_no_cap(self, monkeypatch):
+        monkeypatch.setattr(_extraction, "_free_commit_bytes", lambda: None)
+        assert _extraction.adaptive_encoder_threads(3840, 2160) == []
+
+    def test_small_resolution_uncapped_on_modest_machine(self, monkeypatch):
+        # 1080p on 6 GB free, 8 cores: per-thread ~108 MB, afford ~27 > cores
+        monkeypatch.setattr(_extraction, "_free_commit_bytes",
+                            lambda: 6 * 1024**3)
+        monkeypatch.setattr(_extraction.os, "cpu_count", lambda: 8)
+        assert _extraction.adaptive_encoder_threads(1920, 1080) == []
+
+    def test_cap_args_reach_ffmpeg_command(self, monkeypatch, tmp_path):
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        commands = []
+
+        class _P(TestCorruptFrameRetry._FakeProc):
+            pass
+
+        def fake_popen(cmd, **kwargs):
+            commands.append(cmd)
+            for i in range(3):
+                (out_dir / f"frame_{i:06d}.exr").write_bytes(b"x")
+            return _P(cmd)
+
+        fake_validation = ffmpeg_tools.FFmpegValidationResult(
+            ok=True, message="ok", ffmpeg_path="ffmpeg", ffprobe_path="ffprobe",
+        )
+        monkeypatch.setattr(
+            _extraction, "require_ffmpeg_install",
+            lambda require_probe=True: fake_validation,
+        )
+        monkeypatch.setattr(_extraction, "probe_video", lambda path: {
+            "fps": 25.0, "width": 3840, "height": 2160, "frame_count": 3,
+            "pix_fmt": "yuv420p", "color_space": "bt709",
+            "color_primaries": "", "color_transfer": "", "color_range": "tv",
+        })
+        monkeypatch.setattr(_extraction, "detect_hwaccel", lambda ffmpeg=None: [])
+        monkeypatch.setattr(_extraction, "_recompress_to_dwab",
+                            lambda *a, **k: [])
+        monkeypatch.setattr(_extraction.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(_extraction, "adaptive_encoder_threads",
+                            lambda w, h: ["-threads:v", "6"])
+
+        ffmpeg_tools.extract_frames("clip.mp4", str(out_dir), total_frames=3)
+        thr = commands[0].index("-threads:v")
+        assert commands[0][thr + 1] == "6"
+
+
+class TestOutOfMemoryMessage:
+    """FFmpeg -12 'Cannot allocate memory' must surface as a human message,
+    not a raw codec error (issue #184 QA)."""
+
+    def test_oom_stderr_raises_human_message(self, monkeypatch, tmp_path):
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+
+        class _OOMProc:
+            def __init__(self, cmd, **kwargs):
+                self.stdin = None
+                self.stderr = io.StringIO(
+                    "[vf#0:0] Error while filtering: Cannot allocate memory\n"
+                )
+                self.returncode = 1
+
+            def poll(self):
+                return 1
+
+            def wait(self, timeout=None):
+                return 1
+
+            def kill(self):
+                pass
+
+        fake_validation = ffmpeg_tools.FFmpegValidationResult(
+            ok=True, message="ok", ffmpeg_path="ffmpeg", ffprobe_path="ffprobe",
+        )
+        monkeypatch.setattr(
+            _extraction, "require_ffmpeg_install",
+            lambda require_probe=True: fake_validation,
+        )
+        monkeypatch.setattr(_extraction, "probe_video", lambda path: {
+            "fps": 25.0, "width": 3840, "height": 2160, "frame_count": 3,
+            "pix_fmt": "yuv420p", "color_space": "bt709",
+            "color_primaries": "", "color_transfer": "", "color_range": "tv",
+        })
+        monkeypatch.setattr(_extraction, "detect_hwaccel", lambda ffmpeg=None: [])
+        monkeypatch.setattr(_extraction, "_free_commit_bytes", lambda: None)
+        monkeypatch.setattr(_extraction.subprocess, "Popen", _OOMProc)
+
+        try:
+            ffmpeg_tools.extract_frames("clip.mp4", str(out_dir), total_frames=3)
+            assert False, "OOM must raise"
+        except RuntimeError as exc:
+            assert "Not enough free memory" in str(exc)
+            assert "Close other applications" in str(exc)
 
 
 class TestRecompressSubprocessFailure:

--- a/tests/test_ffmpeg_tools.py
+++ b/tests/test_ffmpeg_tools.py
@@ -2,7 +2,6 @@
 import io
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 import backend.ffmpeg_tools as ffmpeg_tools
@@ -184,6 +183,285 @@ class TestExtractFrames:
         assert "-pix_fmt" not in commands[0]
         vf_index = commands[0].index("-vf")
         assert commands[0][vf_index + 1].startswith("scale=in_color_matrix=bt709")
+        # Issue #175: -vsync was removed in FFmpeg git-master; we must use
+        # -fps_mode:v passthrough instead, and never emit the legacy -vsync.
+        assert "-fps_mode:v" in commands[0]
+        fps_index = commands[0].index("-fps_mode:v")
+        assert commands[0][fps_index + 1] == "passthrough"
+        assert "-vsync" not in commands[0]
+
+    def test_extract_frames_resume_branch_uses_fps_mode_not_vsync(self, monkeypatch, tmp_path):
+        """The resume/seek branch (start_frame > 0) must also use -fps_mode:v."""
+        commands = []
+
+        class _FakeProc:
+            def __init__(self, cmd):
+                self.cmd = cmd
+                self.stdin = None
+                self.stderr = io.StringIO("")
+                self.returncode = 0
+
+            def wait(self, timeout=None):
+                return 0
+
+            def poll(self):
+                return 0
+
+            def kill(self):
+                self.returncode = -9
+
+        def fake_popen(cmd, **kwargs):
+            commands.append(cmd)
+            return _FakeProc(cmd)
+
+        fake_validation = ffmpeg_tools.FFmpegValidationResult(
+            ok=True, message="ok", ffmpeg_path="ffmpeg", ffprobe_path="ffprobe",
+        )
+        monkeypatch.setattr(
+            _extraction, "require_ffmpeg_install",
+            lambda require_probe=True: fake_validation,
+        )
+        monkeypatch.setattr(_extraction, "detect_hwaccel", lambda ffmpeg=None: [])
+        monkeypatch.setattr(_extraction, "_recompress_to_dwab", lambda *a, **k: None)
+        monkeypatch.setattr(_extraction, "probe_video", lambda path: {
+            "fps": 24.0, "width": 1920, "height": 1080, "frame_count": 1000,
+            "pix_fmt": "yuv420p", "color_space": "bt709",
+            "color_primaries": "bt709", "color_transfer": "", "color_range": "",
+        })
+        monkeypatch.setattr(_extraction.subprocess, "Popen", fake_popen)
+
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        # Pre-seed many partial frames so resume rolls back yet start_frame > 0.
+        for i in range(50):
+            (out_dir / f"frame_{i:06d}.exr").write_bytes(b"x")
+
+        ffmpeg_tools.extract_frames("clip.mov", str(out_dir), total_frames=1000)
+
+        assert commands, "no FFmpeg command captured"
+        cmd = commands[0]
+        assert "-ss" in cmd, "resume branch should seek with -ss"
+        assert "-fps_mode:v" in cmd
+        assert cmd[cmd.index("-fps_mode:v") + 1] == "passthrough"
+        assert "-vsync" not in cmd
+
+
+class TestCorruptFrameRetry:
+    """Issue #184: hardware-decode extraction can write corrupt EXR frames.
+    The DWAB pass reports them; extract_frames must retry with software
+    decode and fail loudly if frames are still unreadable."""
+
+    class _FakeProc:
+        def __init__(self, cmd):
+            self.cmd = cmd
+            self.stdin = None
+            self.stderr = io.StringIO("")
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+        def poll(self):
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    def _setup(self, monkeypatch, out_dir, recompress_results):
+        """Wire fakes: Popen writes dummy frames; recompress pops results."""
+        commands = []
+
+        def fake_popen(cmd, **kwargs):
+            commands.append(cmd)
+            for i in range(3):
+                (out_dir / f"frame_{i:06d}.exr").write_bytes(b"x")
+            return self._FakeProc(cmd)
+
+        calls = list(recompress_results)
+
+        def fake_recompress(dir_, on_progress=None, cancel_event=None):
+            return calls.pop(0) if calls else []
+
+        # First pass uses the pooled recompress; the safe-mode retry uses
+        # the sequential fallback. Both pop from the same result queue.
+        monkeypatch.setattr(_extraction, "_recompress_sequential",
+                            fake_recompress)
+
+        fake_validation = ffmpeg_tools.FFmpegValidationResult(
+            ok=True, message="ok", ffmpeg_path="ffmpeg", ffprobe_path="ffprobe",
+        )
+        monkeypatch.setattr(
+            _extraction, "require_ffmpeg_install",
+            lambda require_probe=True: fake_validation,
+        )
+        monkeypatch.setattr(_extraction, "probe_video", lambda path: {
+            "fps": 25.0, "width": 960, "height": 540, "frame_count": 3,
+            "pix_fmt": "yuv420p", "color_space": "smpte170m",
+            "color_primaries": "", "color_transfer": "", "color_range": "tv",
+        })
+        monkeypatch.setattr(_extraction, "_recompress_to_dwab", fake_recompress)
+        monkeypatch.setattr(_extraction.subprocess, "Popen", fake_popen)
+        return commands
+
+    def test_corrupt_frames_trigger_software_retry(self, monkeypatch, tmp_path):
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        monkeypatch.setattr(
+            _extraction, "detect_hwaccel",
+            lambda ffmpeg=None: ["-hwaccel", "cuda"],
+        )
+        commands = self._setup(
+            monkeypatch, out_dir,
+            recompress_results=[["frame_000001.exr"], []],
+        )
+
+        extracted = ffmpeg_tools.extract_frames(
+            "clip.mp4", str(out_dir), total_frames=3,
+        )
+
+        assert extracted == 3
+        assert len(commands) == 2, "corrupt frames must trigger one retry"
+        assert "-hwaccel" in commands[0]
+        assert "-hwaccel" not in commands[1], "retry must use software decode"
+        thr = commands[1].index("-threads:v")
+        assert commands[1][thr + 1] == "1", "retry must single-thread the encode"
+
+    def test_still_corrupt_after_retry_raises(self, monkeypatch, tmp_path):
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        monkeypatch.setattr(
+            _extraction, "detect_hwaccel",
+            lambda ffmpeg=None: ["-hwaccel", "cuda"],
+        )
+        self._setup(
+            monkeypatch, out_dir,
+            recompress_results=[["frame_000001.exr"], ["frame_000001.exr"]],
+        )
+
+        try:
+            ffmpeg_tools.extract_frames("clip.mp4", str(out_dir), total_frames=3)
+            assert False, "unreadable frames after retry must raise"
+        except RuntimeError as exc:
+            assert "unreadable" in str(exc)
+            assert "Repair FFmpeg" in str(exc)
+
+    def test_software_decode_corruption_also_retries(self, monkeypatch, tmp_path):
+        # The encode-thread race is decode-independent, so a corrupt
+        # software-decode pass still gets one single-threaded retry.
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        monkeypatch.setattr(_extraction, "detect_hwaccel", lambda ffmpeg=None: [])
+        commands = self._setup(
+            monkeypatch, out_dir,
+            recompress_results=[["frame_000002.exr"], []],
+        )
+
+        extracted = ffmpeg_tools.extract_frames(
+            "clip.mp4", str(out_dir), total_frames=3,
+        )
+        assert extracted == 3
+        assert len(commands) == 2
+        assert "-threads:v" in commands[1]
+
+    def test_clean_extraction_no_retry(self, monkeypatch, tmp_path):
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        monkeypatch.setattr(
+            _extraction, "detect_hwaccel",
+            lambda ffmpeg=None: ["-hwaccel", "cuda"],
+        )
+        commands = self._setup(monkeypatch, out_dir, recompress_results=[[]])
+
+        extracted = ffmpeg_tools.extract_frames(
+            "clip.mp4", str(out_dir), total_frames=3,
+        )
+        assert extracted == 3
+        assert len(commands) == 1
+
+    def test_hw_decode_failure_on_resume_restarts_from_zero(
+        self, monkeypatch, tmp_path,
+    ):
+        """Hardware-decode failure wipes ALL frames (including the resume
+        prefix), so the software retry must restart from frame 0 — not seek
+        to the old resume point and silently drop the prefix."""
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        # Pre-seed frames so the resume branch picks start_frame > 0
+        for i in range(20):
+            (out_dir / f"frame_{i:06d}.exr").write_bytes(b"x")
+
+        monkeypatch.setattr(
+            _extraction, "detect_hwaccel",
+            lambda ffmpeg=None: ["-hwaccel", "cuda"],
+        )
+        commands = self._setup(monkeypatch, out_dir, recompress_results=[[]])
+
+        # First (hardware) run fails, software retry succeeds
+        outer = self
+
+        def failing_first_popen(cmd, **kwargs):
+            commands.append(cmd)
+            proc = outer._FakeProc(cmd)
+            if "-hwaccel" in cmd:
+                proc.returncode = 1
+
+                def poll():
+                    return 1
+                proc.poll = poll
+            else:
+                for i in range(3):
+                    (out_dir / f"frame_{i:06d}.exr").write_bytes(b"x")
+            return proc
+
+        monkeypatch.setattr(_extraction.subprocess, "Popen", failing_first_popen)
+
+        ffmpeg_tools.extract_frames(
+            "clip.mp4", str(out_dir), total_frames=1000,
+        )
+
+        assert len(commands) == 2
+        assert "-ss" in commands[0], "resume branch should seek initially"
+        assert "-ss" not in commands[1], "software retry must not seek"
+        sn = commands[1].index("-start_number")
+        assert commands[1][sn + 1] == "0", "software retry must restart at 0"
+
+
+class TestRecompressSubprocessFailure:
+    """A crashed or timed-out recompress subprocess verifies nothing — it
+    must report every frame as suspect, never return 'clean'."""
+
+    class _DeadProc:
+        def __init__(self, cmd, **kwargs):
+            self.stdout = io.StringIO("")   # no PROGRESS/DONE ever printed
+            self.stderr = io.StringIO("Traceback: worker pool exploded")
+            self.returncode = 1
+
+        def poll(self):
+            return 1
+
+        def wait(self, timeout=None):
+            return 1
+
+        def kill(self):
+            pass
+
+    def test_nonzero_exit_reports_all_frames_suspect(self, monkeypatch, tmp_path):
+        out_dir = tmp_path / "frames"
+        out_dir.mkdir()
+        files = []
+        for i in range(4):
+            name = f"frame_{i:06d}.exr"
+            (out_dir / name).write_bytes(b"x")
+            files.append(name)
+
+        monkeypatch.setattr(_extraction.subprocess, "Popen", self._DeadProc)
+
+        failed = _extraction._recompress_subprocess(
+            str(out_dir), files, len(files),
+            str(out_dir / ".dwab_done"),
+        )
+        assert failed == files, "incomplete pass must mark all frames suspect"
+        assert not (out_dir / ".dwab_done").exists()
 
 
 class TestVideoMetadata:
@@ -294,3 +572,113 @@ class TestValidateFFmpegInstall:
 
         assert "Repair FFmpeg" in help_text
         assert "tools\\ffmpeg" in help_text
+
+
+class TestPinnedFFmpegAsset:
+    """Issue #184: repair must install the pinned verified build, never a
+    rolling BtbN tag whose contents change under us."""
+
+    def test_resolver_returns_pinned_asset(self):
+        name, url = _discovery._resolve_windows_ffmpeg_asset(None)
+        assert name == _discovery._BTBN_PINNED_ASSET
+        assert url == _discovery._BTBN_PINNED_URL
+
+    def test_pin_is_a_dated_immutable_release(self):
+        # A rolling tag ("latest") re-publishes different binaries under the
+        # same URL — the pin must point at a dated autobuild release.
+        assert "/latest/" not in _discovery._BTBN_PINNED_URL
+        assert "autobuild-" in _discovery._BTBN_PINNED_URL
+        assert "master" not in _discovery._BTBN_PINNED_ASSET
+        assert "win64-gpl" in _discovery._BTBN_PINNED_ASSET
+
+    def test_resolver_needs_no_network(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("pinned resolver must not touch the network")
+
+        monkeypatch.setattr(_discovery.urllib.request, "urlopen", boom)
+        name, url = _discovery._resolve_windows_ffmpeg_asset(None)
+        assert name == _discovery._BTBN_PINNED_ASSET
+
+
+class TestKnownBadBuildDetection:
+    """Issue #184: post-tag n8.1.2 rolling builds corrupt EXR frames under
+    NVIDIA hardware decode and must be flagged for repair."""
+
+    def test_known_bad_matches_post_tag_builds(self):
+        bad = [
+            "ffmpeg version n8.1.2-22-g94138f6973-20260710",
+            "ffmpeg version n8.1.2-21-gce3c09c101-20260705",
+            "ffmpeg version n8.1.2-3-gdba917bab5-20260629",
+        ]
+        for line in bad:
+            assert _discovery._KNOWN_BAD_BUILD_RE.search(line), line
+
+    def test_known_bad_ignores_clean_builds(self):
+        good = [
+            "ffmpeg version n8.1.2-20260627",
+            "ffmpeg version 8.0.1-full_build-www.gyan.dev",
+            "ffmpeg version n7.1-latest",
+            "ffmpeg version 7.1.1",
+        ]
+        for line in good:
+            assert not _discovery._KNOWN_BAD_BUILD_RE.search(line), line
+
+    def test_validate_flags_known_bad_install(self, monkeypatch):
+        bad_line = "ffmpeg version n8.1.2-22-g94138f6973-20260710"
+        monkeypatch.setattr(_discovery, "find_ffmpeg", lambda: "/fake/ffmpeg")
+        monkeypatch.setattr(_discovery, "find_ffprobe", lambda: "/fake/ffprobe")
+        monkeypatch.setattr(
+            _discovery, "_read_program_version",
+            lambda path, name: _discovery.FFmpegVersionInfo(
+                first_line=bad_line, major=8,
+            ),
+        )
+        result = _discovery.validate_ffmpeg_install(require_probe=True)
+        assert not result.ok
+        assert result.known_bad
+        assert "Repair FFmpeg" in result.message
+
+    def test_validate_passes_pinned_build(self, monkeypatch):
+        good_line = "ffmpeg version n8.1.2-20260627"
+        monkeypatch.setattr(_discovery, "find_ffmpeg", lambda: "/fake/ffmpeg")
+        monkeypatch.setattr(_discovery, "find_ffprobe", lambda: "/fake/ffprobe")
+        monkeypatch.setattr(
+            _discovery, "_read_program_version",
+            lambda path, name: _discovery.FFmpegVersionInfo(
+                first_line=good_line, major=8,
+            ),
+        )
+        result = _discovery.validate_ffmpeg_install(require_probe=True)
+        assert result.ok
+        assert not result.known_bad
+
+
+class TestRepairSafetyHelpers:
+    """Repair must validate staging and never strand a working FFmpeg."""
+
+    def test_safe_extract_rejects_zip_slip(self, tmp_path):
+        import zipfile as _zip
+        bad = tmp_path / "evil.zip"
+        with _zip.ZipFile(bad, "w") as z:
+            z.writestr("../escape.txt", "pwned")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        try:
+            _discovery._safe_extract_zip(str(bad), str(dest))
+            assert False, "zip-slip member should have been rejected"
+        except RuntimeError as exc:
+            assert "unsafe path" in str(exc)
+        assert not (tmp_path / "escape.txt").exists()
+
+    def test_find_staged_dir_selects_by_contents(self, tmp_path):
+        root = tmp_path / "extract" / "ffmpeg-n8.1-latest-win64-gpl-8.1" / "bin"
+        root.mkdir(parents=True)
+        (root / "ffmpeg.exe").write_bytes(b"x")
+        (root / "ffprobe.exe").write_bytes(b"x")
+        found = _discovery._find_staged_ffmpeg_dir(str(tmp_path / "extract"))
+        assert found is not None
+        assert found.endswith("ffmpeg-n8.1-latest-win64-gpl-8.1")
+
+    def test_find_staged_dir_none_when_binaries_missing(self, tmp_path):
+        (tmp_path / "extract").mkdir()
+        assert _discovery._find_staged_ffmpeg_dir(str(tmp_path / "extract")) is None

--- a/tests/test_ffmpeg_tools.py
+++ b/tests/test_ffmpeg_tools.py
@@ -676,7 +676,10 @@ class TestValidateFFmpegInstall:
         assert not result.ok
         assert "full FFmpeg build" in result.message
 
-    def test_dev_build_is_accepted(self, monkeypatch):
+    def test_dev_build_is_flagged_for_repair(self, monkeypatch):
+        # Behavior change with issue #184: nightlies used to validate OK,
+        # which left the reporter's corrupting master build undetected
+        # through two updates. Dev builds now route to Repair.
         monkeypatch.setattr(_discovery, "find_ffmpeg", lambda: "ffmpeg")
         monkeypatch.setattr(_discovery, "find_ffprobe", lambda: "ffprobe")
 
@@ -689,8 +692,9 @@ class TestValidateFFmpegInstall:
 
         result = ffmpeg_tools.validate_ffmpeg_install()
 
-        assert result.ok
-        assert "FFmpeg OK" in result.message
+        assert not result.ok
+        assert result.known_bad
+        assert "Repair FFmpeg" in result.message
 
     def test_install_help_mentions_local_windows_repair(self, monkeypatch):
         monkeypatch.setattr(_discovery.sys, "platform", "win32")
@@ -764,6 +768,33 @@ class TestKnownBadBuildDetection:
         assert not result.ok
         assert result.known_bad
         assert "Repair FFmpeg" in result.message
+
+    def test_validate_flags_master_nightly(self, monkeypatch):
+        # Issue #184: the reporter's install held a master nightly delivered
+        # by the 2.1.0-era Repair. Exact reported version string.
+        bad_line = ("ffmpeg version N-125505-gc57660fb18-20260708 "
+                    "Copyright (c) 2000-2026 the FFmpeg developers")
+        assert _discovery._FFMPEG_DEV_BUILD_RE.search(bad_line)
+        monkeypatch.setattr(_discovery, "find_ffmpeg", lambda: "/fake/ffmpeg")
+        monkeypatch.setattr(_discovery, "find_ffprobe", lambda: "/fake/ffprobe")
+        monkeypatch.setattr(
+            _discovery, "_read_program_version",
+            lambda path, name: _discovery.FFmpegVersionInfo(
+                first_line=bad_line, major=None, is_dev_build=True,
+            ),
+        )
+        result = _discovery.validate_ffmpeg_install(require_probe=True)
+        assert not result.ok
+        assert result.known_bad
+        assert "Repair FFmpeg" in result.message
+
+    def test_dev_build_regex_variants(self):
+        for line in (
+            "ffmpeg version N-125505-gc57660fb18-20260708",
+            "ffmpeg version git-2026-07-01-abcdef",
+            "ffmpeg version master-20260630",
+        ):
+            assert _discovery._FFMPEG_DEV_BUILD_RE.search(line), line
 
     def test_validate_passes_pinned_build(self, monkeypatch):
         good_line = "ffmpeg version n8.1.2-20260627"

--- a/ui/main_window_mixins/export_mixin.py
+++ b/ui/main_window_mixins/export_mixin.py
@@ -70,9 +70,15 @@ class ExportMixin:
         logger.info(f"Auto-extraction queued: {len(extracting)} clip(s)")
 
     def _on_extract_current_clip(self) -> None:
-        """Handle RUN EXTRACTION button — extract the currently selected clip."""
+        """Handle RUN EXTRACTION button — extract the currently selected clip.
+
+        Accepts ERROR clips too: a failed extraction must be re-runnable
+        from the button, not only from the context menu (issue #184 QA
+        found the button silently dead after a failure). The ERROR retry
+        path in _on_extract_requested wipes partial frames first.
+        """
         clip = self._current_clip
-        if not clip or clip.state != ClipState.EXTRACTING:
+        if not clip or clip.state not in (ClipState.EXTRACTING, ClipState.ERROR):
             return
         self._on_extract_requested([clip])
 
@@ -188,21 +194,44 @@ class ExportMixin:
     def _on_extract_error(self, clip_name: str, error_msg: str) -> None:
         """Handle extraction failure."""
         self._clip_model.update_clip_state(clip_name, ClipState.ERROR)
+        failed_clip = None
         for clip in self._clip_model.clips:
             if clip.name == clip_name:
                 clip.extraction_progress = 0.0
                 clip.extraction_total = 0
                 clip.error_message = error_msg
+                failed_clip = clip
                 break
         self._extract_progress.pop(clip_name, None)
-        # Clear the extraction overlay on the viewer
+        # Clear the extraction overlay AND re-render the viewer — without
+        # the re-render the viewer keeps the stale "Extracting frames..."
+        # placeholder forever (issue #184 QA finding).
         if self._current_clip and self._current_clip.name == clip_name:
             self._dual_viewer.set_extraction_progress(0.0, 0)
+            if failed_clip is not None:
+                self._dual_viewer.set_clip(failed_clip)
         if not self._extract_worker.is_busy:
             self._status_bar.reset_progress()
         from ui.sounds.audio_manager import UIAudio
         UIAudio.error()
         logger.error(f"Extraction failed for {clip_name}: {error_msg}")
+
+        # Known failure signatures get the diagnostic dialog with fix steps
+        # (e.g. the poisoned-FFmpeg build or out-of-memory guidance) instead
+        # of an error that lives only in the log. Only for the clip the user
+        # is looking at — batch failures must not stack dialogs.
+        if self._current_clip and self._current_clip.name == clip_name:
+            from ui.widgets.diagnostic_dialog import DiagnosticDialog, match_diagnostic
+            diag = match_diagnostic(error_msg)
+            if diag is not None:
+                DiagnosticDialog(diag, error_msg, parent=self).exec()
+            else:
+                QMessageBox.warning(
+                    self,
+                    _tr("Extraction Failed"),
+                    _tr("Frame extraction failed for '%s':\n\n%s") % (
+                        clip_name, error_msg),
+                )
 
     # ── Export Video ──
 

--- a/ui/widgets/diagnostic_checks.py
+++ b/ui/widgets/diagnostic_checks.py
@@ -82,6 +82,27 @@ _DIAGNOSTICS: list[Diagnostic] = [
     ),
     # ── FFmpeg ────────────────────────────────────────────────────
     Diagnostic(
+        id="ffmpeg-corrupt-build",
+        title="FFmpeg Build Has a Known Frame-Corruption Bug",
+        pattern=re.compile(
+            r"known frame-corruption bug",
+            re.IGNORECASE,
+        ),
+        explanation=(
+            "The installed FFmpeg build can write unreadable frames during "
+            "video import when NVIDIA hardware decoding is active. Clips "
+            "imported with it may fail later with 'failed to read frame' "
+            "errors. Repair FFmpeg replaces it with a verified build."
+        ),
+        steps=[
+            "Go to Edit > Preferences and click Repair FFmpeg.\n"
+            "This installs a verified FFmpeg build automatically.",
+            "Delete any project that failed with a\n"
+            "'failed to read frame' error and re-import the clip.",
+        ],
+        tags=["ffmpeg", "corrupt", "exr", "repair"],
+    ),
+    Diagnostic(
         id="ffmpeg-invalid",
         title="FFmpeg Install Unsupported",
         pattern=re.compile(
@@ -501,14 +522,17 @@ def run_startup_diagnostics(device: str) -> list[StartupIssue]:
     except Exception as exc:
         logger.warning("Pascal/cu130 startup check failed: %s", exc)
 
-    # 3. FFmpeg missing, too old, or invalid build
+    # 3. FFmpeg missing, too old, invalid, or a known-corrupt build
     try:
         from backend.ffmpeg_tools import validate_ffmpeg_install
         result = validate_ffmpeg_install()
         if not result.ok:
-            # Pick the right diagnostic based on whether FFmpeg was found at all
+            # Pick the right diagnostic based on what validation found
             diag_id = "ffmpeg-missing"
-            if result.ffmpeg_path:
+            if getattr(result, "known_bad", False):
+                # Issue #184: build writes corrupt frames — dedicated warning
+                diag_id = "ffmpeg-corrupt-build"
+            elif result.ffmpeg_path:
                 diag_id = "ffmpeg-invalid"
             diag = next((d for d in _DIAGNOSTICS if d.id == diag_id), None)
             if diag:

--- a/ui/widgets/diagnostic_dialog.py
+++ b/ui/widgets/diagnostic_dialog.py
@@ -82,7 +82,14 @@ class DiagnosticDialog(QDialog):
         steps_area = QScrollArea()
         steps_area.setWidgetResizable(True)
         steps_area.setFrameShape(QScrollArea.Shape.NoFrame)
+        # Same viewport treatment as StartupDiagnosticDialog: no light panel.
+        steps_area.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+        )
+        steps_area.viewport().setAutoFillBackground(False)
         steps_widget = QWidget()
+        steps_widget.setObjectName("diagStepsList")
+        steps_widget.setStyleSheet("#diagStepsList { background: transparent; }")
         steps_layout = QVBoxLayout(steps_widget)
         steps_layout.setContentsMargins(8, 4, 8, 4)
         steps_layout.setSpacing(8)
@@ -178,7 +185,15 @@ class StartupDiagnosticDialog(QDialog):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        # The scroll viewport defaults to the palette base (light) — keep it
+        # on the dialog background so the list never shows a white panel.
+        scroll.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+        )
+        scroll.viewport().setAutoFillBackground(False)
         inner = QWidget()
+        inner.setObjectName("diagIssueList")
+        inner.setStyleSheet("#diagIssueList { background: transparent; }")
         inner_layout = QVBoxLayout(inner)
         inner_layout.setContentsMargins(4, 4, 4, 4)
         inner_layout.setSpacing(16)
@@ -220,6 +235,10 @@ class StartupDiagnosticDialog(QDialog):
 
         if issue.detail:
             det = QLabel(issue.detail)
+            det.setWordWrap(True)
+            det.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse
+            )
             det.setStyleSheet(
                 "QLabel { color: #999; font-size: 12px; font-style: italic; "
                 "background: transparent; border: none; }"


### PR DESCRIPTION
Fixes #184.

## Problem

Repair FFmpeg downloaded BtbN's rolling latest build. FFmpeg's release/8.1 branch picked up a CUDA rework on 2026-06-29 (after the n8.1.2 tag) whose builds can write corrupt EXR frames during hardware-decode extraction: invalid zlib chunks inside ZIP16 files. Reproduced locally on the reporter's exact clip with the exact extraction arguments the app generates. The same builds can also abort with allocation failures in the EXR encoder. Every user who ran Repair FFmpeg after June 30 received a defective build, and AI methods then failed with 'failed to read frame'.

Testing also showed the corruption race fires at a low rate on older builds, so validation has to protect every install, not just poisoned ones.

## Fix

☼ Repair FFmpeg now downloads a pinned, dated, immutable autobuild (2026-06-27, tag-exact n8.1.2), verified against the reproduction clip. No rolling tags, no release-API dependency.
☼ Startup validation flags installed post-tag n8.1.2 rolling builds and shows a dedicated diagnostic that walks the user to Repair FFmpeg.
☼ The DWAB recompression pass reads every frame back and now reports unreadable frames instead of swallowing them. The .dwab_done marker is only written when every frame is clean.
☼ Corrupt extractions retry once in safe mode (software decode plus single-threaded EXR encode), re-validate with a pool-free sequential recompress, and raise an actionable error if frames are still unreadable.
☼ A worker process dying (BrokenProcessPool) or a crashed recompress subprocess now counts as per-frame failure and feeds the retry, never a silent 'clean'.
☼ Hardware-decode extraction failures on a resumed import now restart from frame 0 after the wipe, instead of seeking past the deleted prefix.
☼ Diagnostic dialogs: scroll viewports keep the app background (no white panel), long detail lines word-wrap.

## Verification

☼ Pinned asset re-downloaded fresh and hash-matched against the build validated on the dev machine; EXR encoder confirmed present.
☼ Reproduction matrix on the reporter's clip: corruption reproduced on rolling builds with CUDA decode, encoder allocation failures reproduced with single-threaded encode on rolling builds, pinned build clean across runs.
☼ 30 ffmpeg-tools tests covering the pin, known-bad detection, retry flow, resume interaction, and subprocess failure semantics. Full suite: 732 passed.
☼ Startup modal exercised end to end against a simulated poisoned install (real diagnostics routine, real dialog, app theme).