### PR TITLE
Optional error reporting: report-on-click and opt-in crash reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,19 @@ Independent scans:
 
 ---
 
+## Privacy
+
+EZ-CorridorKey sends no telemetry by default. No usage analytics, no tracking, ever.
+
+Two things can send data, both under your control:
+
+☼ **Report Issue**: when you file a report from the Help menu, the diagnostic summary you see in the dialog can also be sent directly to the developer. A visible checkbox controls it per report.
+☼ **Crash reporting**: an optional toggle in Preferences > Privacy, off by default. When you enable it, crash details are sent automatically.
+
+What a report contains: crash details, GPU/driver info, OS and app version. What it never contains: your media, file names, projects, or personal info. File paths are anonymized before sending.
+
+---
+
 ## Localization
 
 EZ-CorridorKey supports translation into any language. All UI strings are extracted into standard Qt `.ts` files that translators can edit with [Qt Linguist](https://doc.qt.io/qt-6/linguist-translators.html) (free) or any text editor.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,4 +44,5 @@ The following are **out of scope**:
 - All `torch.load()` calls use `weights_only=True` to prevent pickle deserialization attacks
 - Subprocess calls use list-based arguments (no `shell=True`)
 - No network-facing services in the desktop application
+- No telemetry by default; error reporting only happens when the user files a report or enables the Preferences toggle, with paths anonymized and media names removed
 - Docker ports are bound to localhost only

--- a/backend/error_reporting.py
+++ b/backend/error_reporting.py
@@ -262,6 +262,7 @@ def send_report(
     """
     try:
         import sentry_sdk
+        from sentry_sdk.utils import event_from_exception
 
         client = sentry_sdk.Client(
             **_base_init_kwargs(),
@@ -269,22 +270,26 @@ def send_report(
             max_breadcrumbs=0,
         )
         try:
-            scope = sentry_sdk.Scope(client=client)
+            # Capture through this client directly: Scope.capture_* resolves
+            # the process-global client and would silently drop the event.
+            scope = sentry_sdk.Scope()
             scope.set_user({"id": get_install_id()})
             for key, value in collect_tags(gpu_info, stage).items():
                 scope.set_tag(key, value)
             scope.set_extra("bundle", scrub_text(bundle_text or ""))
 
             if exc_info is not None:
-                scope.capture_exception(exc_info)
+                event, hint = event_from_exception(
+                    exc_info, client_options=client.options)
             else:
                 headline = "User report"
                 for line in (bundle_text or "").splitlines():
                     if "ERROR" in line:
                         headline = scrub_text(line.strip())[:200]
                         break
-                scope.capture_message(headline, level="error")
+                event, hint = {"message": headline, "level": "error"}, None
 
+            client.capture_event(event, hint=hint, scope=scope)
             client.flush(timeout=timeout)
         finally:
             client.close(timeout=0)

--- a/backend/error_reporting.py
+++ b/backend/error_reporting.py
@@ -23,6 +23,16 @@ _DSN = "".join([
     "@", "ingest.", "ezscape.space", "/9",
 ])
 
+_ORIGIN = "/".join(["edenaion", "EZ-CorridorKey"])
+
+
+def _origin_ok() -> bool:
+    try:
+        from backend.update_verify import UPDATE_ORIGIN
+        return UPDATE_ORIGIN == _ORIGIN
+    except Exception:
+        return False
+
 # Stage values: installer, updater, runtime, inference.
 # Extraction/import failures map to runtime; GPU job failures to inference.
 VALID_STAGES = frozenset({"installer", "updater", "runtime", "inference"})
@@ -260,6 +270,8 @@ def send_report(
     Uses its own client so nothing stays active afterwards. Must never
     raise: the caller's clipboard/GitHub flow proceeds regardless.
     """
+    if not _origin_ok():
+        return False
     try:
         import sentry_sdk
         from sentry_sdk.utils import event_from_exception
@@ -317,6 +329,8 @@ def init_crash_reporting() -> bool:
     global _crash_reporting_active
     if _crash_reporting_active:
         return True
+    if not _origin_ok():
+        return False
     if not getattr(sys, "frozen", False):
         return False
     if not is_crash_reporting_enabled():

--- a/backend/error_reporting.py
+++ b/backend/error_reporting.py
@@ -1,0 +1,364 @@
+"""Optional error reporting.
+
+Nothing is sent unless the user submits a report themselves or enables
+crash reporting in Preferences (off by default). Paths are anonymized
+and media file names are removed before anything leaves the machine.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import sys
+import uuid
+
+logger = logging.getLogger(__name__)
+
+PRODUCT = "ez-corridorkey"
+
+_DSN = "".join([
+    "https://", "c6c8d171-fdd6-4649-8eb4-2ea4de28943e",
+    "@", "ingest.", "ezscape.space", "/9",
+])
+
+# Stage values: installer, updater, runtime, inference.
+# Extraction/import failures map to runtime; GPU job failures to inference.
+VALID_STAGES = frozenset({"installer", "updater", "runtime", "inference"})
+
+SETTINGS_ORG = "EZSCAPE"
+SETTINGS_APP = "EZ-CorridorKey"
+KEY_CRASH_REPORTS = "privacy/crash_reports_enabled"
+
+_install_id_cache: str | None = None
+_crash_reporting_active = False
+
+
+def get_app_version() -> str:
+    """App version from the bundled pyproject.toml."""
+    candidates = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidates.append(os.path.join(meipass, "pyproject.toml"))
+    candidates.append(os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "pyproject.toml",
+    ))
+    for path in candidates:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    m = re.match(r'\s*version\s*=\s*"([^"]+)"', line)
+                    if m:
+                        return m.group(1)
+        except OSError:
+            continue
+    return "unknown"
+
+
+def _config_dir() -> str:
+    """Per-user local config dir (not the relocatable data dir)."""
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser(
+            "~\\AppData\\Local")
+        return os.path.join(base, "EZ-CorridorKey")
+    if sys.platform == "darwin":
+        return os.path.expanduser(
+            "~/Library/Application Support/EZ-CorridorKey")
+    return os.path.join(
+        os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+        "EZ-CorridorKey",
+    )
+
+
+def get_install_id() -> str:
+    """Stable random id for this install. Contains nothing identifying."""
+    global _install_id_cache
+    if _install_id_cache:
+        return _install_id_cache
+
+    path = os.path.join(_config_dir(), "install_id.json")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            value = json.load(fh).get("install_id", "")
+        uuid.UUID(value)
+        _install_id_cache = value
+        return value
+    except (OSError, ValueError, AttributeError):
+        pass
+
+    value = str(uuid.uuid4())
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"install_id": value}, fh)
+        os.replace(tmp, path)
+        with open(path, encoding="utf-8") as fh:
+            value = json.load(fh).get("install_id", value)
+    except (OSError, ValueError):
+        pass  # in-memory id for this session only
+    _install_id_cache = value
+    return value
+
+
+# ── Scrubbing ────────────────────────────────────────────────────────
+
+_USER_PATH_RE = re.compile(
+    r"(?i)((?:[A-Z]:)?[\\/](?:Users|home)[\\/])([^\\/\s\"']+)"
+)
+_PROJECT_SEG_RE = re.compile(
+    r"(?i)([\\/](?:Projects|clips)[\\/])([^\\/\s\"']+)"
+)
+# App-generated file names that are safe to keep
+_SAFE_BASENAME_RE = re.compile(
+    r"(?i)^(frame_\d+\.exr|alpha[\w-]*\.(?:png|exr)|\.dwab_done|clip\.json|"
+    r"\.?video_metadata\.json|[\w.-]+\.log)$"
+)
+_MEDIA_EXTS = (
+    ".mp4", ".mov", ".avi", ".mkv", ".mxf", ".webm", ".m4v", ".gif",
+    ".png", ".jpg", ".jpeg", ".exr", ".tif", ".tiff", ".bmp", ".dpx",
+)
+_MEDIA_EXT_GROUP = "|".join(ext.lstrip(".") for ext in _MEDIA_EXTS)
+# Path segment (spaces allowed) after a separator, ending in a media ext.
+# Angle brackets excluded so already-scrubbed placeholders never rematch.
+_MEDIA_SEGMENT_RE = re.compile(
+    r"(?i)([\\/])([^\\/\"'<>\r\n]{1,200}?)\.(" + _MEDIA_EXT_GROUP + r")\b"
+)
+# Bare token with no separator (single word file names in prose)
+_MEDIA_TOKEN_RE = re.compile(
+    r"(?i)(?<![\\/])\b([^\\/\s\"',;=<>]+)\.(" + _MEDIA_EXT_GROUP + r")\b"
+)
+
+
+def scrub_text(text: str) -> str:
+    """Remove user names, project names, and media file names from text."""
+    if not text:
+        return text
+
+    text = _USER_PATH_RE.sub(lambda m: m.group(1) + "<user>", text)
+    text = _PROJECT_SEG_RE.sub(lambda m: m.group(1) + "<project>", text)
+
+    def _segment(m: re.Match) -> str:
+        base = m.group(2) + "." + m.group(3)
+        if _SAFE_BASENAME_RE.match(base):
+            return m.group(0)
+        return m.group(1) + "<media>." + m.group(3)
+
+    def _token(m: re.Match) -> str:
+        if _SAFE_BASENAME_RE.match(m.group(0)):
+            return m.group(0)
+        return "<media>." + m.group(2)
+
+    text = _MEDIA_SEGMENT_RE.sub(_segment, text)
+    return _MEDIA_TOKEN_RE.sub(_token, text)
+
+
+def scrub_event(event, hint=None):
+    """Apply scrub_text to every string in an event, recursively."""
+    def walk(node):
+        if isinstance(node, str):
+            return scrub_text(node)
+        if isinstance(node, dict):
+            return {k: walk(v) for k, v in node.items()}
+        if isinstance(node, (list, tuple)):
+            return [walk(v) for v in node]
+        return node
+
+    try:
+        event = walk(event)
+        event["server_name"] = ""
+    except Exception:
+        return None  # never send anything we failed to clean
+    return event
+
+
+# ── Environment tags ─────────────────────────────────────────────────
+
+def collect_tags(gpu_info: dict | None = None, stage: str = "runtime") -> dict:
+    """Machine-environment tags. Every value passes through scrub_text."""
+    tags: dict[str, str] = {
+        "product": PRODUCT,
+        "app_version": get_app_version(),
+        "os": platform.system().lower() or "unknown",
+        "os_version": platform.release() or "unknown",
+        "python_version": platform.python_version(),
+        "stage": stage if stage in VALID_STAGES else "runtime",
+    }
+
+    try:
+        import torch
+        tags["torch_version"] = str(torch.__version__)
+        cuda_ok = bool(torch.cuda.is_available())
+        tags["cuda_available"] = "true" if cuda_ok else "false"
+        tags["cuda_version"] = str(torch.version.cuda) if cuda_ok else "none"
+        if cuda_ok:
+            major, minor = torch.cuda.get_device_capability(0)
+            tags["gpu_arch"] = f"sm_{major}{minor}"
+            tags["gpu_name"] = torch.cuda.get_device_name(0)
+        else:
+            tags["gpu_arch"] = "none"
+    except Exception:
+        tags.setdefault("torch_version", "missing")
+        tags.setdefault("cuda_available", "false")
+        tags.setdefault("gpu_arch", "none")
+
+    if gpu_info:
+        try:
+            name = gpu_info.get("name")
+            if name:
+                tags["gpu_name"] = str(name)
+            total = gpu_info.get("total_gb")
+            if total:
+                tags["vram_gb"] = str(int(round(float(total))))
+        except Exception:
+            pass
+
+    try:
+        from backend.ffmpeg_tools.discovery import validate_ffmpeg_install
+        result = validate_ffmpeg_install(require_probe=False)
+        if result.ffmpeg_version is not None:
+            parts = result.ffmpeg_version.first_line.split()
+            tags["ffmpeg_version"] = parts[2] if len(parts) > 2 else "unknown"
+        else:
+            tags["ffmpeg_version"] = "missing"
+    except Exception:
+        tags["ffmpeg_version"] = "missing"
+
+    return {k: scrub_text(str(v)) for k, v in tags.items()}
+
+
+# ── Sending ──────────────────────────────────────────────────────────
+
+def _base_init_kwargs() -> dict:
+    frozen = bool(getattr(sys, "frozen", False))
+    return {
+        "dsn": _DSN,
+        "release": f"{PRODUCT}@{get_app_version()}",
+        "environment": "production" if frozen else "dev",
+        "auto_session_tracking": False,
+        "traces_sample_rate": None,
+        "before_send_transaction": lambda event, hint: None,
+        "send_default_pii": False,
+        "send_client_reports": False,
+        "include_local_variables": False,
+        "before_send": scrub_event,
+        "shutdown_timeout": 2,
+    }
+
+
+def send_report(
+    bundle_text: str,
+    stage: str = "runtime",
+    gpu_info: dict | None = None,
+    exc_info=None,
+    timeout: float = 5.0,
+) -> bool:
+    """Send one user-initiated report. Returns False on any failure.
+
+    Uses its own client so nothing stays active afterwards. Must never
+    raise: the caller's clipboard/GitHub flow proceeds regardless.
+    """
+    try:
+        import sentry_sdk
+
+        client = sentry_sdk.Client(
+            **_base_init_kwargs(),
+            default_integrations=False,
+            max_breadcrumbs=0,
+        )
+        try:
+            scope = sentry_sdk.Scope(client=client)
+            scope.set_user({"id": get_install_id()})
+            for key, value in collect_tags(gpu_info, stage).items():
+                scope.set_tag(key, value)
+            scope.set_extra("bundle", scrub_text(bundle_text or ""))
+
+            if exc_info is not None:
+                scope.capture_exception(exc_info)
+            else:
+                headline = "User report"
+                for line in (bundle_text or "").splitlines():
+                    if "ERROR" in line:
+                        headline = scrub_text(line.strip())[:200]
+                        break
+                scope.capture_message(headline, level="error")
+
+            client.flush(timeout=timeout)
+        finally:
+            client.close(timeout=0)
+        return True
+    except Exception as exc:
+        logger.debug(f"Report send skipped: {exc}")
+        return False
+
+
+def is_crash_reporting_enabled() -> bool:
+    """The Preferences toggle. Off means nothing is ever initialized."""
+    try:
+        from PySide6.QtCore import QSettings
+        s = QSettings(SETTINGS_ORG, SETTINGS_APP)
+        return s.value(KEY_CRASH_REPORTS, False, type=bool)
+    except Exception:
+        return False
+
+
+def init_crash_reporting() -> bool:
+    """Start automatic crash capture. Only called when the user opted in.
+
+    No-op in non-frozen builds and whenever the toggle is off.
+    """
+    global _crash_reporting_active
+    if _crash_reporting_active:
+        return True
+    if not getattr(sys, "frozen", False):
+        return False
+    if not is_crash_reporting_enabled():
+        return False
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.atexit import AtexitIntegration
+        from sentry_sdk.integrations.dedupe import DedupeIntegration
+        from sentry_sdk.integrations.excepthook import ExcepthookIntegration
+        from sentry_sdk.integrations.logging import LoggingIntegration
+        from sentry_sdk.integrations.threading import ThreadingIntegration
+
+        sentry_sdk.init(
+            **_base_init_kwargs(),
+            default_integrations=False,
+            auto_enabling_integrations=False,
+            max_breadcrumbs=20,
+            integrations=[
+                ExcepthookIntegration(always_run=True),
+                ThreadingIntegration(propagate_hub=True),
+                AtexitIntegration(callback=lambda p, t: None),
+                DedupeIntegration(),
+                LoggingIntegration(level=None, event_level=None),
+            ],
+        )
+        sentry_sdk.set_user({"id": get_install_id()})
+        for key, value in collect_tags(None, "runtime").items():
+            if key != "stage":
+                sentry_sdk.set_tag(key, value)
+        _crash_reporting_active = True
+        return True
+    except Exception as exc:
+        logger.debug(f"Crash reporting not started: {exc}")
+        return False
+
+
+def capture_stage_exception(stage: str, exc: BaseException) -> None:
+    """Record an exception from a known subsystem. Honors the toggle."""
+    if not _crash_reporting_active or not is_crash_reporting_enabled():
+        return
+    try:
+        import sentry_sdk
+
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("stage",
+                          stage if stage in VALID_STAGES else "runtime")
+            sentry_sdk.capture_exception(exc)
+    except Exception:
+        pass

--- a/backend/update_verify.py
+++ b/backend/update_verify.py
@@ -20,6 +20,9 @@ from cryptography.exceptions import InvalidSignature
 
 logger = logging.getLogger(__name__)
 
+# GitHub repository this build updates from.
+UPDATE_ORIGIN = "edenaion/EZ-CorridorKey"
+
 # Paste the contents of ezck_signing_public.pem here after running
 # scripts/generate_signing_key.py. This key ships with every installed
 # copy of the app and is used to verify that updates came from edenaion.

--- a/main.py
+++ b/main.py
@@ -516,6 +516,12 @@ def run_model_path_check(
         result["ok"] = ok
         if errors:
             result["errors"] = errors
+            try:
+                from backend.error_reporting import capture_stage_exception
+                capture_stage_exception(
+                    "installer", RuntimeError("; ".join(errors)))
+            except Exception:
+                pass
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0 if ok else 1
     finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ nvidia-ml-py
 PySide6>=6.7.0
 triton-windows>=3.5,<3.6; sys_platform == 'win32'
 cryptography>=43.0
+sentry-sdk>=2,<3

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -151,7 +151,6 @@ class _FakeScope:
         self.user = None
         self.tags = {}
         self.extras = {}
-        self.captured = []
 
     def set_user(self, u):
         self.user = u
@@ -162,21 +161,24 @@ class _FakeScope:
     def set_extra(self, k, v):
         self.extras[k] = v
 
-    def capture_exception(self, e):
-        self.captured.append(("exception", e))
-
-    def capture_message(self, m, level=None):
-        self.captured.append(("message", m, level))
-
 
 class _FakeClient:
     instances = []
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+        self.options = kwargs
         self.flushed = None
         self.closed = False
+        self.captured = []
         _FakeClient.instances.append(self)
+
+    def capture_event(self, event, hint=None, scope=None):
+        # Mirrors the real contract: events send ONLY through the client
+        # they were built for. Scope.capture_* resolves the global client
+        # and must not be used by send_report.
+        self.captured.append((event, hint, scope))
+        return "event-id"
 
     def flush(self, timeout=None):
         self.flushed = timeout
@@ -195,8 +197,17 @@ class TestSendReport:
             scopes.append(s)
             return s
 
-        fake = types.SimpleNamespace(Client=_FakeClient, Scope=make_scope)
+        utils = types.SimpleNamespace(
+            event_from_exception=lambda exc, client_options=None: (
+                {"exception": {"values": [{"value": str(exc)}]},
+                 "level": "error"},
+                {"exc_info": exc},
+            ),
+        )
+        fake = types.SimpleNamespace(
+            Client=_FakeClient, Scope=make_scope, utils=utils)
         monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+        monkeypatch.setitem(sys.modules, "sentry_sdk.utils", utils)
         return scopes
 
     def test_send_uses_isolated_client_and_hygiene_kwargs(self, monkeypatch):
@@ -214,21 +225,26 @@ class TestSendReport:
         assert kw["max_breadcrumbs"] == 0
         assert client.flushed == 5.0
         assert client.closed
-        scope = scopes[0]
-        assert scope.captured[0][0] == "message"
-        assert "bad thing" in scope.captured[0][1]
+        # Event must go through THIS client, carrying the prepared scope
+        assert len(client.captured) == 1
+        event, hint, scope = client.captured[0]
+        assert "bad thing" in event["message"]
+        assert event["level"] == "error"
         uuid.UUID(scope.user["id"])
         assert scope.tags["product"] == er.PRODUCT
+        assert scopes[0] is scope
 
     def test_send_with_exception(self, monkeypatch):
-        scopes = self._install_fake_sdk(monkeypatch)
+        self._install_fake_sdk(monkeypatch)
         try:
             raise ValueError("boom")
         except ValueError as e:
             ok = er.send_report("bundle", "updater", exc_info=e)
         assert ok
-        assert scopes[0].captured[0][0] == "exception"
-        assert scopes[0].tags["stage"] == "updater"
+        event, hint, scope = _FakeClient.instances[0].captured[0]
+        assert "boom" in str(event["exception"])
+        assert hint is not None
+        assert scope.tags["stage"] == "updater"
 
     def test_missing_sdk_returns_false(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "sentry_sdk", None)

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -256,6 +256,29 @@ class TestSendReport:
         assert er.send_report("bundle", "runtime") is False
 
 
+class TestOriginGate:
+    def test_send_blocked_when_origin_differs(self, monkeypatch):
+        import backend.update_verify as uv
+        monkeypatch.setattr(uv, "UPDATE_ORIGIN", "someone/their-fork")
+        called = []
+        monkeypatch.setitem(
+            sys.modules, "sentry_sdk",
+            types.SimpleNamespace(Client=lambda **k: called.append(k)),
+        )
+        assert er.send_report("bundle", "runtime") is False
+        assert called == []
+
+    def test_init_blocked_when_origin_differs(self, monkeypatch):
+        import backend.update_verify as uv
+        monkeypatch.setattr(uv, "UPDATE_ORIGIN", "someone/their-fork")
+        monkeypatch.setattr(er, "is_crash_reporting_enabled", lambda: True)
+        monkeypatch.setattr(er.sys, "frozen", True, raising=False)
+        assert er.init_crash_reporting() is False
+
+    def test_origin_matches_this_repo(self):
+        assert er._origin_ok() is True
+
+
 class TestCrashReportingGates:
     def test_toggle_off_no_init(self, monkeypatch):
         monkeypatch.setattr(er, "is_crash_reporting_enabled", lambda: False)

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -1,0 +1,260 @@
+"""Tests for backend.error_reporting."""
+import json
+import sys
+import types
+import uuid
+
+import pytest
+
+from backend import error_reporting as er
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(er, "_install_id_cache", None)
+    monkeypatch.setattr(er, "_crash_reporting_active", False)
+    monkeypatch.setattr(er, "_config_dir", lambda: str(tmp_path / "cfg"))
+    yield
+
+
+class TestScrubText:
+    def test_windows_username(self):
+        s = r"C:\Users\FlavioZ\AppData\Local\app\file.log"
+        out = er.scrub_text(s)
+        assert "FlavioZ" not in out
+        assert r"C:\Users\<user>" in out
+
+    def test_linux_and_mac_usernames(self):
+        assert "bob" not in er.scrub_text("/home/bob/x.log")
+        assert "carol" not in er.scrub_text("/Users/carol/x.log")
+
+    def test_media_basenames_redacted(self):
+        s = r"Failed to read C:\proj\My Wedding Video.mp4 frame"
+        out = er.scrub_text(s)
+        assert "Wedding" not in out
+        assert "<media>.mp4" in out
+
+    def test_app_generated_names_kept(self):
+        for name in ("frame_000123.exr", "clip.json", "session_260101.log"):
+            assert name in er.scrub_text(f"path/{name} ok"), name
+
+    def test_project_and_clip_segments(self):
+        s = r"N:\data\Projects\260710_wedding\clips\bride_close\Frames\frame_000001.exr"
+        out = er.scrub_text(s)
+        assert "wedding" not in out
+        assert "bride" not in out
+        assert "frame_000001.exr" in out
+
+    def test_idempotent(self):
+        cases = [
+            r"C:\Users\Someone\Projects\secret\clips\shot1\a.mp4",
+            r"C:/Users/user/Downloads/PF0044 - Copia.mp4 -> dest",
+            "standalone My Take 07.mov in prose",
+        ]
+        for s in cases:
+            once = er.scrub_text(s)
+            assert er.scrub_text(once) == once, s
+            assert "<<" not in once, s
+
+    def test_empty(self):
+        assert er.scrub_text("") == ""
+
+
+class TestScrubEvent:
+    def test_recursive_walk(self):
+        event = {
+            "message": r"C:\Users\Someone\clip.mp4",
+            "extra": {"bundle": ["/home/bob/take01.mov", {"k": "/Users/x/y.png"}]},
+            "server_name": "MY-PC",
+            "number": 5,
+        }
+        out = er.scrub_event(event)
+        blob = json.dumps(out)
+        assert "Someone" not in blob
+        assert "bob" not in blob
+        assert "take01" not in blob
+        assert out["server_name"] == ""
+        assert out["number"] == 5
+
+    def test_failure_returns_none(self, monkeypatch):
+        monkeypatch.setattr(er, "scrub_text", lambda s: 1 / 0)
+        assert er.scrub_event({"message": "x"}) is None
+
+
+class TestInstallId:
+    def test_minted_once_and_stable(self):
+        a = er.get_install_id()
+        b = er.get_install_id()
+        assert a == b
+        uuid.UUID(a)
+
+    def test_survives_reread_from_disk(self, monkeypatch):
+        a = er.get_install_id()
+        monkeypatch.setattr(er, "_install_id_cache", None)
+        assert er.get_install_id() == a
+
+    def test_disk_failure_falls_back_in_memory(self, monkeypatch):
+        monkeypatch.setattr(er, "_config_dir",
+                            lambda: "\\\\?\\invalid\0dir")
+        value = er.get_install_id()
+        uuid.UUID(value)
+
+
+class TestCollectTags:
+    def _fake_torch(self, cuda: bool, version="2.9.1+cu128"):
+        torch = types.SimpleNamespace()
+        torch.__version__ = version
+        torch.version = types.SimpleNamespace(cuda="12.8" if cuda else None)
+        torch.cuda = types.SimpleNamespace(
+            is_available=lambda: cuda,
+            get_device_capability=lambda i: (12, 0),
+            get_device_name=lambda i: "NVIDIA GeForce RTX 5090",
+        )
+        return torch
+
+    def test_with_cuda_wheel_suffix_preserved(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", self._fake_torch(True))
+        tags = er.collect_tags({"name": "RTX 5090", "total_gb": 31.8}, "inference")
+        assert tags["torch_version"] == "2.9.1+cu128"
+        assert tags["cuda_available"] == "true"
+        assert tags["gpu_arch"] == "sm_120"
+        assert tags["vram_gb"] == "32"
+        assert tags["stage"] == "inference"
+        assert tags["product"] == er.PRODUCT
+
+    def test_without_cuda(self, monkeypatch):
+        monkeypatch.setitem(
+            sys.modules, "torch", self._fake_torch(False, "2.9.1+xpu"))
+        tags = er.collect_tags(None, "runtime")
+        assert tags["torch_version"] == "2.9.1+xpu"
+        assert tags["cuda_available"] == "false"
+        assert tags["gpu_arch"] == "none"
+
+    def test_invalid_stage_maps_to_runtime(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", self._fake_torch(False))
+        assert er.collect_tags(None, "banana")["stage"] == "runtime"
+
+    def test_ffmpeg_missing(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", self._fake_torch(False))
+        import backend.ffmpeg_tools.discovery as disc
+        monkeypatch.setattr(
+            disc, "validate_ffmpeg_install",
+            lambda require_probe=False: types.SimpleNamespace(
+                ffmpeg_version=None),
+        )
+        assert er.collect_tags(None, "runtime")["ffmpeg_version"] == "missing"
+
+
+class _FakeScope:
+    def __init__(self, client=None):
+        self.client = client
+        self.user = None
+        self.tags = {}
+        self.extras = {}
+        self.captured = []
+
+    def set_user(self, u):
+        self.user = u
+
+    def set_tag(self, k, v):
+        self.tags[k] = v
+
+    def set_extra(self, k, v):
+        self.extras[k] = v
+
+    def capture_exception(self, e):
+        self.captured.append(("exception", e))
+
+    def capture_message(self, m, level=None):
+        self.captured.append(("message", m, level))
+
+
+class _FakeClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.flushed = None
+        self.closed = False
+        _FakeClient.instances.append(self)
+
+    def flush(self, timeout=None):
+        self.flushed = timeout
+
+    def close(self, timeout=None):
+        self.closed = True
+
+
+class TestSendReport:
+    def _install_fake_sdk(self, monkeypatch):
+        _FakeClient.instances = []
+        scopes = []
+
+        def make_scope(client=None):
+            s = _FakeScope(client)
+            scopes.append(s)
+            return s
+
+        fake = types.SimpleNamespace(Client=_FakeClient, Scope=make_scope)
+        monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+        return scopes
+
+    def test_send_uses_isolated_client_and_hygiene_kwargs(self, monkeypatch):
+        scopes = self._install_fake_sdk(monkeypatch)
+        ok = er.send_report("line one\nERROR bad thing happened", "runtime")
+        assert ok
+        client = _FakeClient.instances[0]
+        kw = client.kwargs
+        assert kw["default_integrations"] is False
+        assert kw["traces_sample_rate"] is None
+        assert kw["auto_session_tracking"] is False
+        assert kw["send_default_pii"] is False
+        assert kw["send_client_reports"] is False
+        assert kw["include_local_variables"] is False
+        assert kw["max_breadcrumbs"] == 0
+        assert client.flushed == 5.0
+        assert client.closed
+        scope = scopes[0]
+        assert scope.captured[0][0] == "message"
+        assert "bad thing" in scope.captured[0][1]
+        uuid.UUID(scope.user["id"])
+        assert scope.tags["product"] == er.PRODUCT
+
+    def test_send_with_exception(self, monkeypatch):
+        scopes = self._install_fake_sdk(monkeypatch)
+        try:
+            raise ValueError("boom")
+        except ValueError as e:
+            ok = er.send_report("bundle", "updater", exc_info=e)
+        assert ok
+        assert scopes[0].captured[0][0] == "exception"
+        assert scopes[0].tags["stage"] == "updater"
+
+    def test_missing_sdk_returns_false(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+        assert er.send_report("bundle", "runtime") is False
+
+    def test_internal_failure_never_raises(self, monkeypatch):
+        self._install_fake_sdk(monkeypatch)
+        monkeypatch.setattr(er, "collect_tags", lambda *a: 1 / 0)
+        assert er.send_report("bundle", "runtime") is False
+
+
+class TestCrashReportingGates:
+    def test_toggle_off_no_init(self, monkeypatch):
+        monkeypatch.setattr(er, "is_crash_reporting_enabled", lambda: False)
+        monkeypatch.setattr(er.sys, "frozen", True, raising=False)
+        assert er.init_crash_reporting() is False
+
+    def test_dev_build_no_init_even_when_on(self, monkeypatch):
+        monkeypatch.setattr(er, "is_crash_reporting_enabled", lambda: True)
+        monkeypatch.delattr(er.sys, "frozen", raising=False)
+        assert er.init_crash_reporting() is False
+
+    def test_capture_stage_noop_when_inactive(self, monkeypatch):
+        called = []
+        fake = types.SimpleNamespace(
+            capture_exception=lambda e: called.append(e))
+        monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+        er.capture_stage_exception("updater", RuntimeError("x"))
+        assert called == []

--- a/tests/test_setup_wizard_consent.py
+++ b/tests/test_setup_wizard_consent.py
@@ -1,0 +1,73 @@
+"""First-run crash reporting ask in the setup wizard."""
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import QCoreApplication, QSettings  # noqa: E402
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(qapp):
+    QCoreApplication.setOrganizationName("EZSCAPE-Test")
+    QCoreApplication.setApplicationName("EZ-CorridorKey-Test")
+    s = QSettings()
+    s.clear()
+    s.sync()
+    yield
+    s = QSettings()
+    s.clear()
+    s.sync()
+    QCoreApplication.setOrganizationName("EZSCAPE")
+    QCoreApplication.setApplicationName("EZ-CorridorKey")
+
+
+def _make_wizard():
+    from ui.widgets.setup_wizard import SetupWizard
+    return SetupWizard()
+
+
+class TestFirstRunConsent:
+    def test_shown_when_never_prompted(self):
+        w = _make_wizard()
+        assert w._crash_check is not None
+        assert w._crash_check.isChecked() is False, "must default off"
+
+    def test_persist_yes(self):
+        w = _make_wizard()
+        w._crash_check.setChecked(True)
+        w._persist_crash_consent()
+        s = QSettings()
+        assert s.value("privacy/crash_reports_enabled", False, type=bool) is True
+        assert s.value("privacy/crash_reports_prompted", False, type=bool) is True
+
+    def test_persist_no(self):
+        w = _make_wizard()
+        w._persist_crash_consent()
+        s = QSettings()
+        assert s.value("privacy/crash_reports_enabled", True, type=bool) is False
+        assert s.value("privacy/crash_reports_prompted", False, type=bool) is True
+
+    def test_hidden_once_answered(self):
+        w = _make_wizard()
+        w._persist_crash_consent()
+        w2 = _make_wizard()
+        assert w2._crash_check is None
+
+    def test_persist_noop_when_not_shown(self):
+        w = _make_wizard()
+        w._persist_crash_consent()
+        w2 = _make_wizard()
+        # Answered already: persisting again must not touch the choice
+        s = QSettings()
+        s.setValue("privacy/crash_reports_enabled", True)
+        w2._persist_crash_consent()
+        assert s.value("privacy/crash_reports_enabled", False, type=bool) is True

--- a/ui/app.py
+++ b/ui/app.py
@@ -248,6 +248,14 @@ def create_app(argv: list[str] | None = None) -> QApplication:
     # (Corridor Digital\CorridorKey → EZSCAPE\EZ-CorridorKey)
     _migrate_legacy_settings()
 
+    # Optional crash reporting — does nothing unless the user enabled it
+    # in Preferences (off by default) and this is an installed build.
+    try:
+        from backend.error_reporting import init_crash_reporting
+        init_crash_reporting()
+    except Exception as exc:
+        logger.debug("Crash reporting init skipped: %s", exc)
+
     # Keep the Windows Apps & Features version in sync with the bundled build
     # after a skinny update. No-op on non-Windows and in dev mode.
     try:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -221,8 +221,9 @@ class _UpdateChecker(QThread):
             # downloads from (_run_frozen_update). Reading main's pyproject.toml
             # instead would nag for a version that has no downloadable release
             # yet whenever main is bumped ahead of a cut release.
+            from backend.update_verify import UPDATE_ORIGIN
             url = (
-                "https://api.github.com/repos/edenaion/EZ-CorridorKey"
+                f"https://api.github.com/repos/{UPDATE_ORIGIN}"
                 "/releases/latest"
             )
             req = urllib.request.Request(url, headers={"User-Agent": "CorridorKey"})

--- a/ui/main_window_mixins/settings_mixin.py
+++ b/ui/main_window_mixins/settings_mixin.py
@@ -760,6 +760,11 @@ class SettingsMixin:
             progress.close()
         except Exception as e:
             progress.close()
+            try:
+                from backend.error_reporting import capture_stage_exception
+                capture_stage_exception("updater", e)
+            except Exception:
+                pass
             QMessageBox.critical(
                 self, _tr("Update Failed"),
                 _tr("Could not update automatically:\n\n%s\n\n"

--- a/ui/main_window_mixins/settings_mixin.py
+++ b/ui/main_window_mixins/settings_mixin.py
@@ -499,8 +499,9 @@ class SettingsMixin:
                 return
 
             # Fetch latest release info from GitHub API
+            from backend.update_verify import UPDATE_ORIGIN
             api_url = (
-                "https://api.github.com/repos/edenaion/EZ-CorridorKey"
+                f"https://api.github.com/repos/{UPDATE_ORIGIN}"
                 "/releases/latest"
             )
             req = urllib.request.Request(

--- a/ui/widgets/preferences_dialog.py
+++ b/ui/widgets/preferences_dialog.py
@@ -54,6 +54,7 @@ KEY_INFERENCE_BACKEND = "inference/backend"
 KEY_OUTPUT_DIRECTORY = "output/default_directory"
 KEY_UI_LANGUAGE = "ui/language"
 KEY_SHOW_UPDATE_BUTTON = "ui/show_update_button"
+KEY_CRASH_REPORTS = "privacy/crash_reports_enabled"
 
 # Defaults
 DEFAULT_SHOW_TOOLTIPS = True
@@ -62,6 +63,7 @@ DEFAULT_SHOW_UPDATE_BUTTON = True
 DEFAULT_COPY_SOURCE = True
 DEFAULT_COPY_SEQUENCES = False
 DEFAULT_LOOP_PLAYBACK = True
+DEFAULT_CRASH_REPORTS = False
 DEFAULT_EXR_COMPRESSION = "dwab"
 DEFAULT_TRACKER_MODEL = "facebook/sam2.1-hiera-base-plus"
 DEFAULT_PARALLEL_CLIPS = 1
@@ -522,12 +524,38 @@ class PreferencesDialog(QDialog):
 
         # --- Layout order ---
         # UI > Project > Playback > Tracking > Inference > Output > Video Tools
+        # Privacy section
+        privacy_group = QGroupBox(self.tr("Privacy"))
+        privacy_layout = QVBoxLayout(privacy_group)
+
+        self._crash_reports_cb = QCheckBox(
+            self.tr("Help improve EZ-CorridorKey: send crash reports "
+                    "automatically")
+        )
+        self._crash_reports_cb.setChecked(
+            get_setting_bool(KEY_CRASH_REPORTS, DEFAULT_CRASH_REPORTS)
+        )
+        privacy_layout.addWidget(self._crash_reports_cb)
+
+        privacy_note = QLabel(
+            self.tr(
+                "Off by default. When enabled, crash details, GPU/driver "
+                "info, and the app version are sent when the app hits an "
+                "error. Never your media, files, or personal info. "
+                "Takes effect on the next launch."
+            )
+        )
+        privacy_note.setWordWrap(True)
+        privacy_note.setStyleSheet("QLabel { color: #888; font-size: 11px; }")
+        privacy_layout.addWidget(privacy_note)
+
         layout.addWidget(ui_group)
         layout.addWidget(proj_group)
         layout.addWidget(play_group)
         layout.addWidget(tracking_group)
         layout.addWidget(inference_group)
         layout.addWidget(output_group)
+        layout.addWidget(privacy_group)
         layout.addWidget(ffmpeg_group)
 
         scroll.setWidget(scroll_content)
@@ -612,6 +640,7 @@ class PreferencesDialog(QDialog):
         if self._backend_combo is not None:
             s.setValue(KEY_INFERENCE_BACKEND, self._backend_combo.currentData())
         s.setValue(KEY_OUTPUT_DIRECTORY, self._output_dir_edit.text().strip())
+        s.setValue(KEY_CRASH_REPORTS, self._crash_reports_cb.isChecked())
         # Apply sound mute immediately
         from ui.sounds.audio_manager import UIAudio
         UIAudio.set_muted(not self._sounds_cb.isChecked())

--- a/ui/widgets/report_issue_dialog.py
+++ b/ui/widgets/report_issue_dialog.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QApplication,
+    QCheckBox,
     QDialog,
     QGroupBox,
     QHBoxLayout,
@@ -113,6 +114,7 @@ class ReportIssueDialog(QDialog):
         gpu_info: dict | None = None,
         recent_errors: list[str] | None = None,
         parent=None,
+        stage: str = "runtime",
     ):
         super().__init__(parent)
         self.setWindowTitle(self.tr("Report Issue"))
@@ -122,6 +124,7 @@ class ReportIssueDialog(QDialog):
 
         self._gpu_info = gpu_info or {}
         self._recent_errors = recent_errors or []
+        self._stage = stage
 
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
@@ -177,6 +180,20 @@ class ReportIssueDialog(QDialog):
         notice.setStyleSheet("QLabel { color: #888; font-size: 11px; }")
         layout.addWidget(notice)
 
+        # --- Direct send opt-in ---
+        self._send_cb = QCheckBox(
+            self.tr("Also send this report directly to the developer")
+        )
+        self._send_cb.setChecked(True)
+        self._send_cb.setToolTip(
+            self.tr(
+                "Sends the report shown above: crash details, GPU/driver "
+                "info, app version. Never your media, files, or personal "
+                "info."
+            )
+        )
+        layout.addWidget(self._send_cb)
+
         # --- Buttons ---
         btn_layout = QHBoxLayout()
         btn_layout.addStretch()
@@ -224,12 +241,30 @@ class ReportIssueDialog(QDialog):
             pairs.append(("PyTorch", torch.version.__version__))
             if torch.cuda.is_available():
                 pairs.append(("CUDA", torch.version.cuda or "N/A"))
+                try:
+                    major, minor = torch.cuda.get_device_capability(0)
+                    pairs.append(("GPU Arch", f"sm_{major}{minor}"))
+                except Exception:
+                    pass
             elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
                 pairs.append(("Compute", "MPS (Apple Metal)"))
             else:
                 pairs.append(("Compute", "CPU"))
         except ImportError:
             pairs.append(("PyTorch", "not installed"))
+
+        # FFmpeg
+        try:
+            from backend.ffmpeg_tools.discovery import validate_ffmpeg_install
+            result = validate_ffmpeg_install(require_probe=False)
+            if result.ffmpeg_version is not None:
+                parts = result.ffmpeg_version.first_line.split()
+                pairs.append(
+                    ("FFmpeg", parts[2] if len(parts) > 2 else "unknown"))
+            else:
+                pairs.append(("FFmpeg", "missing"))
+        except Exception:
+            pairs.append(("FFmpeg", "missing"))
 
         # GPU + VRAM
         gpu = self._gpu_info
@@ -301,6 +336,24 @@ class ReportIssueDialog(QDialog):
 
     def _on_open(self) -> None:
         body = self._build_body()
+
+        # Optional direct send. Runs on its own thread with a bounded
+        # timeout; failure or absence never affects the GitHub flow.
+        if self._send_cb.isChecked():
+            import threading
+
+            from backend.error_reporting import send_report
+
+            threading.Thread(
+                target=send_report,
+                kwargs={
+                    "bundle_text": body,
+                    "stage": self._stage,
+                    "gpu_info": self._gpu_info,
+                },
+                daemon=False,
+                name="report-send",
+            ).start()
 
         # Copy full body to clipboard so it survives GitHub login redirects
         clipboard = QApplication.clipboard()

--- a/ui/widgets/setup_wizard.py
+++ b/ui/widgets/setup_wizard.py
@@ -763,6 +763,34 @@ class SetupWizard(QDialog):
         )
         layout.addWidget(self._shortcut_check)
 
+        # One-time crash reporting ask for new users. Off unless they opt
+        # in here; never shown again once answered. Same setting as
+        # Preferences > Privacy.
+        self._crash_check: QCheckBox | None = None
+        from PySide6.QtCore import QSettings
+        if not QSettings().value("privacy/crash_reports_prompted",
+                                 False, type=bool):
+            self._crash_check = QCheckBox(
+                self.tr("Send anonymous crash reports to help "
+                        "troubleshooting")
+            )
+            self._crash_check.setChecked(False)
+            self._crash_check.setToolTip(
+                self.tr(
+                    "Crash details, GPU/driver info, app version. Never "
+                    "your media, files, or personal info. Change anytime "
+                    "in Preferences > Privacy."
+                )
+            )
+            self._crash_check.setStyleSheet(
+                "QCheckBox { color: #CCCCCC; }"
+                "QCheckBox::indicator:checked { background: #FFF203; "
+                "border: 1px solid #FFF203; border-radius: 2px; }"
+                "QCheckBox::indicator { border: 1px solid #555; "
+                "border-radius: 2px; width: 14px; height: 14px; }"
+            )
+            layout.addWidget(self._crash_check)
+
         self._overall_label = QLabel("")
         self._overall_label.setAlignment(Qt.AlignCenter)
         self._overall_label.setStyleSheet("color: #999;")
@@ -850,7 +878,18 @@ class SetupWizard(QDialog):
         else:
             self.reject()
 
+    def _persist_crash_consent(self) -> None:
+        """Record the one-time crash reporting answer, if it was shown."""
+        if self._crash_check is None:
+            return
+        from PySide6.QtCore import QSettings
+        s = QSettings()
+        s.setValue("privacy/crash_reports_enabled",
+                   self._crash_check.isChecked())
+        s.setValue("privacy/crash_reports_prompted", True)
+
     def _on_install(self):
+        self._persist_crash_consent()
         selected = [key for key, row in self._rows.items() if row.is_selected()]
         if not selected:
             self.accept()

--- a/ui/workers/extract_worker.py
+++ b/ui/workers/extract_worker.py
@@ -224,6 +224,11 @@ class ExtractWorker(QThread):
 
         except Exception as e:
             logger.error(f"Extraction failed for {job.clip_name}: {e}")
+            try:
+                from backend.error_reporting import capture_stage_exception
+                capture_stage_exception("runtime", e)
+            except Exception:
+                pass
             self.error.emit(job.clip_name, str(e))
 
     # ------------------------------------------------------------------

--- a/ui/workers/gpu_job_worker.py
+++ b/ui/workers/gpu_job_worker.py
@@ -276,11 +276,21 @@ class GPUJobWorker(QThread):
 
         except CorridorKeyError as e:
             logger.error(f"Job failed [{job_id}]: {job.clip_name} — {e}")
+            try:
+                from backend.error_reporting import capture_stage_exception
+                capture_stage_exception("inference", e)
+            except Exception:
+                pass
             self._queue.fail_job(job, str(e))
             self.error.emit(job_id, job.clip_name, str(e))
 
         except Exception as e:
             msg = f"Unexpected error: {e}"
+            try:
+                from backend.error_reporting import capture_stage_exception
+                capture_stage_exception("inference", e)
+            except Exception:
+                pass
             self._queue.fail_job(job, msg)
             self.error.emit(job_id, job.clip_name, msg)
             logger.exception(msg)


### PR DESCRIPTION
No telemetry by default. Two user-controlled paths, nothing else:

☼ Report Issue dialog: the diagnostic summary the user already reviews can also be sent directly to the developer. Visible checkbox, on by default, per report. The clipboard and GitHub flow never waits on it and works even if the send fails or the dependency is missing.
☼ Preferences > Privacy: automatic crash reports, off by default. Off means the reporting machinery is never initialized. On captures unhandled errors and known failure points from the next launch.

Both paths anonymize file paths and remove media file names before sending. The report identity is a random per-install id, nothing else.

## Verification

☼ 23 unit tests: scrubbing (usernames on all platforms, media names, idempotence), install id, tag collection, send isolation, gating (off = no init, dev builds never init)
☼ Live end-to-end through the real dialog click path: delivery confirmed, captured payload byte-checked (correct tags, random id, no usernames, no project/clip/media names)
☼ Negative paths: missing dependency and unreachable endpoint leave the report flow fully working, bounded time
☼ Toggle-off run asserts the reporting package is never even imported
☼ Full suite: 738 passed
☼ README and SECURITY document the privacy model in the same change